### PR TITLE
fix: save input images to media folder and use aipg-media references

### DIFF
--- a/WebUI/electron/main.ts
+++ b/WebUI/electron/main.ts
@@ -84,6 +84,8 @@ let win: BrowserWindow | null
 let serviceRegistry: ApiServiceRegistryImpl | null = null
 const mediaDir = getMediaDir()
 fs.mkdirSync(mediaDir, { recursive: true })
+const mediaInputDir = path.join(mediaDir, 'input')
+fs.mkdirSync(mediaInputDir, { recursive: true })
 let langchainChild: UtilityProcess | null = null
 
 // 🚧 Use ['ENV_NAME'] avoid vite:define plugin - Vite@2.x
@@ -520,6 +522,24 @@ function initEventHandle() {
     } catch (error) {
       appLogger.error(`${JSON.stringify(error, Object.getOwnPropertyNames, 2)}`, 'electron-backend')
     }
+  })
+
+  ipcMain.handle('saveImageToMediaInput', async (_event, dataUri: string) => {
+    if (typeof dataUri !== 'string' || !dataUri.startsWith('data:image/')) {
+      throw new Error('saveImageToMediaInput: expected a data URI (data:image/...)')
+    }
+    const match = dataUri.match(/^data:image\/(png|jpeg|webp);base64,(.+)$/)
+    if (!match) {
+      throw new Error('saveImageToMediaInput: unsupported image type or malformed data URI')
+    }
+    const mimeSubtype = match[1]
+    const base64Data = match[2]
+    const ext = mimeSubtype === 'jpeg' ? 'jpg' : mimeSubtype
+    const filename = `${randomUUID()}.${ext}`
+    const filePath = path.join(mediaInputDir, filename)
+    const buffer = Buffer.from(base64Data, 'base64')
+    await fs.promises.writeFile(filePath, buffer)
+    return `input/${filename}`
   })
 
   /** Get command line parameters when launched from IPOS to decide the default home page */

--- a/WebUI/electron/preload.ts
+++ b/WebUI/electron/preload.ts
@@ -61,6 +61,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
     ipcRenderer.invoke('showOpenDialog', options),
   reportClientEvent: (eventId: number) => ipcRenderer.send('reportClientEvent', eventId),
   saveImage: (url: string) => ipcRenderer.send('saveImage', url),
+  saveImageToMediaInput: (dataUri: string) => ipcRenderer.invoke('saveImageToMediaInput', dataUri),
   wakeupApiService: () => ipcRenderer.send('wakeupApiService'),
   openImageWin: (url: string, title: string, width: number, height: number) =>
     ipcRenderer.send('openImageWin', url, title, width, height),

