### PR TITLE
feat: allow picking non standard models in manual mode

### DIFF
--- a/WebUI/electron/main.ts
+++ b/WebUI/electron/main.ts
@@ -627,6 +627,12 @@ function initEventHandle() {
     return pathsManager.scanEmbedding()
   })
 
+  ipcMain.handle('getComfyUIModels', (_event, modelType: string) => {
+    return pathsManager.scanComfyUIModels(modelType)
+  })
+
+  ipcMain.handle('getPlatform', () => process.platform)
+
   ipcMain.handle('addDocumentToRAGList', (_event, document: IndexedDocument) => {
     return handleUtilityFunction<IndexedDocument, IndexedDocument>(
       'addDocumentToRAGList',

--- a/WebUI/electron/pathsManager.ts
+++ b/WebUI/electron/pathsManager.ts
@@ -91,6 +91,40 @@ export class PathsManager {
 
     return [...modelsSet]
   }
+  /**
+   * List available ComfyUI models for a given model type (e.g. checkpoints, loras).
+   * Returns relative paths from the type directory, using OS path separator (e.g. "SubDir\\model.safetensors").
+   */
+  scanComfyUIModels(modelType: string): string[] {
+    const dir = (this.modelPaths as Record<string, string>)[modelType]
+    if (!dir || !fs.existsSync(dir)) {
+      return []
+    }
+    const baseDir = path.resolve(dir)
+    const seen = new Set<string>()
+    const walk = (currentDir: string, relativePrefix: string): void => {
+      let entries: fs.Dirent[] = []
+      try {
+        entries = fs.readdirSync(currentDir, { withFileTypes: true })
+      } catch (error) {
+        console.error(`Failed to read model directory "${currentDir}"`, error)
+        return
+      }
+      for (const ent of entries) {
+        const fullPath = path.join(currentDir, ent.name)
+        const relativePath = relativePrefix ? `${relativePrefix}${path.sep}${ent.name}` : ent.name
+        if (ent.isDirectory()) {
+          walk(fullPath, relativePath)
+        } else if (ent.isFile()) {
+          const normalized = relativePath.replace(/\//g, path.sep)
+          seen.add(normalized)
+        }
+      }
+    }
+    walk(baseDir, '')
+    return [...seen].sort()
+  }
+
   scanEmbedding(): Model[] {
     const embeddingModels: Model[] = []
     llmBackendTypes.forEach((backend) => {

--- a/WebUI/electron/preload.ts
+++ b/WebUI/electron/preload.ts
@@ -90,6 +90,8 @@ contextBridge.exposeInMainWorld('electronAPI', {
   getDownloadedGGUFLLMs: () => ipcRenderer.invoke('getDownloadedGGUFLLMs'),
   getDownloadedOpenVINOLLMModels: () => ipcRenderer.invoke('getDownloadedOpenVINOLLMModels'),
   getDownloadedEmbeddingModels: () => ipcRenderer.invoke('getDownloadedEmbeddingModels'),
+  getComfyUIModels: (modelType: string) => ipcRenderer.invoke('getComfyUIModels', modelType),
+  getPlatform: () => ipcRenderer.invoke('getPlatform') as Promise<NodeJS.Platform>,
   openImageWithSystem: (url: string) => ipcRenderer.send('openImageWithSystem', url),
   openImageInFolder: (url: string) => ipcRenderer.send('openImageInFolder', url),
   setFullScreen: (enable: boolean) => ipcRenderer.send('setFullScreen', enable),

--- a/WebUI/external/presets/manual.json
+++ b/WebUI/external/presets/manual.json
@@ -9,10 +9,22 @@
   "mediaType": "image",
   "resolutionConfig": {
     "megapixels": [
-      { "label": "0.25", "totalPixels": 262144 },
-      { "label": "0.5", "totalPixels": 495616 },
-      { "label": "0.8", "totalPixels": 802816 },
-      { "label": "1.0", "totalPixels": 1048576 }
+      {
+        "label": "0.25",
+        "totalPixels": 262144
+      },
+      {
+        "label": "0.5",
+        "totalPixels": 495616
+      },
+      {
+        "label": "0.8",
+        "totalPixels": 802816
+      },
+      {
+        "label": "1.0",
+        "totalPixels": 1048576
+      }
     ],
     "aspectRatios": ["21/9", "16/9", "3/2", "4/3", "1/1", "3/4", "2/3", "9/16", "9/21"]
   },
@@ -134,17 +146,25 @@
       "modifiable": true
     },
     {
-      "type": "stringList",
+      "type": "model",
       "label": "Model",
       "displayed": true,
       "modifiable": true,
       "defaultValue": "RunDiffusion---Juggernaut-XL-v9\\Juggernaut-XL_v9_RunDiffusionPhoto_v2.safetensors",
       "nodeTitle": "Load Checkpoint",
       "nodeInput": "ckpt_name",
-      "options": [
-        "RunDiffusion---Juggernaut-XL-v9\\Juggernaut-XL_v9_RunDiffusionPhoto_v2.safetensors",
-        "Lykon---DreamShaper\\DreamShaper_8_pruned.safetensors"
-      ]
+      "modelType": "checkpoints"
+    },
+    {
+      "type": "model",
+      "label": "LoRA",
+      "displayed": true,
+      "modifiable": true,
+      "defaultValue": "None",
+      "nodeTitle": "Load LoRA",
+      "nodeInput": "lora_name",
+      "modelType": "loras",
+      "optional": true
     },
     {
       "type": "stringList",
@@ -209,7 +229,7 @@
         "sampler_name": "dpmpp_2m",
         "scheduler": "normal",
         "denoise": 1,
-        "model": ["4", 0],
+        "model": ["10", 0],
         "positive": ["6", 0],
         "negative": ["7", 0],
         "latent_image": ["5", 0]
@@ -228,6 +248,19 @@
         "title": "Load Checkpoint"
       }
     },
+    "10": {
+      "inputs": {
+        "lora_name": "None",
+        "strength_model": 1,
+        "strength_clip": 1,
+        "model": ["4", 0],
+        "clip": ["4", 1]
+      },
+      "class_type": "LoraLoader",
+      "_meta": {
+        "title": "Load LoRA"
+      }
+    },
     "5": {
       "inputs": {
         "width": 1024,
@@ -242,7 +275,7 @@
     "6": {
       "inputs": {
         "text": "upperbody shot,long hairs, happy, laugh, hugging a teddy bear, looking at viewers, dancing stand, cute, soft color, flowers in background, many flowers, among flowers, best quality, highres, delicate details,",
-        "clip": ["4", 1]
+        "clip": ["10", 1]
       },
       "class_type": "CLIPTextEncode",
       "_meta": {
@@ -252,7 +285,7 @@
     "7": {
       "inputs": {
         "text": "nsfw",
-        "clip": ["4", 1]
+        "clip": ["10", 1]
       },
       "class_type": "CLIPTextEncode",
       "_meta": {

--- a/WebUI/src/assets/js/store/comfyUiPresets.ts
+++ b/WebUI/src/assets/js/store/comfyUiPresets.ts
@@ -1,7 +1,12 @@
 import { defineStore, acceptHMRUpdate } from 'pinia'
 import { WebSocket } from 'partysocket'
 import { ComfyUIApiWorkflow } from './presets'
-import { useImageGenerationPresets, type MediaItem } from './imageGenerationPresets'
+import {
+  useImageGenerationPresets,
+  modelNameForComfyApi,
+  OPTIONAL_MODEL_NONE,
+  type MediaItem,
+} from './imageGenerationPresets'
 import { useI18N } from './i18n'
 import * as toast from '../toast'
 import { useBackendServices } from '@/assets/js/store/backendServices.ts'
@@ -167,6 +172,94 @@ function modifySettingInWorkflow(
     workflow[key].inputs[inputName] = value
   } else if (workflow[key]?.inputs?.['a'] !== undefined) {
     workflow[key].inputs['a'] = value
+  }
+}
+
+/** ComfyUI node input names that hold model/file paths; separator is OS-dependent (see main.ts preset handling). */
+const COMFY_MODEL_PATH_INPUTS = new Set([
+  'ckpt_name',
+  'lora_name',
+  'vae_name',
+  'unet_name',
+  'clip_name',
+  'model_name',
+  'control_net_name',
+])
+
+function normalizeModelPathsInWorkflow(
+  workflow: ComfyUIApiWorkflow,
+  platform: NodeJS.Platform,
+): void {
+  for (const node of Object.values(workflow)) {
+    const inputs = (node as { inputs?: Record<string, unknown> }).inputs
+    if (!inputs) continue
+    for (const [inputName, value] of Object.entries(inputs)) {
+      if (COMFY_MODEL_PATH_INPUTS.has(inputName) && typeof value === 'string') {
+        inputs[inputName] = modelNameForComfyApi(value, platform)
+      }
+    }
+  }
+}
+
+/**
+ * Bypass a node by rewiring its outputs to its upstream and removing the node.
+ * Supported: LoraLoader (output 0 = model from input "model", output 1 = clip from input "clip").
+ */
+function bypassNode(workflow: ComfyUIApiWorkflow, nodeId: string): void {
+  const node = workflow[nodeId] as
+    | { class_type?: string; inputs?: Record<string, unknown> }
+    | undefined
+  if (!node?.inputs) return
+  const classType = node.class_type
+  let rewire: [number, [string, number]][]
+  if (classType === 'LoraLoader') {
+    const model = node.inputs.model as [string, number] | undefined
+    const clip = node.inputs.clip as [string, number] | undefined
+    if (!model || !clip) return
+    rewire = [
+      [0, model],
+      [1, clip],
+    ]
+  } else {
+    return
+  }
+  for (const entry of Object.values(workflow)) {
+    const inputs = (entry as { inputs?: Record<string, unknown> }).inputs
+    if (!inputs) continue
+    for (const key of Object.keys(inputs)) {
+      const v = inputs[key]
+      if (
+        Array.isArray(v) &&
+        v.length === 2 &&
+        typeof v[0] === 'string' &&
+        typeof v[1] === 'number'
+      ) {
+        if (v[0] === nodeId) {
+          const slot = v[1]
+          const upstream = rewire.find(([s]) => s === slot)?.[1]
+          if (upstream) inputs[key] = upstream
+        }
+      }
+    }
+  }
+  delete workflow[nodeId]
+}
+
+/** Rewire and remove optional model nodes whose value is None (e.g. LoRA bypass). */
+function bypassOptionalModelNodes(workflow: ComfyUIApiWorkflow): void {
+  const imageGeneration = useImageGenerationPresets()
+  for (const input of imageGeneration.comfyInputs) {
+    if (
+      input.type !== 'model' ||
+      input.optional !== true ||
+      input.current.value !== OPTIONAL_MODEL_NONE
+    ) {
+      continue
+    }
+    const keys = findKeysByTitle(workflow, input.nodeTitle)
+    for (const key of keys) {
+      bypassNode(workflow, key)
+    }
   }
 }
 
@@ -709,7 +802,10 @@ export const useComfyUiPresets = defineStore(
       return missingInputs
     }
 
-    async function modifyDynamicSettingsInWorkflow(mutableWorkflow: ComfyUIApiWorkflow) {
+    async function modifyDynamicSettingsInWorkflow(
+      mutableWorkflow: ComfyUIApiWorkflow,
+      platform: NodeJS.Platform,
+    ) {
       for (const input of imageGeneration.comfyInputs) {
         const keys = findKeysByTitle(mutableWorkflow, input.nodeTitle)
         if (keys.length === 0) {
@@ -724,6 +820,20 @@ export const useComfyUiPresets = defineStore(
           if (mutableWorkflow[keys[0]].inputs !== undefined) {
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
             ;(mutableWorkflow[keys[0]].inputs as any)[input.nodeInput] = input.current.value
+          }
+        }
+        if (input.type === 'model') {
+          if (input.current.value === OPTIONAL_MODEL_NONE) {
+            // Node will be bypassed by bypassOptionalModelNodes; do not set value
+            continue
+          }
+          if (mutableWorkflow[keys[0]].inputs !== undefined) {
+            const value =
+              typeof input.current.value === 'string'
+                ? modelNameForComfyApi(input.current.value, platform)
+                : input.current.value
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            ;(mutableWorkflow[keys[0]].inputs as any)[input.nodeInput] = value
           }
         }
         if (input.type === 'image' || input.type === 'inpaintMask') {
@@ -836,6 +946,7 @@ export const useComfyUiPresets = defineStore(
         imageGeneration.currentState = 'install_workflow_components'
         await installCustomNodesForActivePresetFully()
 
+        const platform = await window.electronAPI.getPlatform()
         const mutableWorkflow: ComfyUIApiWorkflow = JSON.parse(
           JSON.stringify(preset.comfyUiApiWorkflow),
         )
@@ -849,7 +960,9 @@ export const useComfyUiPresets = defineStore(
         modifySettingInWorkflow(mutableWorkflow, 'prompt', imageGeneration.prompt)
         modifySettingInWorkflow(mutableWorkflow, 'negativePrompt', imageGeneration.negativePrompt)
 
-        await modifyDynamicSettingsInWorkflow(mutableWorkflow)
+        await modifyDynamicSettingsInWorkflow(mutableWorkflow, platform)
+        bypassOptionalModelNodes(mutableWorkflow)
+        normalizeModelPathsInWorkflow(mutableWorkflow, platform)
 
         loaderNodes.value = [
           ...findKeysByClassType(mutableWorkflow, 'CheckpointLoaderSimple'),

--- a/WebUI/src/assets/js/store/imageGenerationPresets.ts
+++ b/WebUI/src/assets/js/store/imageGenerationPresets.ts
@@ -1,9 +1,35 @@
 import { acceptHMRUpdate, defineStore } from 'pinia'
+import { watch } from 'vue'
 import { useComfyUiPresets } from './comfyUiPresets'
 import { useI18N } from './i18n'
 import * as toast from '@/assets/js/toast.ts'
 import { useBackendServices } from './backendServices'
 import { usePresets, type ComfyInput } from './presets'
+
+/** Convert requiredModels "repo/path/file.safetensors" to ComfyUI format "repo---path\\file.safetensors" */
+function requiredModelToComfyUIName(modelPath: string): string {
+  const parts = modelPath.split('/')
+  if (parts.length < 2) return modelPath
+  const firstTwo = parts.slice(0, 2).join('---')
+  const rest = parts.slice(2).join('\\')
+  return rest ? `${firstTwo}\\${rest}` : firstTwo
+}
+
+/** Normalize to ComfyUI format (backslash) so disk scan and requiredModels dedupe correctly across OS. */
+function normalizeComfyUIModelName(name: string): string {
+  return name.replace(/\//g, '\\')
+}
+
+/** Value for optional model inputs when the node should be bypassed (e.g. no LoRA). */
+export const OPTIONAL_MODEL_NONE = 'None'
+
+/**
+ * Convert stored model name to the path separator ComfyUI expects for the current OS.
+ * Matches preset handling in main.ts: Windows expects backslash, non-Windows expects forward slash.
+ */
+export function modelNameForComfyApi(name: string, platform: NodeJS.Platform): string {
+  return platform === 'win32' ? name.replace(/\//g, '\\') : name.replace(/\\/g, '/')
+}
 import { useUIStore } from './ui'
 import { PresetRequirementsData, useDialogStore } from './dialogs'
 import { getMissingComfyuiBackendModels } from './imageGenerationUtils'
@@ -221,6 +247,8 @@ export const useImageGenerationPresets = defineStore(
       return activePreset.value.backend as 'comfyui'
     })
 
+    const modelOptionsByType = ref<Record<string, string[]>>({})
+
     const comfyInputs = computed(() => {
       if (!activePreset.value || activePreset.value.backend !== 'comfyui') return []
       const inputRef = (input: ComfyInput): string => `${input.nodeTitle}.${input.nodeInput}`
@@ -234,9 +262,17 @@ export const useImageGenerationPresets = defineStore(
       }
       const getSavedOrDefault = (input: ComfyInput) => {
         const settingsKey = getSettingsKey()
-        if (!settingsKey) return input.defaultValue
-        const saved = comfyInputsPerPreset.value[settingsKey]?.[inputRef(input)]
-        return saved ?? input.defaultValue
+        const raw = settingsKey
+          ? (comfyInputsPerPreset.value[settingsKey]?.[inputRef(input)] ?? input.defaultValue)
+          : input.defaultValue
+        if (
+          input.type === 'model' &&
+          input.optional === true &&
+          (raw === undefined || raw === '' || raw === OPTIONAL_MODEL_NONE)
+        ) {
+          return OPTIONAL_MODEL_NONE
+        }
+        return raw
       }
 
       const comfyInputs = activePreset.value.settings.filter(
@@ -255,7 +291,11 @@ export const useImageGenerationPresets = defineStore(
           },
         })
 
-        return { ...input, current }
+        const base = { ...input, current }
+        if (input.type === 'model' && input.modelType) {
+          return { ...base, options: modelOptionsByType.value[input.modelType] ?? [] }
+        }
+        return base
       })
     })
 
@@ -265,6 +305,58 @@ export const useImageGenerationPresets = defineStore(
       Record<PresetName, Record<NodeInputReference, unknown> | undefined>
     >({})
     const settingsPerPreset = ref<Record<PresetName, Record<string, unknown>>>({})
+
+    let modelOptionsLoadToken = 0
+
+    async function loadModelOptionsForActivePreset() {
+      const loadToken = ++modelOptionsLoadToken
+      const preset = activePreset.value
+      if (!preset || preset.backend !== 'comfyui') {
+        modelOptionsByType.value = {}
+        return
+      }
+      const modelInputs = preset.settings.filter(
+        (s): s is ComfyInput & { modelType: string } =>
+          'nodeTitle' in s && 'nodeInput' in s && s.type === 'model' && !!s.modelType,
+      )
+      const modelTypes = [...new Set(modelInputs.map((s) => s.modelType))]
+      const required = preset.requiredModels ?? []
+      const optionalModelTypes = new Set(
+        modelInputs.filter((s) => s.optional === true).map((s) => s.modelType),
+      )
+      const nextOptions: Record<string, string[]> = {}
+      for (const modelType of modelTypes) {
+        let fromDisk: string[] = []
+        try {
+          fromDisk = await window.electronAPI.getComfyUIModels(modelType)
+        } catch (e) {
+          console.error('Failed to load ComfyUI models', { modelType, error: e })
+          // ComfyUI path may be missing or backend not running; still show required models
+        }
+        const fromRequired = required
+          .filter((r) => r.type === modelType)
+          .map((r) => requiredModelToComfyUIName(r.model))
+        const normalizedRequired = fromRequired.map(normalizeComfyUIModelName)
+        const normalizedDisk = fromDisk.map(normalizeComfyUIModelName)
+        let merged = [...new Set([...normalizedRequired, ...normalizedDisk])]
+        if (optionalModelTypes.has(modelType)) {
+          merged = [OPTIONAL_MODEL_NONE, ...merged]
+        }
+        nextOptions[modelType] = merged
+      }
+      if (loadToken === modelOptionsLoadToken) {
+        modelOptionsByType.value = nextOptions
+      }
+    }
+
+    // Watch preset object so we re-run after preset reload (same name, new definition) and on preset switch
+    watch(
+      () => activePreset.value,
+      () => {
+        loadModelOptionsForActivePreset()
+      },
+      { immediate: true },
+    )
 
     // Watch resolution changes and sync to target width/height ComfyInputs (for inpainting with target resolution)
     watch(resolution, (newResolution) => {
@@ -704,16 +796,17 @@ export const useImageGenerationPresets = defineStore(
           >
 
           const filteredInputs: typeof comfyInputsPerPreset = {}
-          Object.entries(comfyInputsPerPreset)
-            .filter(([_, inputs]) => inputs !== undefined)
-            .map(([presetName, inputs]) => [
-              presetName,
-              Object.fromEntries(
-                Object.entries(inputs as Record<string, unknown>).filter(([key]) =>
-                  ['image', 'inpaintMask', 'video'].includes(key),
-                ),
-              ),
-            ])
+          for (const [presetName, inputs] of Object.entries(comfyInputsPerPreset)) {
+            if (inputs === undefined) continue
+            const filtered: Record<string, unknown> = {}
+            for (const [key, value] of Object.entries(inputs as Record<string, unknown>)) {
+              const isDataUri =
+                typeof value === 'string' &&
+                (value.startsWith('data:image/') || value.startsWith('data:video/'))
+              if (!isDataUri) filtered[key] = value
+            }
+            filteredInputs[presetName] = filtered
+          }
           const imagesToPersist = Array.isArray(state.generatedImages)
             ? state.generatedImages
                 .filter((img) => img && img.state === 'done')

--- a/WebUI/src/assets/js/store/presets.ts
+++ b/WebUI/src/assets/js/store/presets.ts
@@ -35,6 +35,7 @@ const SettingSchema = z.object({
     'image',
     'video',
     'stringList',
+    'model',
     'outpaintCanvas',
     'inpaintMask',
   ]),
@@ -59,6 +60,16 @@ const ComfyInputSchema = SettingSchema.extend({
   step: z.number().optional(),
   // Optional flag for image inputs - when true and empty, injects black pixel
   optional: z.boolean().optional(),
+  // For type 'model': ComfyUI model type (e.g. 'checkpoints', 'loras') — options are loaded from disk + requiredModels
+  modelType: z.string().optional(),
+}).superRefine((value, ctx) => {
+  if (value.type === 'model' && !value.modelType) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ['modelType'],
+      message: 'modelType is required when type is "model"',
+    })
+  }
 })
 
 // Required Model Schema

--- a/WebUI/src/components/SettingsImageComfyDynamic.vue
+++ b/WebUI/src/components/SettingsImageComfyDynamic.vue
@@ -79,7 +79,7 @@
       ></Input>
 
       <drop-down-new
-        v-else-if="input.type === 'stringList'"
+        v-else-if="input.type === 'stringList' || input.type === 'model'"
         :items="
           (input.options || []).map((opt) => ({
             label: String(opt),

--- a/WebUI/src/components/ui/IconButton.vue
+++ b/WebUI/src/components/ui/IconButton.vue
@@ -12,19 +12,21 @@ defineEmits<{
 </script>
 
 <template>
-  <TooltipProvider :delay-duration="200">
-    <Tooltip>
-      <TooltipTrigger as-child>
-        <button
-          class="bg-muted rounded-xs w-6 h-6 flex items-center justify-center"
-          @click="$emit('click')"
-        >
-          <span class="svg-icon text-foreground w-4 h-4" :class="icon"></span>
-        </button>
-      </TooltipTrigger>
-      <TooltipContent side="left">
-        {{ tooltip }}
-      </TooltipContent>
-    </Tooltip>
-  </TooltipProvider>
+  <span class="inline-flex">
+    <TooltipProvider :delay-duration="200">
+      <Tooltip>
+        <TooltipTrigger as-child>
+          <button
+            class="bg-muted rounded-xs w-6 h-6 flex items-center justify-center"
+            @click="$emit('click')"
+          >
+            <span class="svg-icon text-foreground w-4 h-4" :class="icon"></span>
+          </button>
+        </TooltipTrigger>
+        <TooltipContent side="left">
+          {{ tooltip }}
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  </span>
 </template>

--- a/WebUI/src/env.d.ts
+++ b/WebUI/src/env.d.ts
@@ -93,6 +93,8 @@ type electronAPI = {
   getDownloadedGGUFLLMs(): Promise<string[]>
   getDownloadedOpenVINOLLMModels(): Promise<string[]>
   getDownloadedEmbeddingModels(): Promise<Model[]>
+  getComfyUIModels(modelType: string): Promise<string[]>
+  getPlatform(): Promise<NodeJS.Platform>
   openImageWithSystem(url: string): void
   openImageInFolder(url: string): void
   setFullScreen(enable: boolean): void


### PR DESCRIPTION
**Description:**

Please provide a brief description of the changes made in this pull request.

**Related Issue:**

If this pull request is related to any existing issue, please mention the issue number here.

**Changes Made:**

Please list down the specific changes made in this pull request.

**Testing Done:**

Please describe the testing that has been done to ensure the changes made in this pull request are functioning as expected.

**Screenshots:**

If applicable, please provide screenshots or GIFs or videos to visually demonstrate the changes made.

**Checklist:**

- [ ] I have tested the changes locally.
- [ ] I have self-reviewed the code changes.
- [ ] I have updated the documentation, if necessary.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * LoRA model loading added to image-generation workflows with a "Load LoRA" workflow node.
  * Renderer can now query available ComfyUI models and the runtime platform for improved UI behavior.
  * Model selection supports a new "model" setting type and dropdowns with an optional "None" sentinel.

* **Improvements**
  * Cross-platform normalization of model paths and automated loading/refreshing of model options per preset.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->