### PR TITLE
Minimal improvements and fixes

### DIFF
--- a/WebUI/src/App.vue
+++ b/WebUI/src/App.vue
@@ -233,7 +233,7 @@ function postImageToEnhance(imageUrl: string) {
 function showDownloadModelConfirm(downList: DownloadModelParam[], success?: () => void, fail?: () => void) {
   showDowloadDlg.value = true;
   nextTick(() => {
-    downloadDigCompt.value!.showConfirm(downList, success, fail);
+    downloadDigCompt.value!.showConfirmDialog(downList, success, fail);
   });
 }
 

--- a/WebUI/src/assets/i18n/de.json
+++ b/WebUI/src/assets/i18n/de.json
@@ -130,7 +130,7 @@
 "DOWNLOADER_FOR_IMAGE_PREVIEW": "Bildvorschau Modell",
 "DOWNLOADER_FOR_IMAGE_UPSCALE": "Bild Upscale Modell",
 "DOWNLOADER_FOR_IMAGE_LORA": "Schnelles Bild Modell",
-"DOWNLOADER_DONWLOAD_TASK_PROGRESS": "Download Modell vollständig",
+"DOWNLOADER_DONWLOAD_TASK_PROGRESS": "Modell Downloads abgeschlossen",
 "RAG_FILE_TOTAL_FORMAT": "Datei total: {total}",
 "RAG_DRAG_UPLOAD": "Ziehen Sie Dateien zum Hochladen",
 "RAG_DRAG_UPLOAD_UNSUPPORTED": "Das aktuelle Programm wird mit Administratorrechten gestartet. Aufgrund von Windows-UAC-Einschränkungen kann der Drag-and-Drop-Upload nicht verwendet werden. Bitte verwenden Sie die Schaltfläche „Hinzufügen“ oben, um Dateien hochzuladen.",

--- a/WebUI/src/assets/i18n/en-US.json
+++ b/WebUI/src/assets/i18n/en-US.json
@@ -154,7 +154,7 @@
   "DOWNLOADER_FOR_IMAGE_PREVIEW":"Image Preview Model",
   "DOWNLOADER_FOR_IMAGE_UPSCALE":"Image Upscale Model",
   "DOWNLOADER_FOR_IMAGE_LORA": "Fast Image Model",
-  "DOWNLOADER_DONWLOAD_TASK_PROGRESS":"Download Model Complete",
+  "DOWNLOADER_DONWLOAD_TASK_PROGRESS":"Model Downloads Complete",
   "RAG_FILE_TOTAL_FORMAT": "File total: {total}",
   "RAG_DRAG_UPLOAD": "Drag files to upload",
   "RAG_DRAG_UPLOAD_UNSUPPORTED": "The current program is started with administrator privileges. Due to Windows UAC limitations, drag and drop upload cannot be used. Please use the add button at the top to upload files.",

--- a/WebUI/src/assets/i18n/es.json
+++ b/WebUI/src/assets/i18n/es.json
@@ -130,7 +130,7 @@
 "DOWNLOADER_FOR_IMAGE_PREVIEW": "Modelo de vista previa de imagen",
 "DOWNLOADER_FOR_IMAGE_UPSCALE": "Modelo de imagen aumentada",
 "DOWNLOADER_FOR_IMAGE_LORA": "Modelo de imagen rápida",
-"DOWNLOADER_DONWLOAD_TASK_PROGRESS": "Descarga del modelo completada",
+"DOWNLOADER_DONWLOAD_TASK_PROGRESS": "Descargas del modelo completadas",
 "RAG_FILE_TOTAL_FORMAT": "Archivos totales: {total}",
 "RAG_DRAG_UPLOAD": "Arrastra los archivos para cargar",
 "RAG_DRAG_UPLOAD_UNSUPPORTED": "El programa actual se ejecuta con privilegios de administrador. Debido a las limitaciones de UAC de Windows, no es posible utilizar la carga mediante arrastre. Usa el botón de arriba \"Agregar\" para cargar los archivos.",

--- a/service/model_downloader.py
+++ b/service/model_downloader.py
@@ -122,9 +122,7 @@ class HFPlaygroundDownloader:
         if cache_item is None:
             file_list = list()
             self.enum_file_list(file_list, repo_id, model_type)
-            model_list_cache.__setitem__(
-                {"size": self.total_size, "queue": self.file_queue}
-            )
+            model_list_cache.__setitem__(key, {"size": self.total_size, "queue": self.file_queue})
         else:
             self.total_size = cache_item["size"]
             file_list: list = cache_item["queue"]


### PR DESCRIPTION
Enalbe proper listening to download exceptions form backend again - was broken
Change wording from 'Download Model Complete' to 'Model Downloads Complete' as it fits better the actual overallDownloadTasksProgressBar Reset Taskdownload percent to 0 when entering the confirmModelDownload dialog (sequential downloads otherwise might start with 3/4 task progress bar) Fix invalid python cache fill in downloader.
