### PR TITLE
Make Llama.cpp params configurable via UI

### DIFF
--- a/WebUI/electron/main.ts
+++ b/WebUI/electron/main.ts
@@ -52,6 +52,7 @@ import {
   ComfyUiBackendService,
   COMFYUI_DEFAULT_PARAMETERS,
 } from './subprocesses/comfyUIBackendService'
+import { LLAMACPP_DEFAULT_PARAMETERS } from './subprocesses/llamaCppBackendService'
 import { filterPartnerPresets, updateIntelPresets } from './subprocesses/updateIntelPresets.ts'
 import { getGitHubRepoUrl, resolveBackendVersion, resolveModels } from './remoteUpdates.ts'
 import * as comfyuiTools from './subprocesses/comfyuiTools'
@@ -704,6 +705,7 @@ function initEventHandle() {
   })
 
   ipcMain.handle('getComfyUiDefaultParameters', () => COMFYUI_DEFAULT_PARAMETERS)
+  ipcMain.handle('getLlamaCppDefaultParameters', () => LLAMACPP_DEFAULT_PARAMETERS)
 
   ipcMain.handle('detectDevices', (_event: IpcMainInvokeEvent, serviceName: string) => {
     if (!serviceRegistry) {

--- a/WebUI/electron/preload.ts
+++ b/WebUI/electron/preload.ts
@@ -99,6 +99,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
     ipcRenderer.on('debugLog', (_event, value) => callback(value)),
   wakeupComfyUIService: () => ipcRenderer.send('wakeupComfyUIService'),
   getComfyUiDefaultParameters: () => ipcRenderer.invoke('getComfyUiDefaultParameters'),
+  getLlamaCppDefaultParameters: () => ipcRenderer.invoke('getLlamaCppDefaultParameters'),
   onServiceSetUpProgress: (callback: (data: SetupProgress) => void) =>
     ipcRenderer.on('serviceSetUpProgress', (_event, value) => callback(value)),
   onServiceInfoUpdate: (callback: (service: ApiServiceInformation) => void) =>

--- a/WebUI/electron/subprocesses/llamaCppBackendService.ts
+++ b/WebUI/electron/subprocesses/llamaCppBackendService.ts
@@ -13,6 +13,8 @@ import { binary, extract } from './tools.ts'
 
 const execAsync = promisify(exec)
 
+export const LLAMACPP_DEFAULT_PARAMETERS = '--gpu-layers 999 --log-prefix --jinja --no-mmap -fa off'
+
 interface LlamaServerProcess {
   process: ChildProcess
   port: number
@@ -65,6 +67,8 @@ export class LlamaCppBackendService implements ApiService {
   readonly appLogger = appLoggerInstance
 
   private version = 'b7278'
+
+  private llamaCppParametersString: string = LLAMACPP_DEFAULT_PARAMETERS
 
   updatePort(newPort: number) {
     this.port = newPort
@@ -296,6 +300,13 @@ export class LlamaCppBackendService implements ApiService {
     if (settings.version) {
       this.version = settings.version
       this.appLogger.info(`applied new LlamaCPP version ${this.version}`, this.name)
+    }
+    if (typeof settings.llamaCppParameters === 'string') {
+      this.llamaCppParametersString = settings.llamaCppParameters
+      this.appLogger.info(
+        `applied new LlamaCPP startup parameters: ${this.llamaCppParametersString}`,
+        this.name,
+      )
     }
   }
 
@@ -538,15 +549,9 @@ export class LlamaCppBackendService implements ApiService {
         modelPath,
         '--port',
         port.toString(),
-        '--gpu-layers',
-        '999',
         '--ctx-size',
         ctxSize.toString(),
-        '--log-prefix',
-        '--jinja',
-        '--no-mmap',
-        '-fa',
-        'off',
+        ...this.llamaCppParametersString.split(/\s+/).filter(Boolean),
       ]
 
       const modelFolder = path.dirname(modelPath)

--- a/WebUI/src/assets/js/store/backendServices.ts
+++ b/WebUI/src/assets/js/store/backendServices.ts
@@ -59,6 +59,20 @@ export const useBackendServices = defineStore(
       () => comfyUiParameters.value ?? comfyUiDefaultParameters.value,
     )
 
+    // LlamaCPP startup parameters (persisted). null = use default from backend.
+    const llamaCppParameters = ref<string | null>(null)
+
+    // Default parameters fetched from backend via IPC
+    const llamaCppDefaultParameters = ref<string>('')
+    window.electronAPI.getLlamaCppDefaultParameters().then((v) => {
+      llamaCppDefaultParameters.value = v
+    })
+
+    // Effective parameters: user override or default
+    const effectiveLlamaCppParameters = computed(
+      () => llamaCppParameters.value ?? llamaCppDefaultParameters.value,
+    )
+
     // Full version state (not persisted - computed from live data + overrides)
     const versionState = ref<BackendVersionState>({
       'ai-backend': {},
@@ -262,6 +276,9 @@ export const useBackendServices = defineStore(
       if (serviceName === 'comfyui-backend') {
         serviceSettings.comfyUiParameters = effectiveComfyUiParameters.value
       }
+      if (serviceName === 'llamacpp-backend') {
+        serviceSettings.llamaCppParameters = effectiveLlamaCppParameters.value
+      }
       await updateServiceSettings(serviceSettings)
       window.electronAPI.setUpService(serviceName)
       const result = await listener!.awaitFinalizationAndResetData()
@@ -306,6 +323,12 @@ export const useBackendServices = defineStore(
         await updateServiceSettings({
           serviceName: 'comfyui-backend',
           comfyUiParameters: effectiveComfyUiParameters.value,
+        })
+      }
+      if (serviceName === 'llamacpp-backend') {
+        await updateServiceSettings({
+          serviceName: 'llamacpp-backend',
+          llamaCppParameters: effectiveLlamaCppParameters.value,
         })
       }
       return window.electronAPI.startService(serviceName)
@@ -465,6 +488,9 @@ export const useBackendServices = defineStore(
       comfyUiParameters,
       comfyUiDefaultParameters,
       effectiveComfyUiParameters,
+      llamaCppParameters,
+      llamaCppDefaultParameters,
+      effectiveLlamaCppParameters,
       updateLastUsedBackend,
       resetLastUsedInferenceBackend,
       startAllSetUpServices,
@@ -488,7 +514,12 @@ export const useBackendServices = defineStore(
   },
   {
     persist: {
-      pick: ['versionOverrides', 'lastSelectedDeviceIdPerBackend', 'comfyUiParameters'],
+      pick: [
+        'versionOverrides',
+        'lastSelectedDeviceIdPerBackend',
+        'comfyUiParameters',
+        'llamaCppParameters',
+      ],
     },
   },
 )

--- a/WebUI/src/components/BackendOptions.vue
+++ b/WebUI/src/components/BackendOptions.vue
@@ -79,11 +79,12 @@ const getFormSchema = (backend: BackendServiceName) => {
       )
 
     case 'llamacpp-backend':
-      // LlamaCPP: build numbers like b6048
+      // LlamaCPP: build numbers like b6048, plus optional startup parameters
       return toTypedSchema(
         z
           .object({
             version: z.string().regex(/^b\d+$/, 'Must be a valid build number (e.g. b6048)'),
+            llamaCppParameters: z.string().optional(),
           })
           .passthrough(),
       )
@@ -184,6 +185,12 @@ const getInitialFormValues = () => {
     return {
       ...values,
       comfyUiParameters: backendServices.effectiveComfyUiParameters,
+    }
+  }
+  if (props.backend === 'llamacpp-backend') {
+    return {
+      ...values,
+      llamaCppParameters: backendServices.effectiveLlamaCppParameters,
     }
   }
   return values
@@ -334,7 +341,8 @@ const handleVersionAction = async () => {
 const hasUserOverride = computed(
   () =>
     !!backendServices.versionState[props.backend].uiOverride ||
-    (props.backend === 'comfyui-backend' && backendServices.comfyUiParameters !== null),
+    (props.backend === 'comfyui-backend' && backendServices.comfyUiParameters !== null) ||
+    (props.backend === 'llamacpp-backend' && backendServices.llamaCppParameters !== null),
 )
 
 // Clear the user override
@@ -342,6 +350,9 @@ const clearOverride = () => {
   backendServices.versionState[props.backend].uiOverride = undefined
   if (props.backend === 'comfyui-backend') {
     backendServices.comfyUiParameters = null
+  }
+  if (props.backend === 'llamacpp-backend') {
+    backendServices.llamaCppParameters = null
   }
   settingsDialogOpen.value = false
   menuOpen.value = false
@@ -469,6 +480,16 @@ const showMenuButton = computed(
                       !params || params === backendServices.comfyUiDefaultParameters ? null : params
                   }
 
+                  // Save llamaCppParameters separately (not part of version override)
+                  if (props.backend === 'llamacpp-backend' && 'llamaCppParameters' in values) {
+                    const params = (values as { llamaCppParameters?: string }).llamaCppParameters
+                    // Store null if empty or matches default (meaning 'use default')
+                    backendServices.llamaCppParameters =
+                      !params || params === backendServices.llamaCppDefaultParameters
+                        ? null
+                        : params
+                  }
+
                   settingsDialogOpen = false
                   menuOpen = false
                 })
@@ -553,6 +574,33 @@ const showMenuButton = computed(
                       {{
                         i18nState.BACKEND_COMFYUI_PARAMETERS_DESCRIPTION ||
                         'Command-line arguments passed to ComfyUI on startup. Restart required to apply changes.'
+                      }}
+                    </FormDescription>
+                    <FormMessage />
+                  </FormItem>
+                </FormField>
+
+                <!-- LlamaCPP startup parameters -->
+                <FormField
+                  v-if="backend === 'llamacpp-backend'"
+                  v-slot="{ componentField }"
+                  name="llamaCppParameters"
+                >
+                  <FormItem class="mt-4">
+                    <FormLabel>{{
+                      i18nState.BACKEND_LLAMACPP_PARAMETERS_LABEL || 'Startup Parameters'
+                    }}</FormLabel>
+                    <FormControl>
+                      <Input
+                        type="text"
+                        :placeholder="backendServices.llamaCppDefaultParameters"
+                        v-bind="componentField"
+                      />
+                    </FormControl>
+                    <FormDescription>
+                      {{
+                        i18nState.BACKEND_LLAMACPP_PARAMETERS_DESCRIPTION ||
+                        'Command-line arguments passed to llama-server on startup. Applied on next model load.'
                       }}
                     </FormDescription>
                     <FormMessage />

--- a/WebUI/src/env.d.ts
+++ b/WebUI/src/env.d.ts
@@ -18,6 +18,7 @@ type ServiceSettings = {
   version?: string
   releaseTag?: string
   comfyUiParameters?: string
+  llamaCppParameters?: string
 }
 
 type DemoModeSettings = {
@@ -107,6 +108,7 @@ type electronAPI = {
   ): void
   wakeupComfyUIService(): void
   getComfyUiDefaultParameters(): Promise<string>
+  getLlamaCppDefaultParameters(): Promise<string>
   getServices(): Promise<ApiServiceInformation[]>
   updateServiceSettings(settings: ServiceSettings): Promise<BackendStatus>
 


### PR DESCRIPTION
This introduces "Startup Parameters" for setting llama-cpp cli args, similar to what already existed for comfyui:

<img width="547" height="435" alt="image" src="https://github.com/user-attachments/assets/60578b4f-be10-4304-8347-cb1166f6ef48" />

Implementation is analog to ComfyUi parameters.

Manually verified it works:
- set `--gpu-layers 1` and filter in devTools for "offloaded": it shows `offloaded 1/25 layers to GPU`
- set `--gpu-layers 999` and verified output shows `offloaded 25/25 layers to GPU` (with smollm2-1.7b)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Customizable llama-cpp backend startup parameters available through a dedicated settings dialog interface
  * User-configured parameters automatically persist across all application sessions and system restarts
  * Reset button available to quickly restore backend-provided default parameters at any time
  * Backend default parameter values automatically retrieved and displayed as helpful reference information
  * Form validation ensures all parameter entries are properly validated before being applied to the service

<!-- end of auto-generated comment: release notes by coderabbit.ai -->