### PR TITLE
Feature/add global device recognition

### DIFF
--- a/OpenVINO/detect_devices.py
+++ b/OpenVINO/detect_devices.py
@@ -1,8 +1,135 @@
 #!/usr/bin/env python3
-"""Query OpenVINO devices and output as JSON."""
+"""Query OpenVINO devices and supplement with OS-level iGPU/Apple Silicon detection."""
 import json
+import platform
+import re
+import subprocess
 import sys
 
+
+# ---------------------------------------------------------------------------
+# OS-level GPU enumeration helpers
+# ---------------------------------------------------------------------------
+
+def _enumerate_gpus_windows() -> list[dict]:
+    """Return all display adapters reported by wmic on Windows."""
+    try:
+        result = subprocess.run(
+            ["wmic", "path", "win32_VideoController", "get", "DeviceID,Name", "/format:csv"],
+            capture_output=True, text=True, timeout=10,
+        )
+        gpus = []
+        for line in result.stdout.strip().splitlines()[1:]:
+            parts = line.split(",")
+            if len(parts) < 3:
+                continue
+            device_id = parts[1].strip()
+            name = ",".join(parts[2:]).strip()
+            if name:
+                gpus.append({"wmic_id": device_id, "name": name})
+        return gpus
+    except Exception:
+        return []
+
+
+def _enumerate_gpus_macos() -> list[dict]:
+    """Return all display adapters reported by system_profiler on macOS."""
+    try:
+        result = subprocess.run(
+            ["system_profiler", "SPDisplaysDataType", "-json"],
+            capture_output=True, text=True, timeout=15,
+        )
+        data = json.loads(result.stdout)
+        displays = data.get("SPDisplaysDataType", [])
+        gpus = []
+        for i, d in enumerate(displays):
+            name = d.get("sppci_model") or d.get("_name") or f"GPU {i}"
+            gpus.append({"wmic_id": f"GPU:{i}", "name": name})
+        return gpus
+    except Exception:
+        return []
+
+
+def _is_apple_silicon() -> bool:
+    """Return True when running on Apple Silicon (arm64 macOS)."""
+    return platform.system() == "Darwin" and platform.machine() == "arm64"
+
+
+# ---------------------------------------------------------------------------
+# Synthesise missing iGPU entries
+# ---------------------------------------------------------------------------
+
+def _synthesise_extra_devices(openvino_devices: list[dict]) -> list[dict]:
+    """
+    Return additional device entries that OpenVINO missed.
+
+    OpenVINO exposes a ``CPU`` device whose FULL_DEVICE_NAME embeds the
+    processor brand string.  On AMD APUs (e.g. Ryzen 8845HS w/ Radeon 780M)
+    the iGPU is visible via wmic / system_profiler but OpenVINO only lists it
+    as the CPU.  We synthesise a separate iGPU entry for it.
+
+    On Apple Silicon, OpenVINO has no GPU plugin for Metal, so we synthesise
+    an Apple Silicon entry from the CPU name when running on arm64 macOS.
+    """
+    existing_ids = {d["id"] for d in openvino_devices}
+    extra: list[dict] = []
+
+    # ---- Apple Silicon -------------------------------------------------
+    if _is_apple_silicon():
+        if "APPLE_SILICON" not in existing_ids:
+            # Grab the chip name from the CPU OV device if available
+            apple_name = "Apple Silicon"
+            for d in openvino_devices:
+                if d["id"] == "CPU":
+                    m = re.search(r"Apple\s+(M\d\S*)", d["name"], re.IGNORECASE)
+                    if m:
+                        apple_name = f"Apple {m.group(1)}"
+                    break
+            extra.append({"id": "APPLE_SILICON", "name": apple_name})
+        return extra  # nothing else to do on macOS
+
+    # ---- Windows / Linux iGPU synthesis --------------------------------
+    if platform.system() == "Windows":
+        os_gpus = _enumerate_gpus_windows()
+    else:
+        # Linux: OpenVINO usually exposes iGPUs directly; skip extra work.
+        return []
+
+    # Build the set of GPU names already known to OpenVINO (excluding CPU)
+    ov_gpu_names_lower = {
+        d["name"].lower()
+        for d in openvino_devices
+        if d["id"] != "CPU"
+    }
+
+    igpu_index = 0
+    for gpu in os_gpus:
+        name_lower = gpu["name"].lower()
+
+        # Skip if OpenVINO already reported this GPU (match by substring in either direction)
+        if any(name_lower in ov_name or ov_name in name_lower for ov_name in ov_gpu_names_lower):
+            continue
+
+        # Skip pure CPU entries (shouldn't appear in wmic VideoController, but guard anyway)
+        if re.search(r'\b(core i[3579]|ryzen|xeon|celeron|pentium|athlon)\b', name_lower) and \
+                "graphics" not in name_lower and "radeon" not in name_lower:
+            continue
+
+        # Assign a stable GPU.N id, avoiding collisions with existing OV device ids
+        synth_id = f"GPU.{igpu_index}"
+        while synth_id in existing_ids or synth_id in {e["id"] for e in extra}:
+            igpu_index += 1
+            synth_id = f"GPU.{igpu_index}"
+
+        extra.append({"id": synth_id, "name": gpu["name"]})
+        igpu_index += 1
+
+    return extra
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
 
 def main():
     try:
@@ -11,11 +138,17 @@ def main():
         core = ov.Core()
         devices = []
         for device_id in core.available_devices:
+            if device_id == "AUTO":
+                continue
             try:
                 full_name = core.get_property(device_id, "FULL_DEVICE_NAME")
             except Exception:
                 full_name = device_id
-            devices.append({"id": device_id, "name": full_name})
+            devices.append({"id": device_id, "name": full_name.strip()})
+
+        extra = _synthesise_extra_devices(devices)
+        devices.extend(extra)
+
         print(json.dumps({"success": True, "devices": devices}))
     except Exception as e:
         print(json.dumps({"success": False, "error": str(e)}))

--- a/WebUI/electron/electron-env.d.ts
+++ b/WebUI/electron/electron-env.d.ts
@@ -48,6 +48,7 @@ type SetupData = {
   modelLists: ModelLists
   isAdminExec: boolean
   version: string
+  detectNonIntelDevicesIfAnyIntelDeviceFound: boolean
 }
 
 type UpdateWorkflowsFromIntelResult = {

--- a/WebUI/electron/main.ts
+++ b/WebUI/electron/main.ts
@@ -52,6 +52,7 @@ import {
   ComfyUiBackendService,
   COMFYUI_DEFAULT_PARAMETERS,
 } from './subprocesses/comfyUIBackendService'
+import { LLAMACPP_DEFAULT_PARAMETERS } from './subprocesses/llamaCppBackendService'
 import { filterPartnerPresets, updateIntelPresets } from './subprocesses/updateIntelPresets.ts'
 import { getGitHubRepoUrl, resolveBackendVersion, resolveModels } from './remoteUpdates.ts'
 import * as comfyuiTools from './subprocesses/comfyuiTools'
@@ -704,6 +705,7 @@ function initEventHandle() {
   })
 
   ipcMain.handle('getComfyUiDefaultParameters', () => COMFYUI_DEFAULT_PARAMETERS)