--- a/WebUI/electron/subprocesses/updateIntelPresets.ts
+++ b/WebUI/electron/subprocesses/updateIntelPresets.ts
@@ -183,6 +183,7 @@ async function checkGitRefExists(gitExe: string, workDir: string, ref: string): 
 }
 
 export async function filterPartnerPresets() {
+  if (!app.isPackaged) return
   const presets = await fs.promises.readdir(presetDirTargetPath, { withFileTypes: true })
   const acerPresets = presets.filter((p) => p.name.startsWith('Acer'))
   const acerVisionArtIsInstalled = await getFromRegistry(

--- a/WebUI/package.json
+++ b/WebUI/package.json
@@ -13,6 +13,7 @@
     "lint:eslint": "eslint . --fix",
     "lint": "eslint . --fix",
     "format": "prettier --write .",
+    "type-check": "vue-tsc --noEmit",
     "lint:ci": "eslint .",
     "format:ci": "prettier --check ."
   },

--- a/WebUI/src/assets/js/store/comfyUiPresets.ts
+++ b/WebUI/src/assets/js/store/comfyUiPresets.ts
@@ -7,6 +7,7 @@ import * as toast from '../toast'
 import { useBackendServices } from '@/assets/js/store/backendServices.ts'
 import { usePromptStore } from './promptArea'
 import { z } from 'zod'
+import { imageUrlToDataUri, isImageUrl } from '@/lib/utils'
 
 const WEBSOCKET_OPEN = 1
 
@@ -694,13 +695,12 @@ export const useComfyUiPresets = defineStore(
         const hasNoDefault = input.defaultValue === '' || input.defaultValue === undefined
 
         if (isImageType && isDisplayed && isModifiable && hasNoDefault) {
-          // Check if current value is empty or invalid
           const value = input.current.value
           const isEmpty = value === '' || value === undefined || value === null
           const isString = typeof value === 'string'
-          const isValidDataUri = isString && value.match(/^data:image\/(png|jpeg|webp);base64,/)
+          const isValid = isString && value !== '' && isImageUrl(value)
 
-          if (isEmpty || !isString || !isValidDataUri) {
+          if (isEmpty || !isValid) {
             missingInputs.push(input.label)
           }
         }
@@ -727,20 +727,18 @@ export const useComfyUiPresets = defineStore(
           }
         }
         if (input.type === 'image' || input.type === 'inpaintMask') {
-          // Check if image is optional and empty - if so, use black pixel
-          const isEmpty =
-            typeof input.current.value !== 'string' ||
-            input.current.value === '' ||
-            !input.current.value.match(/^data:image\/(png|jpeg|webp);base64,/)
+          const rawValue = input.current.value
+          const isEmpty = typeof rawValue !== 'string' || rawValue === '' || !isImageUrl(rawValue)
           const isOptional = input.optional === true
 
           let imageDataUri: string
           if (isEmpty && isOptional && input.type === 'image') {
-            // Use black pixel image for optional empty images
             imageDataUri =
               'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII='
-          } else if (typeof input.current.value === 'string') {
-            imageDataUri = input.current.value
+          } else if (typeof rawValue === 'string' && rawValue !== '') {
+            imageDataUri = rawValue.startsWith('aipg-media://')
+              ? await imageUrlToDataUri(rawValue)
+              : rawValue
           } else {
             continue
           }

--- a/WebUI/src/assets/js/store/imageGenerationPresets.ts
+++ b/WebUI/src/assets/js/store/imageGenerationPresets.ts
@@ -7,7 +7,7 @@ import { usePresets, type ComfyInput } from './presets'
 import { useUIStore } from './ui'
 import { PresetRequirementsData, useDialogStore } from './dialogs'
 import { getMissingComfyuiBackendModels } from './imageGenerationUtils'
-import { imageUrlToDataUri } from '@/lib/utils'
+import { imageUrlToDataUri, saveImageToMediaInput } from '@/lib/utils'
 
 export type GenerateState =
   | 'no_start'
@@ -431,12 +431,21 @@ export const useImageGenerationPresets = defineStore(
     }
 
     async function copyImageAsInputForMode(image: MediaItem, mode: WorkflowModeType) {
-      const newImage: MediaItem = { ...image, id: crypto.randomUUID() }
+      const newImage: MediaItem = { ...image, id: crypto.randomUUID(), createdAt: Date.now() }
       newImage.mode = mode
       if (image.type === 'image' && newImage.type === 'image') {
-        // Convert blob URL to base64 data URI for ComfyUI compatibility
         newImage.sourceImageUrl = image.imageUrl
-        newImage.imageUrl = await imageUrlToDataUri(image.imageUrl)
+        if (image.imageUrl.startsWith('aipg-media://')) {
+          newImage.imageUrl = image.imageUrl
+        } else {
+          try {
+            const dataUri = await imageUrlToDataUri(image.imageUrl)
+            newImage.imageUrl = await saveImageToMediaInput(dataUri)
+          } catch (error) {
+            console.error('Error copying image as input for mode', error)
+            toast.error('Error copying image as input for mode')
+          }
+        }
         newImage.fromImageGen = true
       }
 

--- a/WebUI/src/assets/js/store/models.ts
+++ b/WebUI/src/assets/js/store/models.ts
@@ -92,9 +92,10 @@ export const useModels = defineStore(
         ...predefinedModels, // Keep models.json order (first = highest priority)
         ...downloadedModels.filter(notPredefined), // Add non-predefined downloads at end
         ...customModelsFromMetadata, // Custom models from persisted metadata
-        ...models.value.filter(notPredefined).filter(notYetDownloaded).filter(
-          (m) => !customModelsFromMetadata.some((cm) => cm.name === m.name),
-        ),
+        ...models.value
+          .filter(notPredefined)
+          .filter(notYetDownloaded)
+          .filter((m) => !customModelsFromMetadata.some((cm) => cm.name === m.name)),
       ]
         .map<Model>((m) => {
           const predefinedModel = predefinedModels.find((pm) => pm.name === m.name)

--- a/WebUI/src/assets/js/store/openAiCompatibleChat.ts
+++ b/WebUI/src/assets/js/store/openAiCompatibleChat.ts
@@ -3,6 +3,7 @@ import { computed, ref, watch } from 'vue'
 import { Chat } from '@ai-sdk/vue'
 import {
   convertToModelMessages,
+  type FileUIPart,
   DefaultChatTransport,
   LanguageModelUsage,
   streamText,
@@ -17,6 +18,7 @@ import z from 'zod'
 import { AipgTools } from '../tools/tools'
 import * as toast from '../toast'
 import { LanguageModelV2ToolResultOutput } from '@ai-sdk/provider'
+import { imageUrlToDataUri } from '@/lib/utils'
 
 const LlamaCppRawValueTimingsSchema = z.object({
   cache_n: z.number(),
@@ -94,7 +96,28 @@ export const useOpenAiCompatibleChat = defineStore(
       let timings: z.infer<typeof LlamaCppRawValueTimingsSchema> | undefined = undefined
       let usage: LanguageModelUsage | undefined = undefined
       const systemPromptToUse = temporarySystemPrompt.value || textInference.systemPrompt
-      let messages = convertToModelMessages(m.messages) //.filter((m) => m.role !== 'tool')
+      let messages = convertToModelMessages(m.messages)
+
+      // Convert aipg-media image URLs to base64 for the backend
+      messages = await Promise.all(
+        messages.map(async (msg) => {
+          if (msg.role !== 'user' || !Array.isArray(msg.content)) return msg
+          const content = await Promise.all(
+            msg.content.map(async (part) => {
+              if (
+                part.type === 'file' &&
+                part.mediaType?.startsWith('image/') &&
+                typeof part.data === 'string' &&
+                part.data.startsWith('aipg-media://')
+              ) {
+                return { ...part, data: await imageUrlToDataUri(part.data) }
+              }
+              return part
+            }),
+          )
+          return { ...msg, content }
+        }),
+      )
 
       // Filter out annotatedImageUrl json from tool results
       messages = messages.map((m) => {
@@ -291,7 +314,7 @@ export const useOpenAiCompatibleChat = defineStore(
     })
 
     const messageInput = ref('')
-    const fileInput = ref<FileList | null>(null)
+    const fileInput = ref<FileUIPart[]>([])
     const temporarySystemPrompt = ref<string | null>(null)
 
     async function generate(question: string) {
@@ -302,10 +325,8 @@ export const useOpenAiCompatibleChat = defineStore(
       manuallyStopped.value = false
 
       // 2. Block if images attached to non-vision model
-      if (fileInput.value && !textInference.modelSupportsVision) {
-        const hasImageFiles = Array.from(fileInput.value).some((file) =>
-          file.type.startsWith('image/'),
-        )
+      if (fileInput.value.length > 0 && !textInference.modelSupportsVision) {
+        const hasImageFiles = fileInput.value.some((part) => part.mediaType?.startsWith('image/'))
         if (hasImageFiles) {
           const errorMessage =
             'The selected model does not support image inputs. Please remove the images or select a vision-capable model.'
@@ -329,7 +350,7 @@ export const useOpenAiCompatibleChat = defineStore(
       try {
         await chat.sendMessage({
           text: messageInput.value,
-          files: fileInput.value ? fileInput.value : undefined,
+          files: fileInput.value.length > 0 ? fileInput.value : undefined,
           metadata: {
             model: textInference.activeModel,
             timestamp: Date.now(),
@@ -347,12 +368,12 @@ export const useOpenAiCompatibleChat = defineStore(
         }
       }
 
-      // 6. Persist conversation
+      // 6. Persist conversation (sanitize base64 image parts to aipg-media)
       conversations.updateConversation(messages.value, conversations.activeKey)
 
       // 7. Clear inputs
       messageInput.value = ''
-      fileInput.value = null
+      fileInput.value = []
     }
 
     async function stop() {
@@ -368,12 +389,11 @@ export const useOpenAiCompatibleChat = defineStore(
       conversations.updateConversation(messages.value, conversations.activeKey)
     }
 
-    function removeMessage(messageId: string) {
+    async function removeMessage(messageId: string) {
       const chat = chats[conversations.activeKey]
       if (!chat) return
       const indexOfAssistantMeessage = chat.messages.findIndex((m) => m.id === messageId)
       console.log('removeMessage', { messageId, indexOfAssistantMeessage, messages: chat.messages })
-      // remove also the user message before the assistant message
       if (indexOfAssistantMeessage > 0) {
         chat.messages.splice(indexOfAssistantMeessage - 1, 2)
       } else {

--- a/WebUI/src/components/SettingsBasic.vue
+++ b/WebUI/src/components/SettingsBasic.vue
@@ -123,17 +123,14 @@
               </TooltipTrigger>
               <TooltipContent side="bottom" class="max-w-[300px]">
                 {{
-                  languages.SETTINGS_DEVELOPER_KEEP_MODELS_LOADED_INFO
-                    || 'When enabled, chat and image generation models stay loaded in memory simultaneously. Requires more VRAM but avoids reloading models when switching between chat and image generation.'
+                  languages.SETTINGS_DEVELOPER_KEEP_MODELS_LOADED_INFO ||
+                  'When enabled, chat and image generation models stay loaded in memory simultaneously. Requires more VRAM but avoids reloading models when switching between chat and image generation.'
                 }}
               </TooltipContent>
             </Tooltip>
           </TooltipProvider>
         </div>
-        <Checkbox
-          id="keep-models-loaded"
-          v-model="developerSettings.keepModelsLoaded"
-        />
+        <Checkbox id="keep-models-loaded" v-model="developerSettings.keepModelsLoaded" />
       </div>
     </div>
     <div class="flex justify-between items-center">

--- a/WebUI/src/components/ui/IconButton.vue
+++ b/WebUI/src/components/ui/IconButton.vue
@@ -1,10 +1,5 @@
 <script setup lang="ts">
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipProvider,
-  TooltipTrigger,
-} from '@/components/ui/tooltip'
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip'
 
 defineProps<{
   icon: string

--- a/WebUI/src/components/ui/loadImage/LoadImage.vue
+++ b/WebUI/src/components/ui/loadImage/LoadImage.vue
@@ -61,7 +61,7 @@
 <script setup lang="ts">
 import type { HTMLAttributes } from 'vue'
 import { computed } from 'vue'
-import { cn } from '@/lib/utils'
+import { cn, isImageUrl, saveImageToMediaInput } from '@/lib/utils'
 import { useDropZone } from '@vueuse/core'
 
 const props = defineProps<{
@@ -78,15 +78,7 @@ const emit = defineEmits<{
 
 const acceptedImageTypes = ['image/jpeg', 'image/png', 'image/webp']
 
-const hasImage = computed(() => {
-  const value = props.imageUrlRef.value
-  return (
-    value &&
-    typeof value === 'string' &&
-    value !== '' &&
-    value.match(/^data:image\/(png|jpeg|webp);base64,/)
-  )
-})
+const hasImage = computed(() => isImageUrl(props.imageUrlRef.value))
 
 const imgDropZone = useTemplateRef('imgDropZone')
 
@@ -117,7 +109,7 @@ function processFiles(files: File[] | null, inputCurrent: Ref<string, string>) {
     }
 
     const reader = new FileReader()
-    reader.onload = (e) => {
+    reader.onload = async (e) => {
       if (
         !e.target ||
         !(e.target instanceof FileReader) ||
@@ -127,8 +119,10 @@ function processFiles(files: File[] | null, inputCurrent: Ref<string, string>) {
         console.error('Failed to read file')
         return
       }
-      inputCurrent.value = e.target.result
-      emit('imageLoaded', e.target.result)
+      const dataUri = e.target.result
+      const aipgMediaUrl = await saveImageToMediaInput(dataUri)
+      inputCurrent.value = aipgMediaUrl
+      emit('imageLoaded', aipgMediaUrl)
     }
     reader.readAsDataURL(file)
   }

--- a/WebUI/src/components/ui/loadImage/LoadImageWithPreview.vue
+++ b/WebUI/src/components/ui/loadImage/LoadImageWithPreview.vue
@@ -82,7 +82,7 @@
 <script setup lang="ts">
 import type { HTMLAttributes } from 'vue'
 import { computed } from 'vue'
-import { cn } from '@/lib/utils'
+import { cn, isImageUrl, saveImageToMediaInput } from '@/lib/utils'
 import { useDropZone } from '@vueuse/core'
 import { useDialogStore } from '@/assets/js/store/dialogs'
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip'
@@ -103,15 +103,7 @@ const dialogStore = useDialogStore()
 
 const acceptedImageTypes = ['image/jpeg', 'image/png', 'image/webp']
 
-const hasImage = computed(() => {
-  const value = props.imageUrlRef.value
-  return (
-    value &&
-    typeof value === 'string' &&
-    value !== '' &&
-    value.match(/^data:image\/(png|jpeg|webp);base64,/)
-  )
-})
+const hasImage = computed(() => isImageUrl(props.imageUrlRef.value))
 
 // Determine which image URL to display (always show preview if modified)
 const displayImageUrl = computed(() => {
@@ -153,7 +145,7 @@ function processFiles(files: File[] | null, inputCurrent: Ref<string, string>) {
     }
 
     const reader = new FileReader()
-    reader.onload = (e) => {
+    reader.onload = async (e) => {
       if (
         !e.target ||
         !(e.target instanceof FileReader) ||
@@ -163,10 +155,11 @@ function processFiles(files: File[] | null, inputCurrent: Ref<string, string>) {
         console.error('Failed to read file')
         return
       }
-      inputCurrent.value = e.target.result
-      // Clear preview when a new image is loaded
+      const dataUri = e.target.result
+      const aipgMediaUrl = await saveImageToMediaInput(dataUri)
+      inputCurrent.value = aipgMediaUrl
       dialogStore.clearMaskEditorPreview()
-      emit('imageLoaded', e.target.result)
+      emit('imageLoaded', aipgMediaUrl)
     }
     reader.readAsDataURL(file)
   }

--- a/WebUI/src/env.d.ts
+++ b/WebUI/src/env.d.ts
@@ -71,6 +71,7 @@ type electronAPI = {
   getInitialPage(): Promise<AipgPage>
   getDemoModeSettings(): Promise<DemoModeSettings>
   saveImage(url: string): void
+  saveImageToMediaInput(dataUri: string): Promise<string>
   openImageWin(url: string, title: string, width: number, height: number): void
   wakeupApiService(): void
   screenChange(callback: (width: number, height: number) => void): void

--- a/WebUI/src/lib/utils.ts
+++ b/WebUI/src/lib/utils.ts
@@ -223,6 +223,25 @@ export function isBase64ImageDataUri(url: string | undefined | null): boolean {
 }
 
 /**
+ * Checks if a string is a displayable image URL (base64 data URI or aipg-media).
+ * Use this for "has image" UI checks (e.g. img src, drop zones).
+ */
+export function isImageUrl(url: string | undefined | null): boolean {
+  if (!url || typeof url !== 'string') return false
+  return isBase64ImageDataUri(url) || url.startsWith('aipg-media://')
+}
+
+/**
+ * Saves an image data URI to media/input and returns an aipg-media URL.
+ * @param dataUri - data:image/(png|jpeg|webp);base64,... string
+ * @returns aipg-media://input/<filename>
+ */
+export async function saveImageToMediaInput(dataUri: string): Promise<string> {
+  const pathSegment = await window.electronAPI.saveImageToMediaInput(dataUri)
+  return `aipg-media://${pathSegment}`
+}
+
+/**
  * Converts a blob URL (or any image URL) to a base64 data URI.
  * If the URL is already a base64 data URI, it returns it unchanged.
  * @param url - The URL to convert (blob:, http:, or data: URL)

--- a/WebUI/src/views/Chat.vue
+++ b/WebUI/src/views/Chat.vue
@@ -39,15 +39,17 @@
             </p>
             <img
               v-if="
-                message.parts.find(
-                  (part) => part.type === 'file' && part.mediaType?.startsWith('image/'),
-                )
+                message.parts
+                  .toReversed()
+                  .find((part) => part.type === 'file' && part.mediaType?.startsWith('image/'))
               "
               :src="
                 (
-                  message.parts.find(
-                    (part) => part.type === 'file' && part.mediaType?.startsWith('image/'),
-                  ) as { url?: string }
+                  message.parts
+                    .toReversed()
+                    .find(
+                      (part) => part.type === 'file' && part.mediaType?.startsWith('image/'),
+                    ) as { url?: string }
                 )?.url
               "
               alt="Generated Image"

--- a/WebUI/src/views/PromptArea.vue
+++ b/WebUI/src/views/PromptArea.vue
@@ -189,7 +189,13 @@
 
 <script setup lang="ts">
 import { getCurrentInstance, ref, computed, watch } from 'vue'
-import { mapModeToLabel, downscaleImageTo1MP, imageUrlToDataUri } from '@/lib/utils.ts'
+import type { FileUIPart } from 'ai'
+import {
+  mapModeToLabel,
+  downscaleImageTo1MP,
+  imageUrlToDataUri,
+  saveImageToMediaInput,
+} from '@/lib/utils.ts'
 import { useAudioRecorder } from '@/assets/js/store/audioRecorder'
 import { useSpeechToText } from '@/assets/js/store/speechToText'
 import { usePromptStore } from '@/assets/js/store/promptArea'
@@ -300,38 +306,12 @@ const emits = defineEmits<{
   (e: 'openSettings'): void
 }>()
 
-const imagePreview = computed(() => {
-  if (openAiCompatibleChat.fileInput) {
-    const urls = []
-    let id = 0
-    for (const file of openAiCompatibleChat.fileInput) {
-      const url = URL.createObjectURL(file)
-      urls.push({ id, url, file })
-      id++
-    }
-    return urls
-  }
-  return []
-})
+const imagePreview = computed(() =>
+  openAiCompatibleChat.fileInput.map((part, id) => ({ id, url: part.url, part })),
+)
 
-// Remove image at specified index
 function removeImage(index: number) {
-  if (!openAiCompatibleChat.fileInput) return
-
-  // Revoke object URL for the removed image
-  const preview = imagePreview.value.find((p) => p.id === index)
-  if (preview) {
-    URL.revokeObjectURL(preview.url)
-  }
-
-  // Convert FileList to array and remove the file at index
-  const files = Array.from(openAiCompatibleChat.fileInput)
-  files.splice(index, 1)
-
-  // Create new FileList with remaining files
-  const fileList = new DataTransfer()
-  files.forEach((file) => fileList.items.add(file))
-  openAiCompatibleChat.fileInput = fileList.files
+  openAiCompatibleChat.fileInput = openAiCompatibleChat.fileInput.filter((_, i) => i !== index)
 }
 
 const isProcessing = computed(() => {
@@ -513,23 +493,21 @@ async function handleComfyUIImageUpload(imageFiles: File[]) {
   const imageUrl = URL.createObjectURL(imageFile)
 
   try {
-    // Convert to data URI for ComfyUI
     const dataUri = await imageUrlToDataUri(imageUrl)
+    const aipgMediaUrl = await saveImageToMediaInput(dataUri)
 
-    // Find first image input
     const firstImageInput = imageGeneration.comfyInputs.find((input) => input.type === 'image')
 
     if (firstImageInput) {
-      // Set the image input value
-      firstImageInput.current.value = dataUri
+      firstImageInput.current.value = aipgMediaUrl
 
-      // Create MediaItem and add to history (same as "Send to Edit")
       const imageItem: ImageMediaItem = {
+        createdAt: Date.now(),
         id: crypto.randomUUID(),
         type: 'image',
         mode: 'imageEdit',
         state: 'done',
-        imageUrl: dataUri,
+        imageUrl: aipgMediaUrl,
         sourceImageUrl: imageUrl,
         fromImageGen: true,
         settings: {},
@@ -551,36 +529,36 @@ async function handleComfyUIImageUpload(imageFiles: File[]) {
   }
 }
 
-// Handle image files with downscaling for chat mode
+async function handleChatImageUpload(imageFiles: File[]) {
+  const filesToProcess = await Promise.all(
+    imageFiles.map((file) => downscaleImageTo1MP(file)),
+  ).catch((error) => {
+    console.error('Error downscaling images:', error)
+    return imageFiles
+  })
+
+  const parts: FileUIPart[] = []
+  for (const file of filesToProcess) {
+    const objectUrl = URL.createObjectURL(file)
+    try {
+      const dataUri = await imageUrlToDataUri(objectUrl)
+      const aipgUrl = await saveImageToMediaInput(dataUri)
+      parts.push({ type: 'file', mediaType: file.type, url: aipgUrl, filename: file.name })
+    } finally {
+      URL.revokeObjectURL(objectUrl)
+    }
+  }
+  openAiCompatibleChat.fileInput = parts
+}
+
+// Handle image files: ComfyUI upload vs chat/other → fileInput as aipg-media
 async function handleImageFiles(imageFiles: File[]) {
   if (imageFiles.length === 0) return
 
-  // For ComfyUI modes, route to ComfyUI-specific handler
-  const comfyUiModes: ModeType[] = ['imageGen', 'imageEdit', 'video']
-  if (comfyUiModes.includes(promptStore.getCurrentMode()) && shouldShowImageUploadButton.value) {
-    await handleComfyUIImageUpload(imageFiles)
-    return
-  }
-
-  // Downscale images if in chat mode (images are only sent to vision-capable models)
   if (promptStore.getCurrentMode() === 'chat') {
-    try {
-      const downscaledFiles = await Promise.all(imageFiles.map((file) => downscaleImageTo1MP(file)))
-      const imageFileList = new DataTransfer()
-      downscaledFiles.forEach((file) => imageFileList.items.add(file))
-      openAiCompatibleChat.fileInput = imageFileList.files
-    } catch (error) {
-      console.error('Error downscaling images:', error)
-      // Fallback to original files if downscaling fails
-      const imageFileList = new DataTransfer()
-      imageFiles.forEach((file) => imageFileList.items.add(file))
-      openAiCompatibleChat.fileInput = imageFileList.files
-    }
+    await handleChatImageUpload(imageFiles)
   } else {
-    // For non-chat modes, use original files
-    const imageFileList = new DataTransfer()
-    imageFiles.forEach((file) => imageFileList.items.add(file))
-    openAiCompatibleChat.fileInput = imageFileList.files
+    await handleComfyUIImageUpload(imageFiles)
   }
 }
 


### PR DESCRIPTION
**Description:**

Please provide a brief description of the changes made in this pull request.

**Related Issue:**

If this pull request is related to any existing issue, please mention the issue number here.

**Changes Made:**

Please list down the specific changes made in this pull request.

**Testing Done:**

Please describe the testing that has been done to ensure the changes made in this pull request are functioning as expected.

**Screenshots:**

If applicable, please provide screenshots or GIFs or videos to visually demonstrate the changes made.

**Checklist:**

- [ ] I have tested the changes locally.
- [ ] I have self-reviewed the code changes.
- [ ] I have updated the documentation, if necessary.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Save uploaded images to a local media-input area and return stable media URLs via the app API.

* **Enhancements**
  * Chat, upload, preview and image-generation flows now emit and persist media-backed URLs.
  * Image input validation improved to recognize data URIs and internal media URLs.

* **Refactor**
  * File input model moved to an array-based structure; image items now include creation timestamps.

* **Chores**
  * Added a project type-check script; preset loading now skips non-packaged (development) runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->