### PR TITLE
Feature/restart comfy UI after custom node installation

### DIFF
--- a/WebUI/src/assets/js/store/comfyUi.ts
+++ b/WebUI/src/assets/js/store/comfyUi.ts
@@ -288,28 +288,9 @@ export const useComfyUi = defineStore("comfyUi", () => {
         })
     }
 
-    async function free() {
-        if (!isComfyRunning) {
-            console.debug('ComfyUI backend not running, nothing to free');
-            return;
-        }
-        await fetch(`${comfyBaseUrl.value}/free`, {
-            method: 'POST',
-            headers: {
-                'Content-Type': 'application/json'
-            },
-            body: JSON.stringify({ free_memory: true,
-                unload_models: true })
-        })
-        await fetch(`${useGlobalSetup().apiHost}/api/triggerxpucacheclear`, {
-            method: "POST"
-        })
-    }
-
     return {
         generate,
         stop,
-        free,
     }
 }, {
     persist: {

--- a/WebUI/src/assets/js/store/imageGeneration.ts
+++ b/WebUI/src/assets/js/store/imageGeneration.ts
@@ -618,10 +618,8 @@ export const useImageGeneration = defineStore("imageGeneration", () => {
         previewIdx.value = 0;
         stepText.value = i18nState.COM_GENERATING;
         if (activeWorkflow.value.backend === 'default') {
-            comfyUi.free();
             stableDiffusion.generate();
         } else {
-            stableDiffusion.free();
             comfyUi.generate();
         }
     }

--- a/WebUI/src/assets/js/store/imageGeneration.ts
+++ b/WebUI/src/assets/js/store/imageGeneration.ts
@@ -626,7 +626,7 @@ export const useImageGeneration = defineStore("imageGeneration", () => {
         }
     }
 
-    function stop() {
+    function stopGeneration() {
         stableDiffusion.stop();
         comfyUi.stop();
     }
@@ -677,7 +677,7 @@ export const useImageGeneration = defineStore("imageGeneration", () => {
         getMissingModels,
         updateDestImage,
         generate,
-        stop,
+        stopGeneration,
         reset
     }
 }, {

--- a/WebUI/src/assets/js/store/stableDiffusion.ts
+++ b/WebUI/src/assets/js/store/stableDiffusion.ts
@@ -175,18 +175,12 @@ export const useStableDiffusion = defineStore("stableDiffusion", () => {
         }
     }
 
-    async function free() {
-        await fetch(`${useGlobalSetup().apiHost}/api/free`, {
-            method: "POST"
-        })
-    }
-
     return {
         generateParams,
         generate,
         stop,
-        free,
     }
+
 }, {
     persist: {
         pick: ['settings', 'hdWarningDismissed']

--- a/WebUI/src/env.d.ts
+++ b/WebUI/src/env.d.ts
@@ -112,6 +112,7 @@ type ApiResponse = {
     message: string;
 };
 
+
 type KVObject = {
     [key: string]: any;
 };

--- a/WebUI/src/views/Create.vue
+++ b/WebUI/src/views/Create.vue
@@ -69,7 +69,7 @@
                 <span>{{ languages.COM_GENERATE }}</span>
             </button>
             <button class="gernate-btn self-stretch flex flex-col w-32 flex-none" v-show="imageGeneration.processing"
-                @click="imageGeneration.stop">
+                @click="imageGeneration.stopGeneration">
                 <span class="svg-icon w-7 h-7" :class="{ 'i-stop': !imageGeneration.stopping, 'i-loading': imageGeneration.stopping }"></span>
                 <span>{{ languages.COM_STOP }}</span>
             </button>

--- a/service/comfyui_downloader.py
+++ b/service/comfyui_downloader.py
@@ -117,9 +117,9 @@ def is_custom_node_installed(node_repo_ref: ComfyUICustomNodesGithubRepoId) -> b
     expected_custom_node_path = os.path.join(service_config.comfy_ui_root_path, "custom_nodes", node_repo_ref.repoName)
     return os.path.exists(expected_custom_node_path)
 
-def download_custom_node(node_repo_data: ComfyUICustomNodesGithubRepoId):
+def download_custom_node(node_repo_data: ComfyUICustomNodesGithubRepoId) -> bool:
     if is_custom_node_installed(node_repo_data):
-        return
+        return True
     else:
         try:
             expected_git_url = f"https://github.com/{node_repo_data.username}/{node_repo_data.repoName}"
@@ -128,7 +128,8 @@ def download_custom_node(node_repo_data: ComfyUICustomNodesGithubRepoId):
 
             _install_git_repo(expected_git_url, expected_custom_node_path)
             _install_pip_requirements(potential_node_requirements)
-            return
+            logging.info("installed on a mock basis")
+            return True
         except Exception as e:
             logging.error(f"Failed to install custom comfy node {node_repo_data.username}/{node_repo_data.repoName} due to {e}")
-            raise e
+            return False

--- a/service/web_api.py
+++ b/service/web_api.py
@@ -65,19 +65,6 @@ def llm_chat():
     return Response(stream_with_context(it), content_type="text/event-stream")
 
 
-@app.post("/api/triggerxpucacheclear")
-def trigger_xpu_cache_clear():
-    paint_biz.clear_xpu_cache()
-    return Response("{'message':'triggered xpu cache clearance'}", status=201, mimetype='application/json')
-
-
-@app.post("/api/free")
-def free():
-    paint_biz.dispose()
-    import llm_biz
-    llm_biz.dispose()
-    return jsonify({"code": 0, "message": "success"})
-
 @app.get("/api/llm/stopGenerate")
 def stop_llm_generate():
     import llm_biz

--- a/service/web_api.py
+++ b/service/web_api.py
@@ -408,11 +408,12 @@ def are_custom_nodes_installed(comfyNodeRequest: ComfyUICustomNodesDownloadReque
 @app.input(ComfyUICustomNodesDownloadRequest.Schema, location='json', arg_name='comfyNodeRequest')
 def install_custom_nodes(comfyNodeRequest: ComfyUICustomNodesDownloadRequest):
     try:
-        for x in comfyNodeRequest.data:
-            comfyui_downloader.download_custom_node(x)
-        return jsonify({ f"{x.username}/{x.repoName}" : {"success": True, "errorMessage": ""} for x in comfyNodeRequest.data})
+        nodes_to_be_installed = [x for x in comfyNodeRequest.data if not comfyui_downloader.is_custom_node_installed(x)]
+        installation_result = [ {"node": f"{x.username}/{x.repoName}", "success": comfyui_downloader.download_custom_node(x)} for x in nodes_to_be_installed ]
+        logging.info(f"custom node installation request result: {installation_result}")
+        return jsonify(installation_result)
     except Exception as e:
-        return jsonify({'error_message': f'failed to at least one custom node due to {e}'}), 501
+        return jsonify({'error_message': f'failed to install at least one custom node due to {e}'}), 501
 
 
 


### PR DESCRIPTION
Trigger restart on comfyUI custon node installation
Remove solution to remove memory from within running services - was no longer needed, as:
  - when it was called, the other backend has been fully restarted and thus released all memory
  - this piece of code before the server restarts did not work, as comfyUI now runs in a separate python env and the prevous workaround no longer worked accross different python interpreters-