+  ipcMain.handle('getLlamaCppDefaultParameters', () => LLAMACPP_DEFAULT_PARAMETERS)
 
   ipcMain.handle('detectDevices', (_event: IpcMainInvokeEvent, serviceName: string) => {
     if (!serviceRegistry) {

--- a/WebUI/electron/main.ts
+++ b/WebUI/electron/main.ts
@@ -641,6 +641,7 @@ function initEventHandle() {
       modelPaths: pathsManager.modelPaths,
       isAdminExec: settings.isAdminExec,
       version: app.getVersion(),
+      detectNonIntelDevicesIfAnyIntelDeviceFound: settings.detectNonIntelDevicesIfAnyIntelDeviceFound,
     }
   })
 
@@ -749,6 +750,13 @@ function initEventHandle() {
 
   ipcMain.handle('getComfyUiDefaultParameters', () => COMFYUI_DEFAULT_PARAMETERS)
   ipcMain.handle('getLlamaCppDefaultParameters', () => LLAMACPP_DEFAULT_PARAMETERS)
+
+  ipcMain.handle('getInstalledComfyUiVariant', () => {
+    const service = serviceRegistry?.getService('comfyui-backend')
+    if (!service) return null
+    const info = (service as ComfyUiBackendService).get_info()
+    return info.installedComfyUiVariant ?? null
+  })
 
   ipcMain.handle('getGlobalDetectionResult', () => lastGlobalDetectionResult)
 

--- a/WebUI/electron/main.ts
+++ b/WebUI/electron/main.ts
@@ -57,6 +57,11 @@ import { filterPartnerPresets, updateIntelPresets } from './subprocesses/updateI
 import { getGitHubRepoUrl, resolveBackendVersion, resolveModels } from './remoteUpdates.ts'
 import * as comfyuiTools from './subprocesses/comfyuiTools'
 import { externalResourcesDir, getMediaDir } from './util.ts'
+import {
+  detectAllAiDevices,
+  abortOpenVinoDetection,
+  type GlobalDetectionResult,
+} from './subprocesses/globalDeviceDetection.ts'
 import type { ModelPaths } from '@/assets/js/store/models.ts'
 import type { IndexedDocument, EmbedInquiry } from '@/assets/js/store/textInference.ts'
 import { BackendServiceName } from '@/assets/js/store/backendServices.ts'
@@ -84,6 +89,13 @@ const appLogger = appLoggerInstance
 
 let win: BrowserWindow | null
 let serviceRegistry: ApiServiceRegistryImpl | null = null
+let lastGlobalDetectionResult: GlobalDetectionResult | null = null
+let appIsQuitting = false
+
+app.on('before-quit', () => {
+  appIsQuitting = true
+  abortOpenVinoDetection()
+})
 const mediaDir = getMediaDir()
 fs.mkdirSync(mediaDir, { recursive: true })
 const mediaInputDir = path.join(mediaDir, 'input')
@@ -114,6 +126,7 @@ const LocalSettingsSchema = z.object({
   languageOverride: z.string().nullable().default(null),
   remoteRepository: z.string().default('intel/ai-playground'),
   huggingfaceEndpoint: z.string().default('https://huggingface.co'),
+  detectNonIntelDevicesIfAnyIntelDeviceFound: z.boolean().default(false),
 })
 export type LocalSettings = z.infer<typeof LocalSettingsSchema>
 
@@ -392,6 +405,36 @@ app.on('second-instance', (_event, _commandLine, _workingDirectory) => {
 
 async function initServiceRegistry(win: BrowserWindow, settings: LocalSettings) {
   serviceRegistry = await aiplaygroundApiServiceRegistry(win, settings)
+
+  // Run global device detection in the background — does not block startup.
+  // Runs on every start: first time after BEs are installed, and on every subsequent launch.
+  // Skip detection if OpenVINO is not yet installed (detection relies on its Python venv).
+  const openVinoService = serviceRegistry.getService('openvino-backend')
+  const openVinoIsInstalled = openVinoService?.isSetUp ?? false
+  if (!openVinoIsInstalled) {
+    appLogger.info(
+      'OpenVINO not yet installed — skipping global device detection',
+      'electron-backend',
+    )
+    return serviceRegistry
+  }
+  detectAllAiDevices(settings.detectNonIntelDevicesIfAnyIntelDeviceFound)
+    .then((result) => {
+      if (appIsQuitting) return
+      lastGlobalDetectionResult = result
+      appLogger.info(
+        `Global device detection complete, pushing result to frontend (${result.devices.length} device(s))`,
+        'electron-backend',
+      )
+      if (!win.isDestroyed()) {
+        win.webContents.send('globalDetectionResult', result)
+      }
+    })
+    .catch((err) => {
+      if (appIsQuitting) return
+      appLogger.error(`Global device detection failed: ${err}`, 'electron-backend')
+    })
+
   return serviceRegistry
 }
 
@@ -706,6 +749,8 @@ function initEventHandle() {
 
   ipcMain.handle('getComfyUiDefaultParameters', () => COMFYUI_DEFAULT_PARAMETERS)
   ipcMain.handle('getLlamaCppDefaultParameters', () => LLAMACPP_DEFAULT_PARAMETERS)
+
+  ipcMain.handle('getGlobalDetectionResult', () => lastGlobalDetectionResult)
 
   ipcMain.handle('detectDevices', (_event: IpcMainInvokeEvent, serviceName: string) => {
     if (!serviceRegistry) {

--- a/WebUI/electron/preload.ts
+++ b/WebUI/electron/preload.ts
@@ -99,6 +99,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
     ipcRenderer.on('debugLog', (_event, value) => callback(value)),
   wakeupComfyUIService: () => ipcRenderer.send('wakeupComfyUIService'),
   getComfyUiDefaultParameters: () => ipcRenderer.invoke('getComfyUiDefaultParameters'),
+  getLlamaCppDefaultParameters: () => ipcRenderer.invoke('getLlamaCppDefaultParameters'),
   onServiceSetUpProgress: (callback: (data: SetupProgress) => void) =>
     ipcRenderer.on('serviceSetUpProgress', (_event, value) => callback(value)),
   onServiceInfoUpdate: (callback: (service: ApiServiceInformation) => void) =>

--- a/WebUI/electron/preload.ts
+++ b/WebUI/electron/preload.ts
@@ -100,6 +100,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
   wakeupComfyUIService: () => ipcRenderer.send('wakeupComfyUIService'),
   getComfyUiDefaultParameters: () => ipcRenderer.invoke('getComfyUiDefaultParameters'),
   getLlamaCppDefaultParameters: () => ipcRenderer.invoke('getLlamaCppDefaultParameters'),
+  getInstalledComfyUiVariant: () => ipcRenderer.invoke('getInstalledComfyUiVariant') as Promise<'xpu' | 'cuda' | 'cpu' | null>,
   getGlobalDetectionResult: () => ipcRenderer.invoke('getGlobalDetectionResult'),
   onGlobalDetectionResult: (
     callback: (result: import('./subprocesses/globalDeviceDetection.ts').GlobalDetectionResult) => void,

--- a/WebUI/electron/preload.ts
+++ b/WebUI/electron/preload.ts
@@ -100,6 +100,10 @@ contextBridge.exposeInMainWorld('electronAPI', {
   wakeupComfyUIService: () => ipcRenderer.send('wakeupComfyUIService'),
   getComfyUiDefaultParameters: () => ipcRenderer.invoke('getComfyUiDefaultParameters'),
   getLlamaCppDefaultParameters: () => ipcRenderer.invoke('getLlamaCppDefaultParameters'),
+  getGlobalDetectionResult: () => ipcRenderer.invoke('getGlobalDetectionResult'),
+  onGlobalDetectionResult: (
+    callback: (result: import('./subprocesses/globalDeviceDetection.ts').GlobalDetectionResult) => void,
+  ) => ipcRenderer.on('globalDetectionResult', (_event, value) => callback(value)),
   onServiceSetUpProgress: (callback: (data: SetupProgress) => void) =>
     ipcRenderer.on('serviceSetUpProgress', (_event, value) => callback(value)),
   onServiceInfoUpdate: (callback: (service: ApiServiceInformation) => void) =>

--- a/WebUI/electron/subprocesses/comfyUIBackendService.ts
+++ b/WebUI/electron/subprocesses/comfyUIBackendService.ts
@@ -10,7 +10,7 @@ import {
   patchFile,
   createEnhancedErrorDetails,
 } from './service.ts'
-import { aipgBaseDir, checkBackendWithDetails, installBackend } from './uvBasedBackends/uv.ts'
+import { aipgBaseDir, checkBackendWithDetails, installBackendWithExtra } from './uvBasedBackends/uv.ts'
 import { ProcessError } from './osProcessHelper.ts'
 import { getMediaDir } from '../util.ts'
 import { levelZeroDeviceSelectorEnv } from './deviceDetection.ts'
@@ -19,7 +19,12 @@ import { LocalSettings } from '../main.ts'
 import { downloadCustomNode } from './comfyuiTools.ts'
 type Device = Omit<InferenceDevice, 'selected'>
 
+export type ComfyUiVariant = 'xpu' | 'cuda' | 'cpu'
+
 export const COMFYUI_DEFAULT_PARAMETERS = '--lowvram --reserve-vram 6.0'
+
+/** The single comfyui-deps directory that holds the shared pyproject.toml with xpu/cuda/cpu extras */
+const COMFYUI_DEPS_DIR = 'comfyui-deps'
 
 export class ComfyUiBackendService extends LongLivedPythonApiService {
   constructor(name: BackendServiceName, port: number, win: BrowserWindow, settings: LocalSettings) {
@@ -28,6 +33,15 @@ export class ComfyUiBackendService extends LongLivedPythonApiService {
     this.serviceIsSetUp().then(async (setUp) => {
       this.isSetUp = setUp
       if (this.isSetUp) {
+        // Restore the installed variant so getEnvVars() uses the correct torch backend
+        const installedVariant = this.readInstalledVariant()
+        if (installedVariant !== null) {
+          this.comfyUiVariant = installedVariant
+          this.appLogger.info(
+            `Restored comfyUI variant from marker file: ${installedVariant}`,
+            this.name,
+          )
+        }
         await this.updateCachedVersion()
         this.setStatus('notYetStarted')
       }
@@ -48,6 +62,45 @@ export class ComfyUiBackendService extends LongLivedPythonApiService {
   private environmentMismatchError: ErrorDetails | null = null
 
   private comfyUiParametersString: string = COMFYUI_DEFAULT_PARAMETERS
+  private comfyUiVariant: ComfyUiVariant = 'xpu'
+
+  /** Path of the small JSON file that records which variant is currently installed */
+  private readonly variantMarkerPath = path.join(this.serviceDir, 'aipg-variant.json')
+
+  private readInstalledVariant(): ComfyUiVariant | null {
+    try {
+      if (!filesystem.existsSync(this.variantMarkerPath)) return null
+      const raw = filesystem.readFileSync(this.variantMarkerPath, 'utf-8')
+      const parsed = JSON.parse(raw) as { variant?: string }
+      const v = parsed.variant
+      if (v === 'xpu' || v === 'cuda' || v === 'cpu') return v
+      return null
+    } catch {
+      return null
+    }
+  }
+
+  private writeVariantMarker(variant: ComfyUiVariant): void {
+    filesystem.writeFileSync(this.variantMarkerPath, JSON.stringify({ variant }), 'utf-8')
+  }
+
+  /** Override uninstall to also wipe the generated lockfile and variant marker so a fresh setup starts clean. */
+  async uninstall(): Promise<void> {
+    await super.uninstall()
+    // Remove the generated uv.lock (it will be regenerated on reinstall for the new variant)
+    // and the variant marker. Keep pyproject.toml so serviceIsSetUp can detect the git repo state.
+    for (const file of ['uv.lock', 'aipg-variant.json']) {
+      const filePath = path.join(this.serviceDir, file)
+      if (filesystem.existsSync(filePath)) {
+        try {
+          await filesystem.remove(filePath)
+          this.appLogger.info(`Removed ${file} from ComfyUI dir during uninstall`, this.name)
+        } catch (e) {
+          this.appLogger.warn(`Failed to remove ${file} during uninstall: ${e}`, this.name)
+        }
+      }
+    }
+  }
 
   async serviceIsSetUp(): Promise<boolean> {
     this.appLogger.info(`Checking if comfyUI directories exist`, this.name)
@@ -135,6 +188,25 @@ export class ComfyUiBackendService extends LongLivedPythonApiService {
         this.name,
       )
     }
+    if (settings.comfyUiVariant) {
+      const newVariant = settings.comfyUiVariant
+      const installedVariant = this.readInstalledVariant()
+      this.comfyUiVariant = newVariant
+      this.appLogger.info(`applied new comfyUI variant: ${this.comfyUiVariant}`, this.name)
+
+      // If the variant changed and ComfyUI is already installed, uninstall it so the
+      // user can reinstall with the correct dependencies for the new variant.
+      // A null installedVariant means no marker file exists (pre-tracking install) —
+      // treat it as a mismatch so the user always gets the right variant.
+      if (this.isSetUp && installedVariant !== newVariant) {
+        this.appLogger.info(
+          `ComfyUI variant changed from '${installedVariant ?? 'unknown'}' to '${newVariant}' — uninstalling to force reinstall`,
+          this.name,
+        )
+        await this.uninstall()
+        this.isSetUp = false
+      }
+    }
   }
 
   async getCurrentVersion(): Promise<string | undefined> {
@@ -176,6 +248,11 @@ export class ComfyUiBackendService extends LongLivedPythonApiService {
   get_info(): ApiServiceInformation {
     const baseInfo = super.get_info()
 
+    // Include the currently installed variant so the frontend can reflect it correctly
+    const installedComfyUiVariant: ComfyUiVariant | undefined = this.isSetUp
+      ? this.readInstalledVariant() ?? this.comfyUiVariant
+      : undefined
+
     // Always show environment mismatch error if it exists, even if there's a startup error
     // This guides users toward a potential fix (reinstallation)
     if (this.environmentMismatchError) {
@@ -206,22 +283,60 @@ export class ComfyUiBackendService extends LongLivedPythonApiService {
         return {
           ...baseInfo,
           errorDetails: mergedError,
+          installedComfyUiVariant,
         }
       } else {
         // Only environment mismatch error, no startup error
         return {
           ...baseInfo,
           errorDetails: this.environmentMismatchError,
+          installedComfyUiVariant,
         }
       }
     }
 
-    return baseInfo
+    return { ...baseInfo, installedComfyUiVariant }
   }
 
   async *set_up(): AsyncIterable<SetupProgress> {
     this.appLogger.info('setting up service', this.name)
     this.setStatus('installing')
+
+    // --- prerequisite check: ai-backend and openvino must be installed first ---
+    const aiBackendVenv = path.resolve(path.join(aipgBaseDir, 'service', '.venv'))
+    const openVinoVenv = path.resolve(path.join(aipgBaseDir, 'OpenVINO', '.venv'))
+    const aiBackendReady = filesystem.existsSync(aiBackendVenv)
+    const openVinoReady = filesystem.existsSync(openVinoVenv)
+
+    if (!aiBackendReady || !openVinoReady) {
+      const missing = [
+        !aiBackendReady ? 'AI Backend' : null,
+        !openVinoReady ? 'OpenVINO' : null,
+      ]
+        .filter(Boolean)
+        .join(' and ')
+      this.appLogger.warn(
+        `Cannot set up ComfyUI: ${missing} must be installed first`,
+        this.name,
+        true,
+      )
+      this.setStatus('installationFailed')
+      yield {
+        serviceName: this.name,
+        step: 'prerequisites',
+        status: 'failed',
+        debugMessage: `ComfyUI requires ${missing} to be installed first. Please install them before installing ComfyUI.`,
+        errorDetails: {
+          command: 'prerequisite check',
+          exitCode: 1,
+          stdout: `Required backends not installed: ${missing}`,
+          stderr: '',
+          timestamp: new Date().toISOString(),
+          duration: 0,
+        },
+      }
+      return
+    }
 
     const checkServiceDir = async (): Promise<boolean> => {
       if (!filesystem.existsSync(this.serviceDir)) {
@@ -258,53 +373,63 @@ export class ComfyUiBackendService extends LongLivedPythonApiService {
         await this.git.run(['-C', this.serviceDir, 'checkout', this.revision], {}, this.serviceDir)
       }
 
-      // Copy ComfyUI dependency files and install using bundled uv
-      const comfyUIDepsDir = path.join(aipgBaseDir, 'comfyui-deps')
+      // Copy the shared pyproject.toml (with xpu/cuda/cpu extras) from comfyui-deps
+      const comfyUIDepsDir = path.join(aipgBaseDir, COMFYUI_DEPS_DIR)
       const pyprojectSource = path.join(comfyUIDepsDir, 'pyproject.toml')
-      const uvLockSource = path.join(comfyUIDepsDir, 'uv.lock')
       const pyprojectTarget = path.join(this.serviceDir, 'pyproject.toml')
+      this.appLogger.info(
+        `Copying pyproject.toml from ${pyprojectSource} to ${pyprojectTarget}`,
+        this.name,
+      )
+      await filesystem.copyFile(pyprojectSource, pyprojectTarget)
+
+      // Remove any stale uv.lock so uv regenerates it for the chosen extra
       const uvLockTarget = path.join(this.serviceDir, 'uv.lock')
-
-      // Check if dependencies are already installed
-      let needsInstall = false
-      try {
-        await checkProject(this.serviceDir)
-        this.appLogger.info('ComfyUI dependencies already installed, skipping', this.name)
-      } catch (_checkError) {
-        needsInstall = true
+      if (filesystem.existsSync(uvLockTarget)) {
+        await filesystem.remove(uvLockTarget)
+        this.appLogger.info('Removed stale uv.lock so it will be regenerated', this.name)
       }
 
-      if (needsInstall) {
-        // Copy dependency specification files
-        this.appLogger.info(
-          `Copying pyproject.toml from ${pyprojectSource} to ${pyprojectTarget}`,
-          this.name,
-        )
-        await filesystem.copyFile(pyprojectSource, pyprojectTarget)
-
-        this.appLogger.info(`Copying uv.lock from ${uvLockSource} to ${uvLockTarget}`, this.name)
-        await filesystem.copyFile(uvLockSource, uvLockTarget)
-
-        // Install dependencies
-        this.appLogger.info('Installing ComfyUI dependencies using bundled uv', this.name)
-        await installBackend(this.serviceDir, () => {
-          this.win.webContents.send('show-toast', {
-            type: 'warning',
-            message:
-              'UV cache corruption detected. Retrying installation without cache. This may take longer. You can manually clear the cache at %LOCALAPPDATA%/uv/cache',
-          })
+      // Install dependencies for the selected variant via uv sync --extra <variant>
+      this.appLogger.info(
+        `Installing ComfyUI dependencies for variant '${this.comfyUiVariant}' using uv sync --extra`,
+        this.name,
+      )
+      await installBackendWithExtra(this.serviceDir, this.comfyUiVariant, () => {
+        this.win.webContents.send('show-toast', {
+          type: 'warning',
+          message:
+            'UV cache corruption detected. Retrying installation without cache. This may take longer. You can manually clear the cache at %LOCALAPPDATA%/uv/cache',
         })
-      }
+      })
     }
 
     const configureComfyUI = async (): Promise<void> => {
       try {
-        this.appLogger.info('patching hijacks into comfyUI model_management', this.name)
-        patchFile(
-          path.join(this.serviceDir, 'comfy/model_management.py'),
-          'from comfy.model_management import get_model',
-          ['from ipex_to_cuda import ipex_init', 'ipex_init()'],
-        )
+        // The ipex_to_cuda hijack is only needed for the XPU variant
+        if (this.comfyUiVariant === 'xpu') {
+          this.appLogger.info('patching hijacks into comfyUI model_management', this.name)
+          patchFile(
+            path.join(this.serviceDir, 'comfy/model_management.py'),
+            'from comfy.model_management import get_model',
+            ['from ipex_to_cuda import ipex_init', 'ipex_init()'],
+          )
+        } else {
+          this.appLogger.info(
+            `Removing ipex_to_cuda hijack from model_management for variant '${this.comfyUiVariant}'`,
+            this.name,
+          )
+          const modelMgmtPath = path.join(this.serviceDir, 'comfy/model_management.py')
+          if (filesystem.existsSync(modelMgmtPath)) {
+            let content = filesystem.readFileSync(modelMgmtPath, 'utf-8')
+            // Remove the ipex_to_cuda lines that may have been injected by a previous XPU install
+            content = content
+              .replace(/^from ipex_to_cuda import ipex_init\r?\n/m, '')
+              .replace(/^ipex_init\(\)\r?\n/m, '')
+            filesystem.writeFileSync(modelMgmtPath, content, 'utf-8')
+            this.appLogger.info('Removed ipex_to_cuda lines from model_management.py', this.name)
+          }
+        }
 
         this.appLogger.info('Configuring extra model paths for comfyUI', this.name)
         const extraModelPathsYaml = path.join(this.serviceDir, 'extra_model_paths.yaml')
@@ -514,6 +639,7 @@ export class ComfyUiBackendService extends LongLivedPythonApiService {
         debugMessage: 'dependencies configured',
       }
       this.isSetUp = true
+      this.writeVariantMarker(this.comfyUiVariant)
       await this.updateCachedVersion()
       this.setStatus('notYetStarted')
       currentStep = 'end'
@@ -540,17 +666,27 @@ export class ComfyUiBackendService extends LongLivedPythonApiService {
   }
 
   getEnvVars() {
+    const torchBackend =
+      process.platform === 'win32'
+        ? this.comfyUiVariant === 'cuda'
+          ? 'cuda'
+          : this.comfyUiVariant === 'cpu'
+            ? 'cpu'
+            : 'xpu'
+        : undefined
+    const isXpu = this.comfyUiVariant === 'xpu'
     return {
       PATH: `${path.join(this.pythonEnvDir, 'Library', 'bin')};${path.join(this.git.dir, 'cmd')};${process.env.PATH}`,
       PYTHONNOUSERSITE: 'true',
-      SYCL_ENABLE_DEFAULT_CONTEXTS: '1',
-      SYCL_CACHE_PERSISTENT: '1',
+      // Intel SYCL vars only needed for XPU variant
+      ...(isXpu ? { SYCL_ENABLE_DEFAULT_CONTEXTS: '1', SYCL_CACHE_PERSISTENT: '1' } : {}),
       PYTHONIOENCODING: 'utf-8',
       HF_ENDPOINT: this.settings.huggingfaceEndpoint,
-      ...levelZeroDeviceSelectorEnv(this.devices.find((d) => d.selected)?.id),
+      // ONEAPI_DEVICE_SELECTOR only relevant for XPU
+      ...(isXpu ? levelZeroDeviceSelectorEnv(this.devices.find((d) => d.selected)?.id) : {}),
       PIP_CONFIG_FILE: 'nul',
       UV_NO_CONFIG: '1',
-      UV_TORCH_BACKEND: process.platform === 'win32' ? 'xpu' : undefined,
+      UV_TORCH_BACKEND: torchBackend,
     }
   }
 
@@ -563,6 +699,18 @@ export class ComfyUiBackendService extends LongLivedPythonApiService {
   }
 
   async detectDevices() {
+    // For non-XPU variants the installed torch doesn't have XPU support,
+    // so skip the XPU detection script entirely.
+    if (this.comfyUiVariant !== 'xpu') {
+      this.appLogger.info(
+        `Skipping XPU device detection for variant '${this.comfyUiVariant}'`,
+        this.name,
+      )
+      this.devices = [{ id: '*', name: 'Auto select device', selected: true }]
+      this.updateStatus()
+      return
+    }
+
     // For now, use auto-select device similar to aiBackendService
     const availableDevices = [{ id: '*', name: 'Auto select device', selected: true }]
     let allDevices: Device[] = []
@@ -574,7 +722,7 @@ import sys
 try:
     # Try to get the number of XPU devices
     device_count = torch.xpu.device_count()
-    
+
     # For each device, get its name and print it
     for i in range(device_count):
         try:
@@ -641,8 +789,44 @@ except Exception as e:
     process: ChildProcess
     didProcessExitEarlyTracker: Promise<boolean>
   }> {
+    // For non-XPU variants, ensure the ipex_to_cuda patch is not present in
+    // model_management.py — it may have been left over from a previous XPU install.
+    if (this.comfyUiVariant !== 'xpu') {
+      const modelMgmtPath = path.join(this.serviceDir, 'comfy/model_management.py')
+      if (filesystem.existsSync(modelMgmtPath)) {
+        const original = filesystem.readFileSync(modelMgmtPath, 'utf-8')
+        const patched = original
+          .replace(/^from ipex_to_cuda import ipex_init\r?\n/m, '')
+          .replace(/^ipex_init\(\)\r?\n/m, '')
+        if (patched !== original) {
+          filesystem.writeFileSync(modelMgmtPath, patched, 'utf-8')
+          this.appLogger.info(
+            'Removed ipex_to_cuda lines from model_management.py before startup',
+            this.name,
+          )
+        }
+      }
+    }
+
     const additionalEnvVariables = this.getEnvVars()
     const mediaDir = getMediaDir()
+    const userParams = this.comfyUiParametersString.split(/\s+/).filter(Boolean)
+    // For the cpu variant, always pass --cpu so ComfyUI doesn't attempt CUDA/XPU
+    // even when the installed torch package is the XPU build (e.g. fallback deps).
+    // Remove VRAM flags that are incompatible with --cpu.
+    if (this.comfyUiVariant === 'cpu') {
+      const vramFlags = ['--lowvram', '--normalvram', '--highvram', '--novram', '--gpu-only']
+      for (const flag of vramFlags) {
+        const idx = userParams.indexOf(flag)
+        if (idx !== -1) {
+          userParams.splice(idx, 1)
+          this.appLogger.info(`Removed '${flag}' from parameters (incompatible with --cpu)`, this.name)
+        }
+      }
+      if (!userParams.includes('--cpu')) {
+        userParams.push('--cpu')
+      }
+    }
     const parameters = [
       'main.py',
       '--port',
@@ -651,7 +835,7 @@ except Exception as e:
       'auto',
       '--output-directory',
       mediaDir,
-      ...this.comfyUiParametersString.split(/\s+/).filter(Boolean),
+      ...userParams,
     ]
     this.appLogger.info(
       `starting comfyui with ${JSON.stringify({ parameters, additionalEnvVariables })}`,
@@ -685,6 +869,3 @@ except Exception as e:
   }
 }
 
-function checkProject(_serviceDir: string) {
-  throw new Error('Function not implemented.')
-}

--- a/WebUI/electron/subprocesses/globalDeviceDetection.ts
+++ b/WebUI/electron/subprocesses/globalDeviceDetection.ts
@@ -1,28 +1,24 @@
 /**
  * Global AI device detection.
  *
- * Always uses OpenVINO (via the OpenVINO Python environment) to detect Intel devices.
- * When `recogniseNonIntelDevices` is true (dev mode), additionally detects:
- *   - Apple Silicon (via platform + sysctl)
- *   - NVIDIA GPUs (via nvidia-smi)
- *   - Other discrete / integrated GPUs (generic fallback via platform APIs)
+ * Uses OpenVINO (via the OpenVINO Python environment) to detect all AI devices.
+ * OpenVINO is capable of detecting Intel, NVIDIA and AMD hardware.
+ * When `detectNonIntelDevices` is false and Intel devices are found, non-Intel
+ * devices are filtered out of the result.
  */
 
 import { spawn } from 'node:child_process'
-import { exec } from 'node:child_process'
-import { promisify } from 'node:util'
 import path from 'node:path'
 import { app } from 'electron'
 import * as filesystem from 'fs-extra'
 import { appLoggerInstance } from '../logging/logger.ts'
 import { aipgBaseDir } from './uvBasedBackends/uv.ts'
 
-const execAsync = promisify(exec)
 
 const LOG_SOURCE = 'globalDeviceDetection'
 
 /**
- * In development mode (`!app.isPackaged`) we also run non-Intel detection.
+ * In development mode (`!app.isPackaged`) we also show non-Intel devices.
  * Flip this constant to explicitly control the behaviour in dev.
  */
 export const recogniseNonIntelDevices: boolean = !app.isPackaged
@@ -173,14 +169,28 @@ async function detectIntelDevicesViaOpenVINO(): Promise<DetectedDevice[]> {
           return
         }
 
-        const devices: DetectedDevice[] = result.devices.map((d) => ({
-          id: d.id,
-          name: d.name,
-          kind: 'intel' as DetectedDeviceKind,
-        }))
+        // Filter out the AUTO pseudo-device — it is not a real hardware device
+        const rawDevices = result.devices.filter((d) => d.id !== 'AUTO')
+
+        const devices: DetectedDevice[] = rawDevices.map((d) => {
+          let kind: DetectedDeviceKind
+
+          if (d.id === 'APPLE_SILICON') {
+            kind = 'apple-silicon'
+          } else if (/nvidia/i.test(d.name)) {
+            kind = 'nvidia'
+          } else if (d.id === 'CPU' || /intel/i.test(d.name) || /npu/i.test(d.id)) {
+            kind = 'intel'
+          } else {
+            // GPU.N synthesised entries (AMD iGPU, other discrete GPUs)
+            kind = 'gpu'
+          }
+
+          return { id: d.id, name: d.name, kind }
+        })
 
         appLoggerInstance.info(
-          `OpenVINO detected ${devices.length} Intel device(s): ${devices.map((d) => d.id).join(', ')}`,
+          `OpenVINO detected ${devices.length} device(s): ${devices.map((d) => `${d.id} (${d.name})`).join(', ')}`,
           LOG_SOURCE,
         )
         resolve(devices)
@@ -206,211 +216,21 @@ async function detectIntelDevicesViaOpenVINO(): Promise<DetectedDevice[]> {
 }
 
 // ---------------------------------------------------------------------------
-// Apple Silicon detection
-// ---------------------------------------------------------------------------
-
-async function detectAppleSilicon(): Promise<DetectedDevice[]> {
-  if (process.platform !== 'darwin') {
-    return []
-  }
-
-  try {
-    // `sysctl hw.optional.arm64` returns 1 on Apple Silicon Macs
-    const { stdout } = await execAsync('sysctl -n hw.optional.arm64')
-    if (stdout.trim() === '1') {
-      // Get brand string for a nicer name
-      let brandString = 'Apple Silicon'
-      try {
-        const { stdout: brand } = await execAsync('sysctl -n machdep.cpu.brand_string')
-        brandString = brand.trim() || brandString
-      } catch {
-        // Ignore — brand string is cosmetic
-      }
-
-      appLoggerInstance.info(`Detected Apple Silicon: ${brandString}`, LOG_SOURCE)
-      return [
-        {
-          id: 'APPLE_SILICON',
-          name: brandString,
-          kind: 'apple-silicon',
-        },
-      ]
-    }
-  } catch {
-    // Not Apple Silicon or sysctl not available
-  }
-
-  return []
-}
-
-// ---------------------------------------------------------------------------
-// NVIDIA GPU detection
-// ---------------------------------------------------------------------------
-
-async function detectNvidiaGPUs(): Promise<DetectedDevice[]> {
-  try {
-    // nvidia-smi is available on Windows, Linux, and macOS with CUDA drivers
-    const { stdout } = await execAsync(
-      'nvidia-smi --query-gpu=index,name --format=csv,noheader,nounits',
-    )
-
-    const devices: DetectedDevice[] = stdout
-      .trim()
-      .split('\n')
-      .filter((line) => line.trim().length > 0)
-      .map((line) => {
-        const commaIndex = line.indexOf(',')
-        const index = line.slice(0, commaIndex).trim()
-        const name = line.slice(commaIndex + 1).trim()
-        return {
-          id: `NVIDIA:${index}`,
-          name,
-          kind: 'nvidia' as DetectedDeviceKind,
-        }
-      })
-
-    if (devices.length > 0) {
-      appLoggerInstance.info(
-        `Detected ${devices.length} NVIDIA GPU(s): ${devices.map((d) => d.name).join(', ')}`,
-        LOG_SOURCE,
-      )
-    }
-
-    return devices
-  } catch {
-    // nvidia-smi not available or no NVIDIA drivers installed
-    return []
-  }
-}
-
-// ---------------------------------------------------------------------------
-// Generic GPU detection (fallback for other discrete / integrated GPUs)
-// ---------------------------------------------------------------------------
-
-/**
- * Generic GPU detection via OS-provided tools.
- *
- * - Windows: `wmic path win32_VideoController get Name`
- * - Linux: `lspci` filtered for VGA / 3D / Display entries
- * - macOS: `system_profiler SPDisplaysDataType` for non-Apple-Silicon
- *
- * Returns devices that do NOT look like Intel or NVIDIA hardware
- * (those are already captured by the dedicated detectors above).
- */
-async function detectOtherGPUs(alreadyKnownIds: Set<string>): Promise<DetectedDevice[]> {
-  const rawGpus = await enumerateRawGPUs()
-
-  return rawGpus
-    .filter((gpu) => {
-      // Skip Intel devices — already covered by OpenVINO detection
-      if (/intel/i.test(gpu.name)) return false
-      // Skip NVIDIA devices — already covered by nvidia-smi
-      if (/nvidia/i.test(gpu.name)) return false
-      // Skip Apple Metal / built-in display controllers on ARM macOS
-      if (/apple m\d/i.test(gpu.name)) return false
-      // Skip if already known
-      if (alreadyKnownIds.has(gpu.id)) return false
-      return true
-    })
-    .map((gpu) => ({
-      id: gpu.id,
-      name: gpu.name,
-      kind: 'gpu' as DetectedDeviceKind,
-    }))
-}
-
-type RawGPU = { id: string; name: string }
-
-async function enumerateRawGPUs(): Promise<RawGPU[]> {
-  if (process.platform === 'win32') {
-    return enumerateRawGPUsWindows()
-  }
-  if (process.platform === 'linux') {
-    return enumerateRawGPUsLinux()
-  }
-  if (process.platform === 'darwin') {
-    return enumerateRawGPUsMacOS()
-  }
-  return []
-}
-
-async function enumerateRawGPUsWindows(): Promise<RawGPU[]> {
-  try {
-    const { stdout } = await execAsync(
-      'wmic path win32_VideoController get DeviceID,Name /format:csv',
-    )
-    return stdout
-      .trim()
-      .split('\n')
-      .slice(1) // skip CSV header
-      .filter((line) => line.trim().length > 0)
-      .map((line) => {
-        const parts = line.split(',')
-        // CSV format: Node,DeviceID,Name
-        const deviceId = (parts[1] ?? '').trim()
-        const name = parts.slice(2).join(',').trim()
-        return { id: deviceId || name, name }
-      })
-      .filter((g) => g.name.length > 0)
-  } catch {
-    return []
-  }
-}
-
-async function enumerateRawGPUsLinux(): Promise<RawGPU[]> {
-  try {
-    const { stdout } = await execAsync(
-      "lspci | grep -E '(VGA|3D|Display) compatible controller'",
-    )
-    return stdout
-      .trim()
-      .split('\n')
-      .filter((line) => line.trim().length > 0)
-      .map((line, idx) => {
-        // lspci format: <slot> <class>: <name>
-        const colonIdx = line.indexOf(':')
-        const name = colonIdx >= 0 ? line.slice(colonIdx + 1).trim() : line.trim()
-        const slot = line.slice(0, colonIdx >= 0 ? colonIdx : 8).trim()
-        return { id: slot || `GPU:${idx}`, name }
-      })
-  } catch {
-    return []
-  }
-}
-
-async function enumerateRawGPUsMacOS(): Promise<RawGPU[]> {
-  try {
-    const { stdout } = await execAsync('system_profiler SPDisplaysDataType -json')
-    const data = JSON.parse(stdout) as {
-      SPDisplaysDataType?: { sppci_model?: string; _name?: string }[]
-    }
-    const displays = data.SPDisplaysDataType ?? []
-    return displays
-      .map((d, idx) => ({
-        id: `GPU:${idx}`,
-        name: d.sppci_model ?? d._name ?? `GPU ${idx}`,
-      }))
-      .filter((g) => g.name.length > 0)
-  } catch {
-    return []
-  }
-}
-
-// ---------------------------------------------------------------------------
 // Main entry point
 // ---------------------------------------------------------------------------
 
 /**
- * Runs global AI-capable device detection.
+ * Runs global AI-capable device detection using OpenVINO.
  *
- * Always uses OpenVINO to detect Intel devices first, then decides whether to
- * scan for non-Intel devices (Apple Silicon, NVIDIA, other GPUs) according to:
+ * OpenVINO detects all AI-capable devices including Intel, NVIDIA, and AMD hardware.
+ * Non-Intel devices are filtered out when Intel devices are present and
+ * `detectNonIntelDevices` is false.
  *
- * | Intel found | `detectNonIntelDevices` | Non-Intel scan |
- * |-------------|------------------------|----------------|
- * | no          | any                    | ✅ always       |
- * | yes         | false (prod default)   | ❌ skipped      |
- * | yes         | true  (dev / opt-in)   | ✅ performed    |
+ * | Intel found | `detectNonIntelDevices` | Non-Intel included |
+ * |-------------|------------------------|--------------------|
+ * | no          | any                    | ✅ always           |
+ * | yes         | false (prod default)   | ❌ filtered out     |
+ * | yes         | true  (dev / opt-in)   | ✅ included         |
  *
  * @param detectNonIntelDevices - driven by `settings.detectNonIntelDevicesIfAnyIntelDeviceFound`;
  *   falls back to the module-level `recogniseNonIntelDevices` constant when not provided.
@@ -423,70 +243,44 @@ export async function detectAllAiDevices(
     LOG_SOURCE,
   )
 
-  const allDevices: DetectedDevice[] = []
+  let allDevices: DetectedDevice[] = []
 
-  // Step 1: Intel devices via OpenVINO (always)
   try {
-    const intelDevices = await detectIntelDevicesViaOpenVINO()
-    allDevices.push(...intelDevices)
+    allDevices = await detectIntelDevicesViaOpenVINO()
   } catch (err) {
-    appLoggerInstance.error(`Intel device detection failed: ${err}`, LOG_SOURCE)
+    appLoggerInstance.error(`Device detection via OpenVINO failed: ${err}`, LOG_SOURCE)
   }
 
   const intelDeviceFound = allDevices.some((d) => d.kind === 'intel')
 
-  // Step 2: Non-Intel devices.
-  // - No Intel found → always scan (machine may have no Intel GPU at all)
-  // - Intel found + detectNonIntelDevices false → skip (prod default)
-  // - Intel found + detectNonIntelDevices true → scan (dev / explicit opt-in)
-  const shouldScanNonIntel = !intelDeviceFound || detectNonIntelDevices
-
-  if (shouldScanNonIntel) {
-    appLoggerInstance.info(
-      intelDeviceFound
-        ? 'Intel device found and non-Intel detection enabled — scanning for additional devices'
-        : 'No Intel devices found — scanning for non-Intel devices regardless',
-      LOG_SOURCE,
-    )
-
-    // Apple Silicon
-    try {
-      const appleSilicon = await detectAppleSilicon()
-      allDevices.push(...appleSilicon)
-    } catch (err) {
-      appLoggerInstance.warn(`Apple Silicon detection failed: ${err}`, LOG_SOURCE)
+  // When Intel devices are present and non-Intel detection is disabled, filter
+  // out any non-Intel devices that OpenVINO may have reported (e.g. NVIDIA, AMD).
+  if (intelDeviceFound && !detectNonIntelDevices) {
+    const before = allDevices.length
+    allDevices = allDevices.filter((d) => d.kind === 'intel')
+    if (allDevices.length !== before) {
+      appLoggerInstance.info(
+        `Filtered out ${before - allDevices.length} non-Intel device(s) (detectNonIntelDevices=false)`,
+        LOG_SOURCE,
+      )
     }
-
-    // NVIDIA GPUs
-    try {
-      const nvidiaDevices = await detectNvidiaGPUs()
-      allDevices.push(...nvidiaDevices)
-    } catch (err) {
-      appLoggerInstance.warn(`NVIDIA GPU detection failed: ${err}`, LOG_SOURCE)
-    }
-
-    // Other GPUs (generic)
-    try {
-      const knownIds = new Set(allDevices.map((d) => d.id))
-      const otherGpus = await detectOtherGPUs(knownIds)
-      allDevices.push(...otherGpus)
-    } catch (err) {
-      appLoggerInstance.warn(`Generic GPU detection failed: ${err}`, LOG_SOURCE)
-    }
-  } else {
-    appLoggerInstance.info(
-      'Intel device found and non-Intel detection disabled — skipping non-Intel scan',
-      LOG_SOURCE,
-    )
   }
 
+  // Deduplicate by id
+  const seen = new Set<string>()
+  const deduplicated = allDevices.filter((d) => {
+    if (seen.has(d.id)) return false
+    seen.add(d.id)
+    return true
+  })
+
   const result: GlobalDetectionResult = {
-    devices: allDevices,
+    devices: deduplicated,
     detectedAt: new Date().toISOString(),
   }
 
   appLoggerInstance.info(
-    `Global device detection complete: ${allDevices.length} device(s) found`,
+    `Global device detection complete — ${deduplicated.length} device(s): ${deduplicated.map((d) => `${d.id} (${d.name})`).join(', ') || 'none'}`,
     LOG_SOURCE,
   )
 

--- a/WebUI/electron/subprocesses/globalDeviceDetection.ts
+++ b/WebUI/electron/subprocesses/globalDeviceDetection.ts
@@ -1,0 +1,495 @@
+/**
+ * Global AI device detection.
+ *
+ * Always uses OpenVINO (via the OpenVINO Python environment) to detect Intel devices.
+ * When `recogniseNonIntelDevices` is true (dev mode), additionally detects:
+ *   - Apple Silicon (via platform + sysctl)
+ *   - NVIDIA GPUs (via nvidia-smi)
+ *   - Other discrete / integrated GPUs (generic fallback via platform APIs)
+ */
+
+import { spawn } from 'node:child_process'
+import { exec } from 'node:child_process'
+import { promisify } from 'node:util'
+import path from 'node:path'
+import { app } from 'electron'
+import * as filesystem from 'fs-extra'
+import { appLoggerInstance } from '../logging/logger.ts'
+import { aipgBaseDir } from './uvBasedBackends/uv.ts'
+
+const execAsync = promisify(exec)
+
+const LOG_SOURCE = 'globalDeviceDetection'
+
+/**
+ * In development mode (`!app.isPackaged`) we also run non-Intel detection.
+ * Flip this constant to explicitly control the behaviour in dev.
+ */
+export const recogniseNonIntelDevices: boolean = !app.isPackaged
+
+
+// ---------------------------------------------------------------------------
+// Shared types
+// ---------------------------------------------------------------------------
+
+export type DetectedDeviceKind = 'intel' | 'nvidia' | 'apple-silicon' | 'gpu'
+
+export type DetectedDevice = {
+  /** Stable identifier used to reference this device (e.g. OpenVINO id or "NVIDIA:0") */
+  id: string
+  /** Human-readable display name */
+  name: string
+  /** Broad category of the device */
+  kind: DetectedDeviceKind
+}
+
+export type GlobalDetectionResult = {
+  /** All successfully detected devices */
+  devices: DetectedDevice[]
+  /** ISO timestamp of the detection run */
+  detectedAt: string
+}
+
+// ---------------------------------------------------------------------------
+// OpenVINO-based Intel device detection
+// ---------------------------------------------------------------------------
+
+// Deduplicate: only one OpenVINO detection ever runs per process lifetime.
+// Vite hot-reload causes multiple initServiceRegistry calls in the same
+// Electron process; without this the second call would race against the first
+// one still holding OpenVINO's shared library handles.
+let openVinoDetectionPromise: Promise<DetectedDevice[]> | null = null
+let openVinoChildProcess: ReturnType<typeof spawn> | null = null
+
+/**
+ * Called by main.ts on `before-quit` to kill the in-flight detection child
+ * process immediately, so it doesn't linger until the 8 s timeout fires
+ * while Electron is already tearing down.
+ */
+export function abortOpenVinoDetection(): void {
+  if (openVinoChildProcess) {
+    openVinoChildProcess.kill('SIGTERM')
+    openVinoChildProcess = null
+  }
+}
+
+/**
+ * Runs the OpenVINO `detect_devices.py` script via `uv run` inside the OpenVINO
+ * project to enumerate all devices visible to OpenVINO (CPU, GPU.*, NPU, etc.).
+ *
+ * Returns an empty array when OpenVINO is not yet installed or uv is unavailable.
+ */
+async function detectIntelDevicesViaOpenVINO(): Promise<DetectedDevice[]> {
+  if (openVinoDetectionPromise) {
+    appLoggerInstance.info(
+      'OpenVINO detection already in-flight or completed — reusing result',
+      LOG_SOURCE,
+    )
+    return openVinoDetectionPromise
+  }
+
+  const serviceDir = path.resolve(path.join(aipgBaseDir, 'OpenVINO'))
+  const detectScript = path.resolve(path.join(serviceDir, 'detect_devices.py'))
+  const venvDir = path.resolve(path.join(serviceDir, '.venv'))
+  // Invoke the venv Python directly — avoids any uv environment locks, which
+  // can cause the second Electron process (spawned by Vite hot-reload) to hang
+  // waiting for the lock held by the first process's OpenVINO runtime.
+  const pythonExe = path.join(
+    venvDir,
+    process.platform === 'win32' ? 'Scripts/python.exe' : 'bin/python',
+  )
+
+  if (!filesystem.existsSync(detectScript)) {
+    appLoggerInstance.info(
+      `detect_devices.py not found at ${detectScript} — skipping Intel device detection`,
+      LOG_SOURCE,
+    )
+    return []
+  }
+
+  if (!filesystem.existsSync(pythonExe)) {
+    appLoggerInstance.info(
+      `OpenVINO venv Python not found at ${pythonExe} — OpenVINO not yet installed, skipping Intel device detection`,
+      LOG_SOURCE,
+    )
+    return []
+  }
+
+  openVinoDetectionPromise = new Promise<DetectedDevice[]>((resolve) => {
+    const childProcess = spawn(pythonExe, [detectScript], {
+      cwd: serviceDir,
+      windowsHide: true,
+      env: {
+        ...process.env,
+        VIRTUAL_ENV: venvDir,
+        PATH: `${path.join(venvDir, 'Scripts')};${path.join(venvDir, 'bin')};${process.env.PATH}`,
+      },
+    })
+    openVinoChildProcess = childProcess
+
+    let stdout = ''
+    let stderr = ''
+
+    childProcess.stdout?.on('data', (data: Buffer) => {
+      stdout += data.toString()
+    })
+    childProcess.stderr?.on('data', (data: Buffer) => {
+      stderr += data.toString()
+    })
+
+    childProcess.on('error', (err: Error) => {
+      openVinoChildProcess = null
+      appLoggerInstance.error(
+        `OpenVINO device detection process error: ${err}`,
+        LOG_SOURCE,
+      )
+      resolve([])
+    })
+
+    childProcess.on('exit', (code: number | null) => {
+      openVinoChildProcess = null
+      if (code !== 0) {
+        appLoggerInstance.warn(
+          `OpenVINO detect_devices.py exited with code ${code}: ${stderr}`,
+          LOG_SOURCE,
+        )
+        resolve([])
+        return
+      }
+
+      try {
+        const result = JSON.parse(stdout.trim()) as {
+          success: boolean
+          devices?: { id: string; name: string }[]
+          error?: string
+        }
+
+        if (!result.success || !Array.isArray(result.devices)) {
+          appLoggerInstance.warn(
+            `OpenVINO detect_devices.py returned error: ${result.error}`,
+            LOG_SOURCE,
+          )
+          resolve([])
+          return
+        }
+
+        const devices: DetectedDevice[] = result.devices.map((d) => ({
+          id: d.id,
+          name: d.name,
+          kind: 'intel' as DetectedDeviceKind,
+        }))
+
+        appLoggerInstance.info(
+          `OpenVINO detected ${devices.length} Intel device(s): ${devices.map((d) => d.id).join(', ')}`,
+          LOG_SOURCE,
+        )
+        resolve(devices)
+      } catch (parseErr) {
+        appLoggerInstance.error(
+          `Failed to parse OpenVINO detect_devices.py output: ${stdout}`,
+          LOG_SOURCE,
+        )
+        resolve([])
+      }
+    })
+
+    // Timeout — OpenVINO init can be slow on first run, but if it exceeds this
+    // the venv is likely locked by another Electron process (e.g. Vite hot-reload).
+    setTimeout(() => {
+      childProcess.kill('SIGTERM')
+      appLoggerInstance.warn('OpenVINO device detection timed out after 8 s', LOG_SOURCE)
+      resolve([])
+    }, 8_000)
+  })
+
+  return openVinoDetectionPromise
+}
+
+// ---------------------------------------------------------------------------
+// Apple Silicon detection
+// ---------------------------------------------------------------------------
+
+async function detectAppleSilicon(): Promise<DetectedDevice[]> {
+  if (process.platform !== 'darwin') {
+    return []
+  }
+
+  try {
+    // `sysctl hw.optional.arm64` returns 1 on Apple Silicon Macs
+    const { stdout } = await execAsync('sysctl -n hw.optional.arm64')
+    if (stdout.trim() === '1') {
+      // Get brand string for a nicer name
+      let brandString = 'Apple Silicon'
+      try {
+        const { stdout: brand } = await execAsync('sysctl -n machdep.cpu.brand_string')
+        brandString = brand.trim() || brandString
+      } catch {
+        // Ignore — brand string is cosmetic
+      }
+
+      appLoggerInstance.info(`Detected Apple Silicon: ${brandString}`, LOG_SOURCE)
+      return [
+        {
+          id: 'APPLE_SILICON',
+          name: brandString,
+          kind: 'apple-silicon',
+        },
+      ]
+    }
+  } catch {
+    // Not Apple Silicon or sysctl not available
+  }
+
+  return []
+}
+
+// ---------------------------------------------------------------------------
+// NVIDIA GPU detection
+// ---------------------------------------------------------------------------
+
+async function detectNvidiaGPUs(): Promise<DetectedDevice[]> {
+  try {
+    // nvidia-smi is available on Windows, Linux, and macOS with CUDA drivers
+    const { stdout } = await execAsync(
+      'nvidia-smi --query-gpu=index,name --format=csv,noheader,nounits',
+    )
+
+    const devices: DetectedDevice[] = stdout
+      .trim()
+      .split('\n')
+      .filter((line) => line.trim().length > 0)
+      .map((line) => {
+        const commaIndex = line.indexOf(',')
+        const index = line.slice(0, commaIndex).trim()
+        const name = line.slice(commaIndex + 1).trim()
+        return {
+          id: `NVIDIA:${index}`,
+          name,
+          kind: 'nvidia' as DetectedDeviceKind,
+        }
+      })
+
+    if (devices.length > 0) {
+      appLoggerInstance.info(
+        `Detected ${devices.length} NVIDIA GPU(s): ${devices.map((d) => d.name).join(', ')}`,
+        LOG_SOURCE,
+      )
+    }
+
+    return devices
+  } catch {
+    // nvidia-smi not available or no NVIDIA drivers installed
+    return []
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Generic GPU detection (fallback for other discrete / integrated GPUs)
+// ---------------------------------------------------------------------------
+
+/**
+ * Generic GPU detection via OS-provided tools.
+ *
+ * - Windows: `wmic path win32_VideoController get Name`
+ * - Linux: `lspci` filtered for VGA / 3D / Display entries
+ * - macOS: `system_profiler SPDisplaysDataType` for non-Apple-Silicon
+ *
+ * Returns devices that do NOT look like Intel or NVIDIA hardware
+ * (those are already captured by the dedicated detectors above).
+ */
+async function detectOtherGPUs(alreadyKnownIds: Set<string>): Promise<DetectedDevice[]> {
+  const rawGpus = await enumerateRawGPUs()
+
+  return rawGpus
+    .filter((gpu) => {
+      // Skip Intel devices — already covered by OpenVINO detection
+      if (/intel/i.test(gpu.name)) return false
+      // Skip NVIDIA devices — already covered by nvidia-smi
+      if (/nvidia/i.test(gpu.name)) return false
+      // Skip Apple Metal / built-in display controllers on ARM macOS
+      if (/apple m\d/i.test(gpu.name)) return false
+      // Skip if already known
+      if (alreadyKnownIds.has(gpu.id)) return false
+      return true
+    })
+    .map((gpu) => ({
+      id: gpu.id,
+      name: gpu.name,
+      kind: 'gpu' as DetectedDeviceKind,
+    }))
+}
+
+type RawGPU = { id: string; name: string }
+
+async function enumerateRawGPUs(): Promise<RawGPU[]> {
+  if (process.platform === 'win32') {
+    return enumerateRawGPUsWindows()
+  }
+  if (process.platform === 'linux') {
+    return enumerateRawGPUsLinux()
+  }
+  if (process.platform === 'darwin') {
+    return enumerateRawGPUsMacOS()
+  }
+  return []
+}
+
+async function enumerateRawGPUsWindows(): Promise<RawGPU[]> {
+  try {
+    const { stdout } = await execAsync(
+      'wmic path win32_VideoController get DeviceID,Name /format:csv',
+    )
+    return stdout
+      .trim()
+      .split('\n')
+      .slice(1) // skip CSV header
+      .filter((line) => line.trim().length > 0)
+      .map((line) => {
+        const parts = line.split(',')
+        // CSV format: Node,DeviceID,Name
+        const deviceId = (parts[1] ?? '').trim()
+        const name = parts.slice(2).join(',').trim()
+        return { id: deviceId || name, name }
+      })
+      .filter((g) => g.name.length > 0)
+  } catch {
+    return []
+  }
+}
+
+async function enumerateRawGPUsLinux(): Promise<RawGPU[]> {
+  try {
+    const { stdout } = await execAsync(
+      "lspci | grep -E '(VGA|3D|Display) compatible controller'",
+    )
+    return stdout
+      .trim()
+      .split('\n')
+      .filter((line) => line.trim().length > 0)
+      .map((line, idx) => {
+        // lspci format: <slot> <class>: <name>
+        const colonIdx = line.indexOf(':')
+        const name = colonIdx >= 0 ? line.slice(colonIdx + 1).trim() : line.trim()
+        const slot = line.slice(0, colonIdx >= 0 ? colonIdx : 8).trim()
+        return { id: slot || `GPU:${idx}`, name }
+      })
+  } catch {
+    return []
+  }
+}
+
+async function enumerateRawGPUsMacOS(): Promise<RawGPU[]> {
+  try {
+    const { stdout } = await execAsync('system_profiler SPDisplaysDataType -json')
+    const data = JSON.parse(stdout) as {
+      SPDisplaysDataType?: { sppci_model?: string; _name?: string }[]
+    }
+    const displays = data.SPDisplaysDataType ?? []
+    return displays
+      .map((d, idx) => ({
+        id: `GPU:${idx}`,
+        name: d.sppci_model ?? d._name ?? `GPU ${idx}`,
+      }))
+      .filter((g) => g.name.length > 0)
+  } catch {
+    return []
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Main entry point
+// ---------------------------------------------------------------------------
+
+/**
+ * Runs global AI-capable device detection.
+ *
+ * Always uses OpenVINO to detect Intel devices first, then decides whether to
+ * scan for non-Intel devices (Apple Silicon, NVIDIA, other GPUs) according to:
+ *
+ * | Intel found | `detectNonIntelDevices` | Non-Intel scan |
+ * |-------------|------------------------|----------------|
+ * | no          | any                    | ✅ always       |
+ * | yes         | false (prod default)   | ❌ skipped      |
+ * | yes         | true  (dev / opt-in)   | ✅ performed    |
+ *
+ * @param detectNonIntelDevices - driven by `settings.detectNonIntelDevicesIfAnyIntelDeviceFound`;
+ *   falls back to the module-level `recogniseNonIntelDevices` constant when not provided.
+ */
+export async function detectAllAiDevices(
+  detectNonIntelDevices: boolean = recogniseNonIntelDevices,
+): Promise<GlobalDetectionResult> {
+  appLoggerInstance.info(
+    `Starting global device detection (detectNonIntelDevices=${detectNonIntelDevices})`,
+    LOG_SOURCE,
+  )
+
+  const allDevices: DetectedDevice[] = []
+
+  // Step 1: Intel devices via OpenVINO (always)
+  try {
+    const intelDevices = await detectIntelDevicesViaOpenVINO()
+    allDevices.push(...intelDevices)
+  } catch (err) {
+    appLoggerInstance.error(`Intel device detection failed: ${err}`, LOG_SOURCE)
+  }
+
+  const intelDeviceFound = allDevices.some((d) => d.kind === 'intel')
+
+  // Step 2: Non-Intel devices.
+  // - No Intel found → always scan (machine may have no Intel GPU at all)
+  // - Intel found + detectNonIntelDevices false → skip (prod default)
+  // - Intel found + detectNonIntelDevices true → scan (dev / explicit opt-in)
+  const shouldScanNonIntel = !intelDeviceFound || detectNonIntelDevices
+
+  if (shouldScanNonIntel) {
+    appLoggerInstance.info(
+      intelDeviceFound
+        ? 'Intel device found and non-Intel detection enabled — scanning for additional devices'
+        : 'No Intel devices found — scanning for non-Intel devices regardless',
+      LOG_SOURCE,
+    )
+
+    // Apple Silicon
+    try {
+      const appleSilicon = await detectAppleSilicon()
+      allDevices.push(...appleSilicon)
+    } catch (err) {
+      appLoggerInstance.warn(`Apple Silicon detection failed: ${err}`, LOG_SOURCE)
+    }
+
+    // NVIDIA GPUs
+    try {
+      const nvidiaDevices = await detectNvidiaGPUs()
+      allDevices.push(...nvidiaDevices)
+    } catch (err) {
+      appLoggerInstance.warn(`NVIDIA GPU detection failed: ${err}`, LOG_SOURCE)
+    }
+
+    // Other GPUs (generic)
+    try {
+      const knownIds = new Set(allDevices.map((d) => d.id))
+      const otherGpus = await detectOtherGPUs(knownIds)
+      allDevices.push(...otherGpus)
+    } catch (err) {
+      appLoggerInstance.warn(`Generic GPU detection failed: ${err}`, LOG_SOURCE)
+    }
+  } else {
+    appLoggerInstance.info(
+      'Intel device found and non-Intel detection disabled — skipping non-Intel scan',
+      LOG_SOURCE,
+    )
+  }
+
+  const result: GlobalDetectionResult = {
+    devices: allDevices,
+    detectedAt: new Date().toISOString(),
+  }
+
+  appLoggerInstance.info(
+    `Global device detection complete: ${allDevices.length} device(s) found`,
+    LOG_SOURCE,
+  )
+
+  return result
+}
+

--- a/WebUI/electron/subprocesses/llamaCppBackendService.ts
+++ b/WebUI/electron/subprocesses/llamaCppBackendService.ts
@@ -13,6 +13,8 @@ import { binary, extract } from './tools.ts'
 
 const execAsync = promisify(exec)
 
+export const LLAMACPP_DEFAULT_PARAMETERS = '--gpu-layers 999 --log-prefix --jinja --no-mmap -fa off'
+
 interface LlamaServerProcess {
   process: ChildProcess
   port: number
@@ -65,6 +67,8 @@ export class LlamaCppBackendService implements ApiService {
   readonly appLogger = appLoggerInstance
 
   private version = 'b7278'
+
+  private llamaCppParametersString: string = LLAMACPP_DEFAULT_PARAMETERS
 
   updatePort(newPort: number) {
     this.port = newPort
@@ -296,6 +300,13 @@ export class LlamaCppBackendService implements ApiService {
     if (settings.version) {
       this.version = settings.version
       this.appLogger.info(`applied new LlamaCPP version ${this.version}`, this.name)
+    }
+    if (typeof settings.llamaCppParameters === 'string') {
+      this.llamaCppParametersString = settings.llamaCppParameters
+      this.appLogger.info(
+        `applied new LlamaCPP startup parameters: ${this.llamaCppParametersString}`,
+        this.name,
+      )
     }
   }
 
@@ -538,15 +549,9 @@ export class LlamaCppBackendService implements ApiService {
         modelPath,
         '--port',
         port.toString(),
-        '--gpu-layers',
-        '999',
         '--ctx-size',
         ctxSize.toString(),
-        '--log-prefix',
-        '--jinja',
-        '--no-mmap',
-        '-fa',
-        'off',
+        ...this.llamaCppParametersString.split(/\s+/).filter(Boolean),
       ]
 
       const modelFolder = path.dirname(modelPath)

--- a/WebUI/electron/subprocesses/openVINOBackendService.ts
+++ b/WebUI/electron/subprocesses/openVINOBackendService.ts
@@ -171,14 +171,10 @@ export class OpenVINOBackendService implements ApiService {
   }
 
   async detectDevices() {
-    const defaultDevices: InferenceDevice[] = [
-      { id: 'AUTO', name: 'Auto select device', selected: true },
-    ]
-
     if (!this.isSetUp) {
-      this.appLogger.info('OpenVINO not set up, using default devices', this.name)
-      this.devices = defaultDevices
-      this.sttDevices = [...defaultDevices]
+      this.appLogger.info('OpenVINO not set up, skipping device detection', this.name)
+      this.devices = []
+      this.sttDevices = []
       this.updateStatus()
       return
     }
@@ -204,9 +200,8 @@ export class OpenVINOBackendService implements ApiService {
       this.applyDetectedDevices(ovmsDevices)
     } catch (error) {
       this.appLogger.error(`Failed to detect devices: ${error}`, this.name)
-      // Fallback to default device on error
-      this.devices = defaultDevices
-      this.sttDevices = [...defaultDevices]
+      this.devices = []
+      this.sttDevices = []
     }
     this.updateStatus()
   }
@@ -261,10 +256,6 @@ export class OpenVINOBackendService implements ApiService {
           try {
             const result = JSON.parse(stdout.trim())
             if (result.success && Array.isArray(result.devices)) {
-              this.appLogger.info(
-                `Python detected devices: ${JSON.stringify(result.devices)}`,
-                this.name,
-              )
               resolve(result.devices)
             } else {
               this.appLogger.warn(`Python script returned error: ${result.error}`, this.name)
@@ -338,8 +329,7 @@ export class OpenVINOBackendService implements ApiService {
             const devices = match[1]
               .split(',')
               .map((d) => d.trim())
-              .filter((d) => d.length > 0)
-            this.appLogger.info(`Detected OpenVINO devices: ${devices.join(', ')}`, this.name)
+              .filter((d) => d.length > 0 && d !== 'AUTO')
 
             // Kill the process since we have what we need
             childProcess.kill('SIGTERM')
@@ -399,23 +389,21 @@ export class OpenVINOBackendService implements ApiService {
    * Apply detected devices to the service state.
    */
   private applyDetectedDevices(devices: { id: string; name: string }[]): void {
-    const mappedDevices: InferenceDevice[] = devices.map((device) => ({
+    // Filter out the AUTO pseudo-device — it is not a real hardware device
+    const filteredDevices = devices.filter((d) => d.id !== 'AUTO')
+
+    const mappedDevices: InferenceDevice[] = filteredDevices.map((device) => ({
       id: device.id,
       name: device.name,
       selected: false,
     }))
-
-    // Create base device list with AUTO option
-    const baseDevices: InferenceDevice[] = [
-      { id: 'AUTO', name: 'Auto select device', selected: false },
-      ...mappedDevices,
-    ]
 
     // Helper function to select device by priority
     const selectByPriority = (
       deviceList: InferenceDevice[],
       priority: string[],
     ): InferenceDevice[] => {
+      if (deviceList.length === 0) return deviceList
       const result = deviceList.map((d) => ({ ...d, selected: false }))
       // Match by id prefix (e.g., 'GPU' matches 'GPU.0', 'GPU.1', etc.)
       const selectedDevice = priority
@@ -424,26 +412,22 @@ export class OpenVINOBackendService implements ApiService {
       if (selectedDevice) {
         selectedDevice.selected = true
       } else {
-        result[0].selected = true // Fallback to AUTO
+        result[0].selected = true // Fallback to first available device
       }
       return result
     }
 
-    // LLM devices: priority GPU > AUTO
-    this.devices = selectByPriority(baseDevices, ['GPU'])
+    // LLM devices: priority GPU > first available
+    this.devices = selectByPriority(mappedDevices, ['GPU'])
 
-    // STT devices: priority NPU > CPU > GPU > AUTO
+    // STT devices: priority NPU > CPU > GPU > first available
     this.sttDevices = selectByPriority(
-      baseDevices.map((d) => ({ ...d })),
+      mappedDevices.map((d) => ({ ...d })),
       ['NPU', 'CPU', 'GPU'],
     )
 
     this.appLogger.info(
-      `Available LLM devices: ${JSON.stringify(this.devices, null, 2)}`,
-      this.name,
-    )
-    this.appLogger.info(
-      `Available STT devices: ${JSON.stringify(this.sttDevices, null, 2)}`,
+      `Detected devices — LLM: [${this.devices.map((d) => `${d.id}${d.selected ? '*' : ''}`).join(', ')}] STT: [${this.sttDevices.map((d) => `${d.id}${d.selected ? '*' : ''}`).join(', ')}]`,
       this.name,
     )
   }

--- a/WebUI/electron/subprocesses/openVINOBackendService.ts
+++ b/WebUI/electron/subprocesses/openVINOBackendService.ts
@@ -26,7 +26,7 @@ export class OpenVINOBackendService implements ApiService {
   readonly name = 'openvino-backend' as BackendServiceName
   readonly baseUrl: string
   readonly port: number
-  readonly isRequired: boolean = false
+  readonly isRequired: boolean = true
   readonly win: BrowserWindow
   readonly settings: LocalSettings
 

--- a/WebUI/electron/subprocesses/uvBasedBackends/uv.ts
+++ b/WebUI/electron/subprocesses/uvBasedBackends/uv.ts
@@ -164,6 +164,53 @@ export const installBackend = async (backend: string, onCacheCorruptionDetected?
   }
 }
 
+/**
+ * Install a backend using uv sync with a specific extra (e.g. 'xpu', 'cuda', 'cpu').
+ * Used by ComfyUI which keeps a single pyproject.toml with optional dependency groups.
+ */
+export const installBackendWithExtra = async (
+  backend: string,
+  extra: string,
+  onCacheCorruptionDetected?: () => void,
+) => {
+  const logger = loggerFor(`uv.sync.${path.basename(backend)}`)
+  await assertUv(logger)
+  const uvVenvCommand = [
+    'venv',
+    '--directory',
+    aipgBaseDir,
+    '--project',
+    backend,
+    '--allow-existing',
+    '--relocatable',
+  ]
+  const uvSyncCommand = [
+    'sync',
+    '--directory',
+    aipgBaseDir,
+    '--project',
+    backend,
+    '--extra',
+    extra,
+  ]
+  logger.info(
+    `Installing backend: ${backend} with extra '${extra}' — ${JSON.stringify(uvSyncCommand)}`,
+  )
+  try {
+    await uv(uvVenvCommand, logger)
+    return await uv(uvSyncCommand, logger)
+  } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : String(error)
+    if (isHashMismatchError(errorMessage)) {
+      logger.warn('Hash mismatch detected in UV cache, retrying with --no-cache')
+      onCacheCorruptionDetected?.()
+      await uv(uvVenvCommand, logger)
+      return await uv([...uvSyncCommand, '--no-cache'], logger)
+    }
+    throw error
+  }
+}
+
 export const checkBackend = async (backend: string) => {
   const logger = loggerFor(`uv.check.${backend}`)
   await assertUv(logger)

--- a/WebUI/external/settings-dev.json
+++ b/WebUI/external/settings-dev.json
@@ -6,5 +6,6 @@
   "isDemoModeEnabled": false,
   "demoModeResetInSeconds": null,
   "languageOverride": null,
-  "remoteRepository": "tng/ai-playground"
+  "remoteRepository": "tng/ai-playground",
+  "detectNonIntelDevicesIfAnyIntelDeviceFound": true
 }

--- a/WebUI/package-lock.json
+++ b/WebUI/package-lock.json
@@ -21,7 +21,7 @@
         "@tailwindcss/vite": "^4.2.1",
         "@vee-validate/zod": "^4.15.1",
         "@vueuse/core": "^14.2.1",
-        "ai": "^6.0.116",
+        "ai": "6.0.111",
         "autoprefixer": "^10.4.27",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
@@ -83,14 +83,31 @@
       }
     },
     "node_modules/@ai-sdk/gateway": {
-      "version": "3.0.66",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/gateway/-/gateway-3.0.66.tgz",
-      "integrity": "sha512-SIQ0YY0iMuv+07HLsZ+bB990zUJ6S4ujORAh+Jv1V2KGNn73qQKnGO0JBk+w+Res8YqOFSycwDoWcFlQrVxS4A==",
+      "version": "3.0.63",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/gateway/-/gateway-3.0.63.tgz",
+      "integrity": "sha512-0jwdkN3elC4Q9aT2ALxjXtGGVoye15zYgof6GfvuH1a9QKx9Rj4Wi2vy6SyyLvtSA/lB786dTZgC+cGwe6vzmA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@ai-sdk/provider": "3.0.8",
-        "@ai-sdk/provider-utils": "4.0.19",
+        "@ai-sdk/provider-utils": "4.0.17",
         "@vercel/oidc": "3.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/@ai-sdk/gateway/node_modules/@ai-sdk/provider-utils": {
+      "version": "4.0.17",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-4.0.17.tgz",
+      "integrity": "sha512-oyCeFINTYK0B8ZGUBiQc05G5vytPlKSmTTtm19xfJuUgoi8zkvvRcoPQci4mSnyfpPn2XSFFDfsALG8uGcapfg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "3.0.8",
+        "@standard-schema/spec": "^1.1.0",
+        "eventsource-parser": "^3.0.6"
       },
       "engines": {
         "node": ">=18"
@@ -175,6 +192,41 @@
       },
       "peerDependencies": {
         "vue": "^3.3.4"
+      }
+    },
+    "node_modules/@ai-sdk/vue/node_modules/@ai-sdk/gateway": {
+      "version": "3.0.66",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/gateway/-/gateway-3.0.66.tgz",
+      "integrity": "sha512-SIQ0YY0iMuv+07HLsZ+bB990zUJ6S4ujORAh+Jv1V2KGNn73qQKnGO0JBk+w+Res8YqOFSycwDoWcFlQrVxS4A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "3.0.8",
+        "@ai-sdk/provider-utils": "4.0.19",
+        "@vercel/oidc": "3.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/@ai-sdk/vue/node_modules/ai": {
+      "version": "6.0.116",
+      "resolved": "https://registry.npmjs.org/ai/-/ai-6.0.116.tgz",
+      "integrity": "sha512-7yM+cTmyRLeNIXwt4Vj+mrrJgVQ9RMIW5WO0ydoLoYkewIvsMcvUmqS4j2RJTUXaF1HphwmSKUMQ/HypNRGOmA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/gateway": "3.0.66",
+        "@ai-sdk/provider": "3.0.8",
+        "@ai-sdk/provider-utils": "4.0.19",
+        "@opentelemetry/api": "1.9.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
       }
     },
     "node_modules/@anthropic-ai/sdk": {
@@ -4569,15 +4621,32 @@
       }
     },
     "node_modules/ai": {
-      "version": "6.0.116",
-      "resolved": "https://registry.npmjs.org/ai/-/ai-6.0.116.tgz",
-      "integrity": "sha512-7yM+cTmyRLeNIXwt4Vj+mrrJgVQ9RMIW5WO0ydoLoYkewIvsMcvUmqS4j2RJTUXaF1HphwmSKUMQ/HypNRGOmA==",
+      "version": "6.0.111",
+      "resolved": "https://registry.npmjs.org/ai/-/ai-6.0.111.tgz",
+      "integrity": "sha512-K5aikNm4JGfJkzwIr3yA/qhOYIOIvOqjCxSQjQQ7bWWqm0uuPO2/qgdXL23gYJdTLPPYfvi2TTS+bg2Yp+r2Lw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@ai-sdk/gateway": "3.0.66",
+        "@ai-sdk/gateway": "3.0.63",
         "@ai-sdk/provider": "3.0.8",
-        "@ai-sdk/provider-utils": "4.0.19",
+        "@ai-sdk/provider-utils": "4.0.17",
         "@opentelemetry/api": "1.9.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/ai/node_modules/@ai-sdk/provider-utils": {
+      "version": "4.0.17",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-4.0.17.tgz",
+      "integrity": "sha512-oyCeFINTYK0B8ZGUBiQc05G5vytPlKSmTTtm19xfJuUgoi8zkvvRcoPQci4mSnyfpPn2XSFFDfsALG8uGcapfg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "3.0.8",
+        "@standard-schema/spec": "^1.1.0",
+        "eventsource-parser": "^3.0.6"
       },
       "engines": {
         "node": ">=18"

--- a/WebUI/package.json
+++ b/WebUI/package.json
@@ -31,7 +31,7 @@
     "@tailwindcss/vite": "^4.2.1",
     "@vee-validate/zod": "^4.15.1",
     "@vueuse/core": "^14.2.1",
-    "ai": "^6.0.116",
+    "ai": "6.0.111",
     "autoprefixer": "^10.4.27",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",

--- a/WebUI/src/assets/js/store/backendServices.ts
+++ b/WebUI/src/assets/js/store/backendServices.ts
@@ -59,6 +59,20 @@ export const useBackendServices = defineStore(
       () => comfyUiParameters.value ?? comfyUiDefaultParameters.value,
     )
 
+    // LlamaCPP startup parameters (persisted). null = use default from backend.
+    const llamaCppParameters = ref<string | null>(null)
+
+    // Default parameters fetched from backend via IPC
+    const llamaCppDefaultParameters = ref<string>('')
+    window.electronAPI.getLlamaCppDefaultParameters().then((v) => {
+      llamaCppDefaultParameters.value = v
+    })
+
+    // Effective parameters: user override or default
+    const effectiveLlamaCppParameters = computed(
+      () => llamaCppParameters.value ?? llamaCppDefaultParameters.value,
+    )
+
     // Full version state (not persisted - computed from live data + overrides)
     const versionState = ref<BackendVersionState>({
       'ai-backend': {},
@@ -262,6 +276,9 @@ export const useBackendServices = defineStore(
       if (serviceName === 'comfyui-backend') {
         serviceSettings.comfyUiParameters = effectiveComfyUiParameters.value
       }
+      if (serviceName === 'llamacpp-backend') {
+        serviceSettings.llamaCppParameters = effectiveLlamaCppParameters.value
+      }
       await updateServiceSettings(serviceSettings)
       window.electronAPI.setUpService(serviceName)
       const result = await listener!.awaitFinalizationAndResetData()
@@ -306,6 +323,12 @@ export const useBackendServices = defineStore(
         await updateServiceSettings({
           serviceName: 'comfyui-backend',
           comfyUiParameters: effectiveComfyUiParameters.value,
+        })
+      }
+      if (serviceName === 'llamacpp-backend') {
+        await updateServiceSettings({
+          serviceName: 'llamacpp-backend',
+          llamaCppParameters: effectiveLlamaCppParameters.value,
         })
       }
       return window.electronAPI.startService(serviceName)
@@ -465,6 +488,9 @@ export const useBackendServices = defineStore(
       comfyUiParameters,
       comfyUiDefaultParameters,
       effectiveComfyUiParameters,
+      llamaCppParameters,
+      llamaCppDefaultParameters,
+      effectiveLlamaCppParameters,
       updateLastUsedBackend,
       resetLastUsedInferenceBackend,
       startAllSetUpServices,
@@ -488,7 +514,12 @@ export const useBackendServices = defineStore(
   },
   {
     persist: {
-      pick: ['versionOverrides', 'lastSelectedDeviceIdPerBackend', 'comfyUiParameters'],
+      pick: [
+        'versionOverrides',
+        'lastSelectedDeviceIdPerBackend',
+        'comfyUiParameters',
+        'llamaCppParameters',
+      ],
     },
   },
 )

--- a/WebUI/src/assets/js/store/backendServices.ts
+++ b/WebUI/src/assets/js/store/backendServices.ts
@@ -2,6 +2,9 @@ import { defineStore } from 'pinia'
 import { ref, computed, watch } from 'vue'
 import z from 'zod'
 
+// ComfyUiVariant is declared globally in env.d.ts
+type ComfyUiVariant = 'xpu' | 'cuda' | 'cpu'
+
 const backends = [
   'openvino-backend',
   'ai-backend',
@@ -47,6 +50,33 @@ export const useBackendServices = defineStore(
 
     // ComfyUI startup parameters (persisted). null = use default from backend.
     const comfyUiParameters = ref<string | null>(null)
+
+    // ComfyUI variant (persisted). null = auto-select based on detected hardware.
+    const comfyUiVariant = ref<ComfyUiVariant | null>(null)
+
+    // Tracks the variant actually installed on disk, read from service info on startup.
+    // Not persisted — refreshed every time service info is received.
+    const installedComfyUiVariant = ref<ComfyUiVariant | null>(null)
+
+    // Compute the effective variant based on detected hardware (if no explicit choice)
+    async function getEffectiveComfyUiVariant(): Promise<ComfyUiVariant> {
+      if (comfyUiVariant.value !== null) return comfyUiVariant.value
+      try {
+        const result = await window.electronAPI.getGlobalDetectionResult()
+        if (!result) return 'xpu'
+        // Only OpenVINO GPU.* devices with an Intel name indicate an Intel GPU.
+        // OpenVINO also exposes NVIDIA/AMD hardware under GPU.* IDs, so filter by name.
+        const hasIntelGpu = result.devices.some(
+          (d) => d.kind === 'intel' && d.id.startsWith('GPU') && !/nvidia|amd/i.test(d.name),
+        )
+        if (hasIntelGpu) return 'xpu'
+        const hasNvidia = result.devices.some((d) => d.kind === 'nvidia')
+        if (hasNvidia) return 'cuda'
+        return 'cpu'
+      } catch {
+        return 'xpu'
+      }
+    }
 
     // Default parameters fetched from backend via IPC
     const comfyUiDefaultParameters = ref<string>('')
@@ -129,6 +159,10 @@ export const useBackendServices = defineStore(
           if (service.installedVersion) {
             versionState.value[serviceName].installed = service.installedVersion
           }
+          // Track which ComfyUI variant is installed on disk
+          if (serviceName === 'comfyui-backend' && service.installedComfyUiVariant) {
+            installedComfyUiVariant.value = service.installedComfyUiVariant
+          }
         }
       })
     setTimeout(() => {
@@ -140,6 +174,10 @@ export const useBackendServices = defineStore(
           const serviceName = service.serviceName as BackendServiceName
           if (service.installedVersion) {
             versionState.value[serviceName].installed = service.installedVersion
+          }
+          // Track which ComfyUI variant is installed on disk
+          if (serviceName === 'comfyui-backend' && service.installedComfyUiVariant) {
+            installedComfyUiVariant.value = service.installedComfyUiVariant
           }
         }
       })
@@ -155,6 +193,14 @@ export const useBackendServices = defineStore(
       } else if (!updatedInfo.isSetUp) {
         // Clear installed version if service is not set up
         versionState.value[serviceName].installed = undefined
+      }
+      // Track which ComfyUI variant is installed on disk
+      if (serviceName === 'comfyui-backend') {
+        if (updatedInfo.installedComfyUiVariant) {
+          installedComfyUiVariant.value = updatedInfo.installedComfyUiVariant
+        } else if (!updatedInfo.isSetUp) {
+          installedComfyUiVariant.value = null
+        }
       }
     })
 
@@ -275,6 +321,7 @@ export const useBackendServices = defineStore(
       const serviceSettings: ServiceSettings = { serviceName, ...targetVersionSettings }
       if (serviceName === 'comfyui-backend') {
         serviceSettings.comfyUiParameters = effectiveComfyUiParameters.value
+        serviceSettings.comfyUiVariant = await getEffectiveComfyUiVariant()
       }
       if (serviceName === 'llamacpp-backend') {
         serviceSettings.llamaCppParameters = effectiveLlamaCppParameters.value
@@ -285,6 +332,11 @@ export const useBackendServices = defineStore(
       if (result.success) {
         await detectDevices(serviceName)
         // Installed version is now automatically updated via serviceInfoUpdate
+        // For comfyui-backend, persist the variant that was actually installed so the
+        // dropdown reflects the correct value after a restart.
+        if (serviceName === 'comfyui-backend') {
+          comfyUiVariant.value = serviceSettings.comfyUiVariant ?? null
+        }
       }
       return result
     }
@@ -486,8 +538,11 @@ export const useBackendServices = defineStore(
       versionOverrides,
       lastSelectedDeviceIdPerBackend,
       comfyUiParameters,
+      comfyUiVariant,
+      installedComfyUiVariant,
       comfyUiDefaultParameters,
       effectiveComfyUiParameters,
+      getEffectiveComfyUiVariant,
       llamaCppParameters,
       llamaCppDefaultParameters,
       effectiveLlamaCppParameters,
@@ -518,6 +573,7 @@ export const useBackendServices = defineStore(
         'versionOverrides',
         'lastSelectedDeviceIdPerBackend',
         'comfyUiParameters',
+        'comfyUiVariant',
         'llamaCppParameters',
       ],
     },

--- a/WebUI/src/assets/js/store/detectedDevices.ts
+++ b/WebUI/src/assets/js/store/detectedDevices.ts
@@ -1,0 +1,49 @@
+import { defineStore, acceptHMRUpdate } from 'pinia'
+import { ref } from 'vue'
+
+export type DetectedDeviceKind = 'intel' | 'nvidia' | 'apple-silicon' | 'gpu'
+
+export type DetectedDevice = {
+  id: string
+  name: string
+  kind: DetectedDeviceKind
+}
+
+export type GlobalDetectionResult = {
+  devices: DetectedDevice[]
+  detectedAt: string
+}
+
+export const useDetectedDevices = defineStore(
+  'detectedDevices',
+  () => {
+    const detectionResult = ref<GlobalDetectionResult | null>(null)
+
+    function setDetectionResult(result: GlobalDetectionResult) {
+      detectionResult.value = result
+    }
+
+    // Fetch whatever the main process already has (e.g. from a previous run
+    // before the frontend was ready to receive the push event).
+    window.electronAPI.getGlobalDetectionResult().then((result) => {
+      if (result) {
+        detectionResult.value = result
+      }
+    })
+
+    // Subscribe to live detection results pushed by the main process.
+    window.electronAPI.onGlobalDetectionResult((result) => {
+      detectionResult.value = result
+    })
+
+    return {
+      detectionResult,
+      setDetectionResult,
+    }
+  },
+  { persist: true },
+)
+
+if (import.meta.hot) {
+  import.meta.hot.accept(acceptHMRUpdate(useDetectedDevices, import.meta.hot))
+}

--- a/WebUI/src/assets/js/store/presets.ts
+++ b/WebUI/src/assets/js/store/presets.ts
@@ -153,7 +153,7 @@ const LlmBackendEnum = z.enum(['llamaCPP', 'openVINO', 'ollama'])
 const ChatPresetSchema = BasePresetFieldsSchema.omit({ backend: true }).extend({
   type: z.literal('chat'),
   backends: z.array(LlmBackendEnum).min(1), // Array of allowed backends
-  preferredModels: z.partialRecord(LlmBackendEnum, z.string()).optional(), // Per-backend default models
+  preferredModels: z.record(LlmBackendEnum, z.string()).optional(), // Per-backend default models
   systemPrompt: z.string().optional(),
   contextSize: z.number().optional(),
   maxNewTokens: z.number().optional(),

--- a/WebUI/src/components/BackendOptions.vue
+++ b/WebUI/src/components/BackendOptions.vue
@@ -79,11 +79,12 @@ const getFormSchema = (backend: BackendServiceName) => {
       )
 
     case 'llamacpp-backend':
-      // LlamaCPP: build numbers like b6048
+      // LlamaCPP: build numbers like b6048, plus optional startup parameters
       return toTypedSchema(
         z
           .object({
             version: z.string().regex(/^b\d+$/, 'Must be a valid build number (e.g. b6048)'),
+            llamaCppParameters: z.string().optional(),
           })
           .passthrough(),
       )
@@ -184,6 +185,12 @@ const getInitialFormValues = () => {
     return {
       ...values,
       comfyUiParameters: backendServices.effectiveComfyUiParameters,
+    }
+  }
+  if (props.backend === 'llamacpp-backend') {
+    return {
+      ...values,
+      llamaCppParameters: backendServices.effectiveLlamaCppParameters,
     }
   }
   return values
@@ -334,7 +341,8 @@ const handleVersionAction = async () => {
 const hasUserOverride = computed(
   () =>
     !!backendServices.versionState[props.backend].uiOverride ||
-    (props.backend === 'comfyui-backend' && backendServices.comfyUiParameters !== null),
+    (props.backend === 'comfyui-backend' && backendServices.comfyUiParameters !== null) ||
+    (props.backend === 'llamacpp-backend' && backendServices.llamaCppParameters !== null),
 )
 
 // Clear the user override
@@ -342,6 +350,9 @@ const clearOverride = () => {
   backendServices.versionState[props.backend].uiOverride = undefined
   if (props.backend === 'comfyui-backend') {
     backendServices.comfyUiParameters = null
+  }
+  if (props.backend === 'llamacpp-backend') {
+    backendServices.llamaCppParameters = null
   }
   settingsDialogOpen.value = false
   menuOpen.value = false
@@ -469,6 +480,16 @@ const showMenuButton = computed(
                       !params || params === backendServices.comfyUiDefaultParameters ? null : params
                   }
 
+                  // Save llamaCppParameters separately (not part of version override)
+                  if (props.backend === 'llamacpp-backend' && 'llamaCppParameters' in values) {
+                    const params = (values as { llamaCppParameters?: string }).llamaCppParameters
+                    // Store null if empty or matches default (meaning 'use default')
+                    backendServices.llamaCppParameters =
+                      !params || params === backendServices.llamaCppDefaultParameters
+                        ? null
+                        : params
+                  }
+
                   settingsDialogOpen = false
                   menuOpen = false
                 })
@@ -553,6 +574,33 @@ const showMenuButton = computed(
                       {{
                         i18nState.BACKEND_COMFYUI_PARAMETERS_DESCRIPTION ||
                         'Command-line arguments passed to ComfyUI on startup. Restart required to apply changes.'
+                      }}
+                    </FormDescription>
+                    <FormMessage />
+                  </FormItem>
+                </FormField>
+
+                <!-- LlamaCPP startup parameters -->
+                <FormField
+                  v-if="backend === 'llamacpp-backend'"
+                  v-slot="{ componentField }"
+                  name="llamaCppParameters"
+                >
+                  <FormItem class="mt-4">
+                    <FormLabel>{{
+                      i18nState.BACKEND_LLAMACPP_PARAMETERS_LABEL || 'Startup Parameters'
+                    }}</FormLabel>
+                    <FormControl>
+                      <Input
+                        type="text"
+                        :placeholder="backendServices.llamaCppDefaultParameters"
+                        v-bind="componentField"
+                      />
+                    </FormControl>
+                    <FormDescription>
+                      {{
+                        i18nState.BACKEND_LLAMACPP_PARAMETERS_DESCRIPTION ||
+                        'Command-line arguments passed to llama-server on startup. Applied on next model load.'
                       }}
                     </FormDescription>
                     <FormMessage />

--- a/WebUI/src/components/BackendOptions.vue
+++ b/WebUI/src/components/BackendOptions.vue
@@ -59,6 +59,70 @@ const backendStatus = computed(
 const menuOpen = ref(false)
 const settingsDialogOpen = ref(false)
 
+// ---- ComfyUI variant selection ----
+const detectNonIntelFlag = ref(false)
+const globalDetectionResult = ref<GlobalDetectionResult | null>(null)
+
+window.electronAPI.getInitSetting().then((data) => {
+  detectNonIntelFlag.value = data.detectNonIntelDevicesIfAnyIntelDeviceFound
+})
+window.electronAPI.getGlobalDetectionResult().then((result) => {
+  globalDetectionResult.value = result
+})
+window.electronAPI.onGlobalDetectionResult((result) => {
+  globalDetectionResult.value = result
+})
+
+const hasIntelDevice = computed(() =>
+  (globalDetectionResult.value?.devices ?? []).some(
+    (d) =>
+      d.kind === 'intel' &&
+      d.id.startsWith('GPU') &&
+      !/nvidia|amd/i.test(d.name),
+  ),
+)
+const hasNvidiaDevice = computed(() =>
+  (globalDetectionResult.value?.devices ?? []).some((d) => d.kind === 'nvidia'),
+)
+
+/** Auto-select variant: intel GPU → xpu, nvidia → cuda, else → cpu */
+const computedDefaultVariant = computed((): ComfyUiVariant => {
+  if (hasIntelDevice.value) return 'xpu'
+  if (hasNvidiaDevice.value) return 'cuda'
+  return 'cpu'
+})
+
+// Standalone variant state — populated from disk when the dialog opens, not from the form.
+// This avoids any stale-initial-values issue with vee-validate.
+const selectedVariant = ref<ComfyUiVariant>('xpu')
+
+watch(settingsDialogOpen, async (open) => {
+  if (open && props.backend === 'comfyui-backend') {
+    const installed = await window.electronAPI.getInstalledComfyUiVariant()
+    selectedVariant.value = installed ?? computedDefaultVariant.value
+  }
+})
+
+/** Show variant dropdown when detectNonIntelDevicesIfAnyIntelDeviceFound is true
+ *  AND there is at least one Intel GPU or NVIDIA device */
+const showVariantSelector = computed(
+  () =>
+    props.backend === 'comfyui-backend' &&
+    detectNonIntelFlag.value &&
+    (hasIntelDevice.value || hasNvidiaDevice.value),
+)
+
+/** Available variant options — only show options for which hardware exists */
+const variantOptions = computed<{ value: ComfyUiVariant; label: string }[]>(() => {
+  const opts: { value: ComfyUiVariant; label: string }[] = []
+  if (hasIntelDevice.value) opts.push({ value: 'xpu', label: 'Intel XPU' })
+  if (hasNvidiaDevice.value) opts.push({ value: 'cuda', label: 'NVIDIA CUDA' })
+  opts.push({ value: 'cpu', label: 'CPU only' })
+  return opts
+})
+
+type ComfyUiVariant = 'xpu' | 'cuda' | 'cpu'
+
 // Backend-specific validation schemas
 const getFormSchema = (backend: BackendServiceName) => {
   switch (backend) {
@@ -74,6 +138,7 @@ const getFormSchema = (backend: BackendServiceName) => {
                 z.string().regex(/^v\d+\.\d+\.\d+$/, 'Must be a valid version tag (e.g. v1.0.0)'),
               ),
             comfyUiParameters: z.string().optional(),
+            comfyUiVariant: z.enum(['xpu', 'cuda', 'cpu']).optional(),
           })
           .passthrough(),
       )
@@ -173,8 +238,9 @@ const getVersionDescription = (backend: BackendServiceName) => {
   }
 }
 
-// Get initial form values based on backend type
-const getInitialFormValues = () => {
+// Get initial form values based on backend type — reactive computed so the form
+// always reflects the latest persisted values when the dialog is (re-)opened.
+const initialFormValues = computed(() => {
   const backendVersionState = backendServices.versionState[props.backend]
   const values: Record<string, unknown> =
     backendVersionState.uiOverride ??
@@ -194,9 +260,45 @@ const getInitialFormValues = () => {
     }
   }
   return values
-}
+})
 
-// Handler for starting a service with enhanced error handling
+// Handler called when the settings form is submitted
+const handleSettingsSave = async (values: Record<string, unknown>) => {
+  console.log('Form submitted with values:', values)
+  const override = BackendVersionSchema.parse(values)
+  backendServices.versionState[props.backend].uiOverride = override
+
+  // Save comfyUiParameters separately (not part of version override)
+  if (props.backend === 'comfyui-backend' && 'comfyUiParameters' in values) {
+    const params = (values as { comfyUiParameters?: string }).comfyUiParameters
+    backendServices.comfyUiParameters =
+      !params || params === backendServices.comfyUiDefaultParameters ? null : params
+  }
+
+  // Save the variant from the standalone ref (not from form values).
+  // If it differs from what is currently installed, uninstall and reinstall.
+  if (props.backend === 'comfyui-backend') {
+    const installedVariant = await window.electronAPI.getInstalledComfyUiVariant()
+    const chosenVariant = selectedVariant.value
+    backendServices.comfyUiVariant = chosenVariant
+    if (chosenVariant !== installedVariant) {
+      settingsDialogOpen.value = false
+      menuOpen.value = false
+      await handleReinstall()
+      return
+    }
+  }
+
+  // Save llamaCppParameters separately (not part of version override)
+  if (props.backend === 'llamacpp-backend' && 'llamaCppParameters' in values) {
+    const params = (values as { llamaCppParameters?: string }).llamaCppParameters
+    backendServices.llamaCppParameters =
+      !params || params === backendServices.llamaCppDefaultParameters ? null : params
+  }
+
+  settingsDialogOpen.value = false
+  menuOpen.value = false
+}
 const handleStartService = async () => {
   try {
     const status = await backendServices.startService(props.backend)
@@ -342,14 +444,16 @@ const hasUserOverride = computed(
   () =>
     !!backendServices.versionState[props.backend].uiOverride ||
     (props.backend === 'comfyui-backend' && backendServices.comfyUiParameters !== null) ||
+    (props.backend === 'comfyui-backend' && backendServices.comfyUiVariant !== null) ||
     (props.backend === 'llamacpp-backend' && backendServices.llamaCppParameters !== null),
 )
 
 // Clear the user override
-const clearOverride = () => {
+const clearOverride = async () => {
   backendServices.versionState[props.backend].uiOverride = undefined
   if (props.backend === 'comfyui-backend') {
     backendServices.comfyUiParameters = null
+    backendServices.comfyUiVariant = null
   }
   if (props.backend === 'llamacpp-backend') {
     backendServices.llamaCppParameters = null
@@ -428,8 +532,7 @@ const showMenuButton = computed(
         v-if="showSettings"
         v-slot="{ handleSubmit }"
         as=""
-        :initial-values="getInitialFormValues()"
-        keep-values
+        :initial-values="initialFormValues"
         :validation-schema="formSchema"
       >
         <Dialog
@@ -465,35 +568,7 @@ const showMenuButton = computed(
 
             <form
               id="dialogForm"
-              @submit="
-                handleSubmit($event, (values) => {
-                  console.log('Form submitted with values:', values)
-                  const override = BackendVersionSchema.parse(values)
-
-                  backendServices.versionState[props.backend].uiOverride = override
-
-                  // Save comfyUiParameters separately (not part of version override)
-                  if (props.backend === 'comfyui-backend' && 'comfyUiParameters' in values) {
-                    const params = (values as { comfyUiParameters?: string }).comfyUiParameters
-                    // Store null if empty or matches default (meaning 'use default')
-                    backendServices.comfyUiParameters =
-                      !params || params === backendServices.comfyUiDefaultParameters ? null : params
-                  }
-
-                  // Save llamaCppParameters separately (not part of version override)
-                  if (props.backend === 'llamacpp-backend' && 'llamaCppParameters' in values) {
-                    const params = (values as { llamaCppParameters?: string }).llamaCppParameters
-                    // Store null if empty or matches default (meaning 'use default')
-                    backendServices.llamaCppParameters =
-                      !params || params === backendServices.llamaCppDefaultParameters
-                        ? null
-                        : params
-                  }
-
-                  settingsDialogOpen = false
-                  menuOpen = false
-                })
-              "
+              @submit="handleSubmit($event, handleSettingsSave)"
             >
               <!-- Ollama backend has two fields -->
               <template v-if="backend === 'ollama-backend'">
@@ -579,6 +654,26 @@ const showMenuButton = computed(
                     <FormMessage />
                   </FormItem>
                 </FormField>
+
+                <!-- ComfyUI variant selector (only when non-Intel detection is enabled and relevant hardware found) -->
+                <div v-if="showVariantSelector" class="mt-4">
+                  <label class="text-sm font-medium">Installation Variant</label>
+                  <select
+                    v-model="selectedVariant"
+                    class="mt-1 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2"
+                  >
+                    <option
+                      v-for="opt in variantOptions"
+                      :key="opt.value"
+                      :value="opt.value"
+                    >
+                      {{ opt.label }}
+                    </option>
+                  </select>
+                  <p class="text-sm text-muted-foreground mt-1">
+                    Choose which GPU backend to install ComfyUI for. Requires reinstall to take effect.
+                  </p>
+                </div>
 
                 <!-- LlamaCPP startup parameters -->
                 <FormField

--- a/WebUI/src/env.d.ts
+++ b/WebUI/src/env.d.ts
@@ -18,6 +18,7 @@ type ServiceSettings = {
   version?: string
   releaseTag?: string
   comfyUiParameters?: string
+  llamaCppParameters?: string
 }
 
 type DemoModeSettings = {
@@ -107,6 +108,7 @@ type electronAPI = {
   ): void
   wakeupComfyUIService(): void
   getComfyUiDefaultParameters(): Promise<string>
+  getLlamaCppDefaultParameters(): Promise<string>
   getServices(): Promise<ApiServiceInformation[]>
   updateServiceSettings(settings: ServiceSettings): Promise<BackendStatus>
 

--- a/WebUI/src/env.d.ts
+++ b/WebUI/src/env.d.ts
@@ -13,12 +13,15 @@ interface ImportMeta {
   readonly env: ImportMetaEnv
 }
 
+type ComfyUiVariant = 'xpu' | 'cuda' | 'cpu'
+
 type ServiceSettings = {
   serviceName: BackendServiceName
   version?: string
   releaseTag?: string
   comfyUiParameters?: string
   llamaCppParameters?: string
+  comfyUiVariant?: ComfyUiVariant
 }
 
 type DemoModeSettings = {
@@ -122,6 +125,7 @@ type electronAPI = {
   wakeupComfyUIService(): void
   getComfyUiDefaultParameters(): Promise<string>
   getLlamaCppDefaultParameters(): Promise<string>
+  getInstalledComfyUiVariant(): Promise<ComfyUiVariant | null>
   getGlobalDetectionResult(): Promise<GlobalDetectionResult | null>
   onGlobalDetectionResult(callback: (result: GlobalDetectionResult) => void): void
   getServices(): Promise<ApiServiceInformation[]>
@@ -474,6 +478,8 @@ type ApiServiceInformation = {
   sttDevices?: InferenceDevice[]
   errorDetails: ErrorDetails | null
   installedVersion?: { version: string; releaseTag?: string }
+  /** Only populated for comfyui-backend — the variant that is currently installed */
+  installedComfyUiVariant?: ComfyUiVariant
 }
 
 type Model = {

--- a/WebUI/src/env.d.ts
+++ b/WebUI/src/env.d.ts
@@ -31,6 +31,19 @@ type AipgPage = 'create' | 'enhance' | 'answer' | 'learn-more'
 type WorkflowModeType = 'imageGen' | 'imageEdit' | 'video'
 type ModeType = 'chat' | WorkflowModeType
 
+type DetectedDeviceKind = 'intel' | 'nvidia' | 'apple-silicon' | 'gpu'
+
+type DetectedDevice = {
+  id: string
+  name: string
+  kind: DetectedDeviceKind
+}
+
+type GlobalDetectionResult = {
+  devices: DetectedDevice[]
+  detectedAt: string
+}
+
 type electronAPI = {
   startDrag: (fileName: string) => void
   getFilePath: (file: File) => string
@@ -109,6 +122,8 @@ type electronAPI = {
   wakeupComfyUIService(): void
   getComfyUiDefaultParameters(): Promise<string>
   getLlamaCppDefaultParameters(): Promise<string>
+  getGlobalDetectionResult(): Promise<GlobalDetectionResult | null>
+  onGlobalDetectionResult(callback: (result: GlobalDetectionResult) => void): void
   getServices(): Promise<ApiServiceInformation[]>
   updateServiceSettings(settings: ServiceSettings): Promise<BackendStatus>
 

--- a/comfyui-deps/pyproject.toml
+++ b/comfyui-deps/pyproject.toml
@@ -5,7 +5,7 @@ requires-python = "==3.12.*"
 dependencies = [
   "addict",
   "aiohttp>=3.11.8",
-  "albumentations",
+  "albumentations>=1.4.16",
   "alembic",
   "av>=14.2.0",
   "chardet",
@@ -33,20 +33,19 @@ dependencies = [
   "mediapipe>=0.10.32",
   "mss>=10.1.0",
   "ninja~=1.11.1.4",
-  "numpy>=1.25.0",
+  "numpy==1.26.3",
   "numba>=0.63.1",
   "omegaconf",
   "onnx>=1.14.0",
   "onnxruntime",
   "opencv-python>=4.7.0.72",
-  "Pillow>=12.1.1",
+  "Pillow>=10.3.0",
   "protobuf>=6.33.5",
   "psutil",
   "pydantic-settings~=2.0",
   "pydantic~=2.0",
   "pygithub",
   "python-dateutil",
-  "triton-xpu>=3.6.0; sys_platform == 'win32'",
   "pyyaml",
   "rich",
   "safetensors>=0.4.2",
@@ -63,10 +62,7 @@ dependencies = [
   "timm>=0.9.2",
   "tokenizers>=0.13.3",
   "toml",
-  "torch>=2.10.0",
-  "torchaudio",
   "torchsde",
-  "torchvision",
   "tqdm",
   "transformers[timm]>=4.50.3",
   "trimesh[easy]",
@@ -79,6 +75,24 @@ dependencies = [
   "yarl>=1.18.0",
 ]
 
+[project.optional-dependencies]
+xpu = [
+  "torch>=2.10.0",
+  "torchaudio",
+  "torchvision",
+  "triton-xpu>=3.6.0; sys_platform != 'darwin'",
+]
+cpu = [
+  "torch>=2.10.0",
+  "torchaudio",
+  "torchvision",
+]
+cuda = [
+  "torch>=2.10.0",
+  "torchaudio",
+  "torchvision",
+]
+
 [tool.uv]
 python-preference = "only-managed"
 link-mode = "clone"
@@ -86,28 +100,35 @@ index-strategy = "unsafe-best-match"
 required-environments = ["sys_platform == 'win32'", "sys_platform == 'darwin'"]
 prerelease = "if-necessary-or-explicit"
 environments = ["sys_platform == 'win32'", "sys_platform == 'darwin'"]
+conflicts = [
+    [
+      { extra = "xpu" },
+      { extra = "cpu" },
+      { extra = "cuda" },
+    ],
+]
 
 [tool.uv.pip]
 torch-backend = "xpu"
 
 [tool.uv.sources]
 torch = [
-  { index = "pytorch-xpu", marker = "sys_platform == 'win32'" },
-  { index = "pytorch-cpu", marker = "sys_platform == 'darwin'" },
+  { index = "pytorch-xpu", extra = "xpu", marker = "sys_platform != 'darwin'" },
+  { index = "pytorch-cuda", extra = "cuda", marker = "sys_platform != 'darwin'" },
+  { index = "pytorch-cpu", extra = "cpu" },
 ]
 torchaudio = [
-  { index = "pytorch-xpu", marker = "sys_platform == 'win32'" },
-  { index = "pytorch-cpu", marker = "sys_platform == 'darwin'" },
+  { index = "pytorch-xpu", extra = "xpu", marker = "sys_platform != 'darwin'" },
+  { index = "pytorch-cuda", extra = "cuda", marker = "sys_platform != 'darwin'" },
+  { index = "pytorch-cpu", extra = "cpu" },
 ]
 torchvision = [
-  { index = "pytorch-xpu", marker = "sys_platform == 'win32'" },
-  { index = "pytorch-cpu", marker = "sys_platform == 'darwin'" },
-]
-pytorch-triton-xpu = [
-  { index = "pytorch-xpu", marker = "sys_platform == 'win32' or sys_platform == 'linux'" },
+  { index = "pytorch-xpu", extra = "xpu", marker = "sys_platform != 'darwin'" },
+  { index = "pytorch-cuda", extra = "cuda", marker = "sys_platform != 'darwin'" },
+  { index = "pytorch-cpu", extra = "cpu" },
 ]
 triton-xpu = [
-  { index = "pytorch-xpu", marker = "sys_platform == 'win32' or sys_platform == 'linux'" },
+  { index = "pytorch-xpu", extra = "xpu", marker = "sys_platform != 'darwin'" },
 ]
 insightface = [
   { url = "https://github.com/TNG/AI-Playground/releases/download/insightface-0.7.3/insightface-0.7.3-cp312-cp312-macosx_11_0_arm64.whl", marker = "sys_platform == 'darwin'" },
@@ -123,3 +144,9 @@ explicit = true
 name = "pytorch-cpu"
 url = "https://download.pytorch.org/whl/cpu"
 explicit = true
+
+[[tool.uv.index]]
+name = "pytorch-cuda"
+url = "https://download.pytorch.org/whl/cu126"
+explicit = true
+


### PR DESCRIPTION
Still not satisfied with using OpenVINO for the device detection, as it's list includes generic entries and does not split integrated GPUs from CPUs.

In dev mode Comfy can be re-installed to use e.g. the CPU, instead of the dedicated GPU:
<img width="356" height="362" alt="Screenshot 2026-04-07 074652" src="https://github.com/user-attachments/assets/9b576826-38f3-4dd3-803b-8a4a8d85aafc" />

