### PR TITLE
Cleanup of `_tmp` folders under `model/` dir on startup

### DIFF
--- a/WebUI/electron/main.ts
+++ b/WebUI/electron/main.ts
@@ -1397,7 +1397,8 @@ app.whenReady().then(async () => {
         ? path.join(process.resourcesPath, 'models')
         : path.join(__dirname, '../../../models'),
     )
-    cleanupTempFolders(modelsDir)
+    // Start temp-folder cleanup without blocking application startup
+    const _ = cleanupTempFolders(modelsDir)
 
     initEventHandle()
 

--- a/WebUI/electron/main.ts
+++ b/WebUI/electron/main.ts
@@ -42,6 +42,7 @@ import { exec } from 'node:child_process'
 import { randomUUID } from 'node:crypto'
 import sudo from 'sudo-prompt'
 import { PathsManager } from './pathsManager'
+import { cleanupTempFolders } from './tempFolderCleanup'
 import { appLoggerInstance } from './logging/logger.ts'
 import {
   aiplaygroundApiServiceRegistry,
@@ -1390,6 +1391,9 @@ app.whenReady().then(async () => {
     app.exit()
   } else {
     const settings = await loadSettings()
+
+    cleanupTempFolders(path.join(externalRes, '..', 'models'))
+
     initEventHandle()
 
     // Custom protocol docking is file protocol

--- a/WebUI/electron/main.ts
+++ b/WebUI/electron/main.ts
@@ -1392,7 +1392,12 @@ app.whenReady().then(async () => {
   } else {
     const settings = await loadSettings()
 
-    cleanupTempFolders(path.join(externalRes, '..', 'models'))
+    const modelsDir = path.resolve(
+      app.isPackaged
+        ? path.join(process.resourcesPath, 'models')
+        : path.join(__dirname, '../../../models'),
+    )
+    cleanupTempFolders(modelsDir)
 
     initEventHandle()
 

--- a/WebUI/electron/main.ts
+++ b/WebUI/electron/main.ts
@@ -1398,7 +1398,7 @@ app.whenReady().then(async () => {
         : path.join(__dirname, '../../../models'),
     )
     // Start temp-folder cleanup without blocking application startup
-    const _ = cleanupTempFolders(modelsDir)
+    void cleanupTempFolders(modelsDir)
 
     initEventHandle()
 

--- a/WebUI/electron/tempFolderCleanup.ts
+++ b/WebUI/electron/tempFolderCleanup.ts
@@ -1,0 +1,26 @@
+import fs from 'node:fs'
+import path from 'node:path'
+
+export function cleanupTempFolders(baseDir: string) {
+  if (!fs.existsSync(baseDir)) return
+
+  const tempFolderNames = ['_tmp']
+
+  const entries = fs.readdirSync(baseDir, { recursive: true, withFileTypes: true })
+  const tempFolders = entries
+    .filter((e) => e.isDirectory() && tempFolderNames.includes(e.name))
+    .map((e) => path.join(baseDir, e.path))
+
+  for (const tempFolder of tempFolders) {
+    try {
+      fs.rmSync(tempFolder, { recursive: true, force: true })
+      console.log(`[cleanup] Removed temp folder: ${tempFolder}`)
+    } catch (error) {
+      console.error(`[cleanup] Failed to remove ${tempFolder}:`, error)
+    }
+  }
+
+  if (tempFolders.length > 0) {
+    console.log(`[cleanup] Cleaned up ${tempFolders.length} temp folder(s)`)
+  }
+}

--- a/WebUI/electron/tempFolderCleanup.ts
+++ b/WebUI/electron/tempFolderCleanup.ts
@@ -1,5 +1,9 @@
 import fs from 'node:fs'
 import path from 'node:path'
+import { appLoggerInstance } from './logging/logger.ts'
+
+const logger = appLoggerInstance
+const LOG_SOURCE = 'tmpCleanup'
 
 // Matches temp folders created by model_downloader.py getTmpPath(), e.g.
 // fd824df26f56f9a3_tmp, 0a1b2c3d4e5f6789_tmp, etc.
@@ -14,15 +18,16 @@ export function findTempFolders(baseDir: string): string[] {
 }
 
 export function cleanupTempFolders(baseDir: string) {
-  console.log(`[tmpCleanup] Attempting to clean up temp folders in: ${baseDir}`)
+  logger.info(`[tmpCleanup] Attempting to clean up temp folders in: ${baseDir}`, LOG_SOURCE)
   if (!fs.existsSync(baseDir)) {
-    console.warn(`[tmpCleanup] Base directory does not exist: ${baseDir}`)
+    logger.warn(`[tmpCleanup] Base directory does not exist: ${baseDir}`, LOG_SOURCE)
     return
   }
 
   if (!path.normalize(baseDir).split(path.sep).includes(REQUIRED_PARENT_FOLDER)) {
-    console.warn(
+    logger.warn(
       `[tmpCleanup] Base directory does not contain a ${REQUIRED_PARENT_FOLDER} folder. This should not happen, aborting.`,
+      LOG_SOURCE,
     )
     return
   }
@@ -30,21 +35,24 @@ export function cleanupTempFolders(baseDir: string) {
   const tempFolders = findTempFolders(baseDir)
 
   if (tempFolders.length === 0) {
-    console.log(`[tmpCleanup] No temp folders found.`)
+    logger.info(`[tmpCleanup] No temp folders found.`, LOG_SOURCE)
     return
   }
 
-  console.log(`[tmpCleanup] Found the following temp folder(s):`)
+  logger.info(`[tmpCleanup] Found the following temp folder(s):`, LOG_SOURCE)
   for (const tempFolder of tempFolders) {
-    console.log(`[tmpCleanup] - ${tempFolder}`)
+    logger.info(`[tmpCleanup] - ${tempFolder}`, LOG_SOURCE)
   }
 
   for (const tempFolder of tempFolders) {
     try {
-      console.log(`[tmpCleanup] Removing: ${tempFolder}`)
+      logger.info(`[tmpCleanup] Removing: ${tempFolder}`, LOG_SOURCE)
       fs.rmSync(tempFolder, { recursive: true, force: true })
     } catch (error) {
-      console.error(`[tmpCleanup] Failed to remove ${tempFolder}:`, error)
+      logger.error(
+        `[tmpCleanup] Failed to remove ${tempFolder}: ${error instanceof Error ? error.message : String(error)}`,
+        LOG_SOURCE,
+      )
     }
   }
 }

--- a/WebUI/electron/tempFolderCleanup.ts
+++ b/WebUI/electron/tempFolderCleanup.ts
@@ -16,8 +16,8 @@ export async function findTempFolders(baseDir: string): Promise<string[]> {
     return entries
       .filter((e) => e.isDirectory() && TMP_FOLDER_PATTERN.test(e.name))
       .map((e) => path.join(e.parentPath, e.name))
-  } catch (error: any) {
-    if (error.code === 'ENOENT') {
+  } catch (error: unknown) {
+    if (error instanceof Error && 'code' in error && error.code === 'ENOENT') {
       return []
     }
     throw error

--- a/WebUI/electron/tempFolderCleanup.ts
+++ b/WebUI/electron/tempFolderCleanup.ts
@@ -18,41 +18,48 @@ export function findTempFolders(baseDir: string): string[] {
 }
 
 export function cleanupTempFolders(baseDir: string) {
-  logger.info(`[tmpCleanup] Attempting to clean up temp folders in: ${baseDir}`, LOG_SOURCE)
-  if (!fs.existsSync(baseDir)) {
-    logger.warn(`[tmpCleanup] Base directory does not exist: ${baseDir}`, LOG_SOURCE)
-    return
-  }
+  try {
+    logger.info(`[tmpCleanup] Attempting to clean up temp folders in: ${baseDir}`, LOG_SOURCE)
+    if (!fs.existsSync(baseDir)) {
+      logger.warn(`[tmpCleanup] Base directory does not exist: ${baseDir}`, LOG_SOURCE)
+      return
+    }
 
-  if (!path.normalize(baseDir).split(path.sep).includes(REQUIRED_PARENT_FOLDER)) {
-    logger.warn(
-      `[tmpCleanup] Base directory does not contain a ${REQUIRED_PARENT_FOLDER} folder. This should not happen, aborting.`,
-      LOG_SOURCE,
-    )
-    return
-  }
-
-  const tempFolders = findTempFolders(baseDir)
-
-  if (tempFolders.length === 0) {
-    logger.info(`[tmpCleanup] No temp folders found.`, LOG_SOURCE)
-    return
-  }
-
-  logger.info(`[tmpCleanup] Found the following temp folder(s):`, LOG_SOURCE)
-  for (const tempFolder of tempFolders) {
-    logger.info(`[tmpCleanup] - ${tempFolder}`, LOG_SOURCE)
-  }
-
-  for (const tempFolder of tempFolders) {
-    try {
-      logger.info(`[tmpCleanup] Removing: ${tempFolder}`, LOG_SOURCE)
-      fs.rmSync(tempFolder, { recursive: true, force: true })
-    } catch (error) {
-      logger.error(
-        `[tmpCleanup] Failed to remove ${tempFolder}: ${error instanceof Error ? error.message : String(error)}`,
+    if (!path.normalize(baseDir).split(path.sep).includes(REQUIRED_PARENT_FOLDER)) {
+      logger.warn(
+        `[tmpCleanup] Base directory does not contain a ${REQUIRED_PARENT_FOLDER} folder. This should not happen, aborting.`,
         LOG_SOURCE,
       )
+      return
     }
+
+    const tempFolders = findTempFolders(baseDir)
+
+    if (tempFolders.length === 0) {
+      logger.info(`[tmpCleanup] No temp folders found.`, LOG_SOURCE)
+      return
+    }
+
+    logger.info(`[tmpCleanup] Found the following temp folder(s):`, LOG_SOURCE)
+    for (const tempFolder of tempFolders) {
+      logger.info(`[tmpCleanup] - ${tempFolder}`, LOG_SOURCE)
+    }
+
+    for (const tempFolder of tempFolders) {
+      try {
+        logger.info(`[tmpCleanup] Removing: ${tempFolder}`, LOG_SOURCE)
+        fs.rmSync(tempFolder, { recursive: true, force: true })
+      } catch (error) {
+        logger.error(
+          `[tmpCleanup] Failed to remove ${tempFolder}: ${error instanceof Error ? error.message : String(error)}`,
+          LOG_SOURCE,
+        )
+      }
+    }
+  } catch (err) {
+    logger.error(
+      `Fatal error in cleanupTempFolders: ${err instanceof Error ? err.message : String(err)}`,
+      LOG_SOURCE,
+    )
   }
 }

--- a/WebUI/electron/tempFolderCleanup.ts
+++ b/WebUI/electron/tempFolderCleanup.ts
@@ -10,17 +10,27 @@ const LOG_SOURCE = 'tmpCleanup'
 export const TMP_FOLDER_PATTERN = /^[0-9a-f]{16}_tmp$/
 const REQUIRED_PARENT_FOLDER = 'models'
 
-export function findTempFolders(baseDir: string): string[] {
-  const entries = fs.readdirSync(baseDir, { recursive: true, withFileTypes: true })
-  return entries
-    .filter((e) => e.isDirectory() && TMP_FOLDER_PATTERN.test(e.name))
-    .map((e) => path.join(e.parentPath, e.name))
+export async function findTempFolders(baseDir: string): Promise<string[]> {
+  try {
+    const entries = await fs.promises.readdir(baseDir, { recursive: true, withFileTypes: true })
+    return entries
+      .filter((e) => e.isDirectory() && TMP_FOLDER_PATTERN.test(e.name))
+      .map((e) => path.join(e.parentPath, e.name))
+  } catch (error: any) {
+    if (error.code === 'ENOENT') {
+      return []
+    }
+    throw error
+  }
 }
 
-export function cleanupTempFolders(baseDir: string) {
+export async function cleanupTempFolders(baseDir: string): Promise<void> {
   try {
     logger.info(`[tmpCleanup] Attempting to clean up temp folders in: ${baseDir}`, LOG_SOURCE)
-    if (!fs.existsSync(baseDir)) {
+
+    try {
+      await fs.promises.access(baseDir)
+    } catch {
       logger.warn(`[tmpCleanup] Base directory does not exist: ${baseDir}`, LOG_SOURCE)
       return
     }
@@ -33,7 +43,7 @@ export function cleanupTempFolders(baseDir: string) {
       return
     }
 
-    const tempFolders = findTempFolders(baseDir)
+    const tempFolders = await findTempFolders(baseDir)
 
     if (tempFolders.length === 0) {
       logger.info(`[tmpCleanup] No temp folders found.`, LOG_SOURCE)
@@ -48,7 +58,7 @@ export function cleanupTempFolders(baseDir: string) {
     for (const tempFolder of tempFolders) {
       try {
         logger.info(`[tmpCleanup] Removing: ${tempFolder}`, LOG_SOURCE)
-        fs.rmSync(tempFolder, { recursive: true, force: true })
+        await fs.promises.rm(tempFolder, { recursive: true, force: true })
       } catch (error) {
         logger.error(
           `[tmpCleanup] Failed to remove ${tempFolder}: ${error instanceof Error ? error.message : String(error)}`,

--- a/WebUI/electron/tempFolderCleanup.ts
+++ b/WebUI/electron/tempFolderCleanup.ts
@@ -1,26 +1,39 @@
 import fs from 'node:fs'
 import path from 'node:path'
 
-export function cleanupTempFolders(baseDir: string) {
-  if (!fs.existsSync(baseDir)) return
+// Matches temp folder naming convention from the model_downloader.py getTmpPath()
+// fd824df26f56f9a3_tmp, 0a1b2c3d4e5f6789_tmp, etc.
+const TMP_FOLDER_PATTERN = /^[0-9a-f]{16}_tmp$/
 
-  const tempFolderNames = ['_tmp']
+export function cleanupTempFolders(baseDir: string) {
+  console.log(`[tmpCleanup] Attempting to clean up temp folders in: ${baseDir}`)
+  if (!fs.existsSync(baseDir)){
+    console.warn(`[tmpCleanup] Base directory does not exist: ${baseDir}`)
+     return
+    }
 
   const entries = fs.readdirSync(baseDir, { recursive: true, withFileTypes: true })
   const tempFolders = entries
-    .filter((e) => e.isDirectory() && tempFolderNames.includes(e.name))
-    .map((e) => path.join(baseDir, e.path))
+    .filter((e) => e.isDirectory() && TMP_FOLDER_PATTERN.test(e.name))
+    .map((e) => path.join(e.parentPath, e.name))
 
-  for (const tempFolder of tempFolders) {
-    try {
-      fs.rmSync(tempFolder, { recursive: true, force: true })
-      console.log(`[cleanup] Removed temp folder: ${tempFolder}`)
-    } catch (error) {
-      console.error(`[cleanup] Failed to remove ${tempFolder}:`, error)
+  if (tempFolders.length === 0) {
+    console.log(`[tmpCleanup] No temp folders found.`)
+    return
+  } else {
+    console.log(`[tmpCleanup] Found the following temp folder(s) to clean up:`)
+    for (const tempFolder of tempFolders) {
+      console.log(`[tmpCleanup] ${tempFolder}`)
     }
   }
 
-  if (tempFolders.length > 0) {
-    console.log(`[cleanup] Cleaned up ${tempFolders.length} temp folder(s)`)
-  }
+  // disabled to verify correct paths first...
+  // for (const tempFolder of tempFolders) {
+  //   try {
+  //     console.log(`[tmpCleanup] Removing temp folder: ${tempFolder}`)
+  //     fs.rmSync(tempFolder, { recursive: true, force: true })
+  //   } catch (error) {
+  //     console.error(`[tmpCleanup] Failed to remove ${tempFolder}:`, error)
+  //   }
+  // }
 }

--- a/WebUI/electron/tempFolderCleanup.ts
+++ b/WebUI/electron/tempFolderCleanup.ts
@@ -1,39 +1,50 @@
 import fs from 'node:fs'
 import path from 'node:path'
 
-// Matches temp folder naming convention from the model_downloader.py getTmpPath()
+// Matches temp folders created by model_downloader.py getTmpPath(), e.g.
 // fd824df26f56f9a3_tmp, 0a1b2c3d4e5f6789_tmp, etc.
-const TMP_FOLDER_PATTERN = /^[0-9a-f]{16}_tmp$/
+export const TMP_FOLDER_PATTERN = /^[0-9a-f]{16}_tmp$/
+const REQUIRED_PARENT_FOLDER = 'models'
+
+export function findTempFolders(baseDir: string): string[] {
+  const entries = fs.readdirSync(baseDir, { recursive: true, withFileTypes: true })
+  return entries
+    .filter((e) => e.isDirectory() && TMP_FOLDER_PATTERN.test(e.name))
+    .map((e) => path.join(e.parentPath, e.name))
+}
 
 export function cleanupTempFolders(baseDir: string) {
   console.log(`[tmpCleanup] Attempting to clean up temp folders in: ${baseDir}`)
-  if (!fs.existsSync(baseDir)){
+  if (!fs.existsSync(baseDir)) {
     console.warn(`[tmpCleanup] Base directory does not exist: ${baseDir}`)
-     return
-    }
+    return
+  }
 
-  const entries = fs.readdirSync(baseDir, { recursive: true, withFileTypes: true })
-  const tempFolders = entries
-    .filter((e) => e.isDirectory() && TMP_FOLDER_PATTERN.test(e.name))
-    .map((e) => path.join(e.parentPath, e.name))
+  if (!path.normalize(baseDir).split(path.sep).includes(REQUIRED_PARENT_FOLDER)) {
+    console.warn(
+      `[tmpCleanup] Base directory does not contain a ${REQUIRED_PARENT_FOLDER} folder. This should not happen, aborting.`,
+    )
+    return
+  }
+
+  const tempFolders = findTempFolders(baseDir)
 
   if (tempFolders.length === 0) {
     console.log(`[tmpCleanup] No temp folders found.`)
     return
-  } else {
-    console.log(`[tmpCleanup] Found the following temp folder(s) to clean up:`)
-    for (const tempFolder of tempFolders) {
-      console.log(`[tmpCleanup] ${tempFolder}`)
-    }
   }
 
-  // disabled to verify correct paths first...
-  // for (const tempFolder of tempFolders) {
-  //   try {
-  //     console.log(`[tmpCleanup] Removing temp folder: ${tempFolder}`)
-  //     fs.rmSync(tempFolder, { recursive: true, force: true })
-  //   } catch (error) {
-  //     console.error(`[tmpCleanup] Failed to remove ${tempFolder}:`, error)
-  //   }
-  // }
+  console.log(`[tmpCleanup] Found the following temp folder(s):`)
+  for (const tempFolder of tempFolders) {
+    console.log(`[tmpCleanup] - ${tempFolder}`)
+  }
+
+  for (const tempFolder of tempFolders) {
+    try {
+      console.log(`[tmpCleanup] Removing: ${tempFolder}`)
+      fs.rmSync(tempFolder, { recursive: true, force: true })
+    } catch (error) {
+      console.error(`[tmpCleanup] Failed to remove ${tempFolder}:`, error)
+    }
+  }
 }

--- a/WebUI/electron/test/tempFolderCleanup.test.ts
+++ b/WebUI/electron/test/tempFolderCleanup.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import path from 'node:path'
+import { tmpdir } from 'node:os'
+import { mkdirSync, rmSync, existsSync, writeFileSync } from 'node:fs'
+import { cleanupTempFolders, TMP_FOLDER_PATTERN } from '../tempFolderCleanup'
+
+describe('TMP_FOLDER_PATTERN', () => {
+  it('matches valid temp folder names', () => {
+    expect(TMP_FOLDER_PATTERN.test('fd824df26f56f9a3_tmp')).toBe(true)
+    expect(TMP_FOLDER_PATTERN.test('0a1b2c3d4e5f6789_tmp')).toBe(true)
+    expect(TMP_FOLDER_PATTERN.test('1234567890abcdef_tmp')).toBe(true)
+  })
+
+  it('does not match invalid folder names', () => {
+    expect(TMP_FOLDER_PATTERN.test('normal_folder')).toBe(false)
+    expect(TMP_FOLDER_PATTERN.test('1234567890abcdef')).toBe(false)
+    expect(TMP_FOLDER_PATTERN.test('1234567890abcdef_tmpr')).toBe(false)
+    expect(TMP_FOLDER_PATTERN.test('1234abcd_tmp')).toBe(false)
+    expect(TMP_FOLDER_PATTERN.test('1234567890ABCDEF_tmp')).toBe(false)
+  })
+})
+
+describe('cleanupTempFolders', () => {
+  describe('with models in path', () => {
+    let testDir: string
+
+    beforeEach(() => {
+      vi.restoreAllMocks()
+      testDir = path.join(tmpdir(), `tmpCleanup-test-${Date.now()}`, 'models')
+      mkdirSync(testDir, { recursive: true })
+    })
+
+    afterEach(() => {
+      const parentDir = path.dirname(testDir)
+      if (existsSync(parentDir)) {
+        rmSync(parentDir, { recursive: true, force: true })
+      }
+    })
+
+    it('does nothing when directory does not exist', () => {
+      const nonExistent = path.join(testDir, 'nonexistent')
+      expect(() => cleanupTempFolders(nonExistent)).not.toThrow()
+    })
+
+    it('does nothing when no temp folders exist', () => {
+      const normalDir = path.join(testDir, 'normal_folder')
+      mkdirSync(normalDir)
+
+      cleanupTempFolders(testDir)
+
+      expect(existsSync(normalDir)).toBe(true)
+    })
+
+    it('removes temp folders inside models path', () => {
+      const tempFolder = path.join(testDir, 'fd824df26f56f9a3_tmp')
+      const nestedDir = path.join(testDir, 'subdir', 'nested')
+      const nestedTempFolder = path.join(nestedDir, '0a1b2c3d4e5f6789_tmp')
+      const normalFolder = path.join(testDir, 'normal_folder')
+      const nestedNormalFolder = path.join(nestedDir, 'normal_nested')
+
+      mkdirSync(tempFolder)
+      mkdirSync(nestedDir, { recursive: true })
+      mkdirSync(nestedTempFolder)
+      mkdirSync(normalFolder)
+      mkdirSync(nestedNormalFolder)
+      writeFileSync(path.join(tempFolder, 'test.txt'), 'test')
+
+      cleanupTempFolders(testDir)
+
+      expect(existsSync(tempFolder)).toBe(false)
+      expect(existsSync(nestedTempFolder)).toBe(false)
+      expect(existsSync(normalFolder)).toBe(true)
+      expect(existsSync(nestedNormalFolder)).toBe(true)
+      expect(existsSync(nestedDir)).toBe(true)
+    })
+  })
+
+  describe('without models in path', () => {
+    it('does NOT remove temp folders', () => {
+      const nonModelsDir = path.join(tmpdir(), `non-models-path-${Date.now()}`)
+      const tempFolder = path.join(nonModelsDir, 'fd824df26f56f9a3_tmp')
+      mkdirSync(nonModelsDir, { recursive: true })
+      mkdirSync(tempFolder)
+      writeFileSync(path.join(tempFolder, 'test.txt'), 'test')
+
+      cleanupTempFolders(nonModelsDir)
+
+      expect(existsSync(tempFolder)).toBe(true)
+      rmSync(nonModelsDir, { recursive: true, force: true })
+    })
+  })
+})

--- a/WebUI/electron/test/tempFolderCleanup.test.ts
+++ b/WebUI/electron/test/tempFolderCleanup.test.ts
@@ -4,6 +4,14 @@ import { tmpdir } from 'node:os'
 import { mkdirSync, rmSync, existsSync, writeFileSync } from 'node:fs'
 import { cleanupTempFolders, TMP_FOLDER_PATTERN } from '../tempFolderCleanup'
 
+vi.mock('../logging/logger.ts', () => ({
+  appLoggerInstance: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}))
+
 describe('TMP_FOLDER_PATTERN', () => {
   it('matches valid temp folder names', () => {
     expect(TMP_FOLDER_PATTERN.test('fd824df26f56f9a3_tmp')).toBe(true)
@@ -42,16 +50,16 @@ describe('cleanupTempFolders', () => {
       expect(() => cleanupTempFolders(nonExistent)).not.toThrow()
     })
 
-    it('does nothing when no temp folders exist', () => {
+    it('does nothing when no temp folders exist', async () => {
       const normalDir = path.join(testDir, 'normal_folder')
       mkdirSync(normalDir)
 
-      cleanupTempFolders(testDir)
+      await cleanupTempFolders(testDir)
 
       expect(existsSync(normalDir)).toBe(true)
     })
 
-    it('removes temp folders inside models path', () => {
+    it('removes temp folders inside models path', async () => {
       const tempFolder = path.join(testDir, 'fd824df26f56f9a3_tmp')
       const nestedDir = path.join(testDir, 'subdir', 'nested')
       const nestedTempFolder = path.join(nestedDir, '0a1b2c3d4e5f6789_tmp')
@@ -65,7 +73,7 @@ describe('cleanupTempFolders', () => {
       mkdirSync(nestedNormalFolder)
       writeFileSync(path.join(tempFolder, 'test.txt'), 'test')
 
-      cleanupTempFolders(testDir)
+      await cleanupTempFolders(testDir)
 
       expect(existsSync(tempFolder)).toBe(false)
       expect(existsSync(nestedTempFolder)).toBe(false)
@@ -76,14 +84,14 @@ describe('cleanupTempFolders', () => {
   })
 
   describe('without models in path', () => {
-    it('does NOT remove temp folders', () => {
+    it('does NOT remove temp folders', async () => {
       const nonModelsDir = path.join(tmpdir(), `non-models-path-${Date.now()}`)
       const tempFolder = path.join(nonModelsDir, 'fd824df26f56f9a3_tmp')
       mkdirSync(nonModelsDir, { recursive: true })
       mkdirSync(tempFolder)
       writeFileSync(path.join(tempFolder, 'test.txt'), 'test')
 
-      cleanupTempFolders(nonModelsDir)
+      await cleanupTempFolders(nonModelsDir)
 
       expect(existsSync(tempFolder)).toBe(true)
       rmSync(nonModelsDir, { recursive: true, force: true })


### PR DESCRIPTION
This scans the /models/ folder on application startup and removes any folder named "_tmp/".
Those are leftovers from broken previous download attempts and cannot be resumed anyway.

The folder name regex logic is the same as used for the `model_downloader.py`.

Logs appear in the real console, not in the dev tools console.

Fixes #179

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic, non-blocking cleanup of temporary model folders runs on app startup to free disk space.
  * Icon buttons now accept tooltips for improved user guidance.

* **Tests**
  * Added tests covering temporary-folder detection and cleanup behavior, including safety checks when model paths are absent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->