### PR TITLE
Set up "agentic debugging" for opencode/chrome-devtools-mcp/electron

### DIFF
--- a/WebUI/.opencode/.gitignore
+++ b/WebUI/.opencode/.gitignore
@@ -1,0 +1,3 @@
+plans/
+bun.lock
+package.json

--- a/WebUI/.opencode/opencode.json
+++ b/WebUI/.opencode/opencode.json
@@ -3,7 +3,7 @@
   "mcp": {
     "chrome-devtools": {
       "type": "local",
-      "command": ["npx", "-y", "chrome-devtools-mcp@latest", "--browser-url=http://127.0.0.1:9222"],
+      "command": ["npx", "-y", "chrome-devtools-mcp@latest", "--browser-url=http://127.0.0.1:29222"],
       "enabled": false
     }
   }

--- a/WebUI/.opencode/opencode.json
+++ b/WebUI/.opencode/opencode.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "https://opencode.ai/config.json",
+  "mcp": {
+    "chrome-devtools": {
+      "type": "local",
+      "command": ["npx", "-y", "chrome-devtools-mcp@latest", "--browser-url=http://127.0.0.1:9222"],
+      "enabled": false
+    }
+  }
+}

--- a/WebUI/agentic-debugging.md
+++ b/WebUI/agentic-debugging.md
@@ -4,7 +4,7 @@ For 'agentic debugging' in OpenCode, Chrome DevTools MCP can be used to inspect 
 
 **Usage:**
 
-1. `npm run dev`
+1. `npm run dev` (adjust `AIPG_DEBUGGING_PORT` in `package.json` if required)
 2. Run `opencode`, press "Ctrl-P" and check "Toggle MCPs" shows "chrome-devtools connected" (config has it disabled per default)
 3. In Opencode ask to:
    - `list pages`
@@ -15,8 +15,8 @@ For 'agentic debugging' in OpenCode, Chrome DevTools MCP can be used to inspect 
 
 **Relevant files:**
 
-- `.opencode/opencode.json` - MCP config for chrome-devtools-mcp connecting to port 9222
-- `electron/main.ts` - Adds `app.commandLine.appendSwitch("remote-debugging-port", "9222")` during dev mode
+- `.opencode/opencode.json` - MCP config for chrome-devtools-mcp connecting to port 29222
+- `electron/main.ts` - Adds `app.commandLine.appendSwitch("remote-debugging-port", "29222")` during dev mode
 
 **Sources:**
 

--- a/WebUI/agentic-debugging.md
+++ b/WebUI/agentic-debugging.md
@@ -1,0 +1,23 @@
+## Opencode, Electron, MCP DevTools Integration
+
+For 'agentic debugging' in OpenCode, Chrome DevTools MCP can be used to inspect the running Vue Electron app.
+
+**Usage:**
+
+1. `npm run dev` (port 9222)
+2. Run `opencode`, press "Ctrl-P" and check "Toggle MCPs" shows "chrome-devtools connected" (config has it disabled per default)
+3. In Opencode ask to:
+   - `list pages`
+   - `take snapshot`
+   - `click button`
+   - `list console messages`
+   - `list network requests`
+
+**Relevant files:**
+
+- `.opencode/opencode.json` - MCP config for chrome-devtools-mcp connecting to port 9222
+- `electron/main.ts` - Adds `app.commandLine.appendSwitch("remote-debugging-port", "9222")` during dev mode
+
+**Sources:**
+
+- [chrome-devtools-mcp](https://github.com/ChromeDevTools/chrome-devtools-mcp) - MCP server for Chrome DevTools

--- a/WebUI/agentic-debugging.md
+++ b/WebUI/agentic-debugging.md
@@ -4,7 +4,7 @@ For 'agentic debugging' in OpenCode, Chrome DevTools MCP can be used to inspect 
 
 **Usage:**
 
-1. `npm run dev` (port 9222)
+1. `npm run dev`
 2. Run `opencode`, press "Ctrl-P" and check "Toggle MCPs" shows "chrome-devtools connected" (config has it disabled per default)
 3. In Opencode ask to:
    - `list pages`

--- a/WebUI/electron/main.ts
+++ b/WebUI/electron/main.ts
@@ -88,8 +88,8 @@ let langchainChild: UtilityProcess | null = null
 
 // 🚧 Use ['ENV_NAME'] avoid vite:define plugin - Vite@2.x
 const VITE_DEV_SERVER_URL = process.env['VITE_DEV_SERVER_URL']
-if (!app.isPackaged) {
-  app.commandLine.appendSwitch('remote-debugging-port', '9222')
+if (!app.isPackaged && process.env.AIPG_DEBUGGING_PORT) {
+  app.commandLine.appendSwitch('remote-debugging-port', process.env.AIPG_DEBUGGING_PORT)
 }
 // const APP_TOOL_HEIGHT = 209;
 const appSize = {

--- a/WebUI/electron/main.ts
+++ b/WebUI/electron/main.ts
@@ -88,6 +88,9 @@ let langchainChild: UtilityProcess | null = null
 
 // 🚧 Use ['ENV_NAME'] avoid vite:define plugin - Vite@2.x
 const VITE_DEV_SERVER_URL = process.env['VITE_DEV_SERVER_URL']
+if (!app.isPackaged) {
+  app.commandLine.appendSwitch('remote-debugging-port', '9222')
+}
 // const APP_TOOL_HEIGHT = 209;
 const appSize = {
   width: 820,

--- a/WebUI/package.json
+++ b/WebUI/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "version": "3.0.2-beta",
   "scripts": {
-    "dev": "cross-env VITE_DEBUG_TOOLS=\"true\" VITE_PLATFORM_TITLE=\"from Intel®\" vite",
+    "dev": "cross-env VITE_DEBUG_TOOLS=\"true\" VITE_PLATFORM_TITLE=\"from Intel®\" AIPG_DEBUGGING_PORT=\"29222\" vite",
     "preview": "vite preview",
     "fetch-external-resources": "node --experimental-strip-types ./build/scripts/fetch-external-resources.mts",
     "patch-nsis-files": "node --experimental-strip-types ./build/scripts/patch-nsis-template.mts",


### PR DESCRIPTION
**Description:**

This PR adds "agentic debugging" capabilities for OpenCode via chrome-devtools during `npm run dev`.
Usage is documented in `./WebUi/agentic-debugging.md`.

**Changes Made:**

- `main.ts` opens a remote debugging port on `9222` durin development
- `.opencode/opencode.json`: mcp config for chrome-dev-tools-mcp on port `9222` (added, but disabled per default)
- `agentic-debugging.md` documents usage instructions

**Testing Done:**

Manually started the app in dev mode, start opencode, activate the mcp in opencode via ctrl-p+mcp+space, then asked to "list pages" and "click imagegen" button.

**Screenshots:**

Asked to click the imagegen button.
<img width="1920" height="1128" alt="image" src="https://github.com/user-attachments/assets/fad07cbb-5b2a-4707-b91a-5661856dd721" />

**Checklist:**

- [x] I have tested the changes locally.
- [x] I have self-reviewed the code changes.
- [x] I have updated the documentation, if necessary.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a guide for agentic debugging that explains how to enable and use interactive devtools for inspecting app behavior.

* **Chores**
  * Added a config to enable optional Chrome DevTools integration for development.
  * Updated development startup to expose a local debugging port.
  * Added ignore rules to streamline the repository.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->