### PR TITLE
feat: add Linux platform support for ai-backend and llamacpp-backend

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -289,3 +289,32 @@ User sends message → `textInference.ensureReadyForInference()` → IPC `ensure
 | `electron/subprocesses/langchain.ts` | RAG utility process (document splitting, embedding, vector search) |
 | `electron/subprocesses/deviceDetection.ts` | Intel GPU device detection and env var setup |
 | `electron/logging/logger.ts` | Logging, sends `debugLog` events to renderer |
+
+## Cursor Cloud specific instructions
+
+### Service overview
+
+Only the **WebUI** (Electron + Vue.js frontend) is relevant for cloud-agent work. All
+commands run from `WebUI/`. Backend services (AI Backend, LlamaCPP, OpenVINO, ComfyUI,
+Ollama) require Intel GPU hardware and pre-built native binaries that are not available in
+the cloud VM — they will show as "notInstalled" at runtime, which is expected.
+
+### Running the dev server
+
+```bash
+cd /workspace/WebUI
+DISPLAY=:1 npm run dev
+```
+
+The Vite dev server starts on `http://localhost:25413` and Electron opens automatically.
+A virtual framebuffer (`Xvfb`) is already running on `:1`.
+
+### Known issues
+
+- **`npm install` requires `--legacy-peer-deps`** due to a `zod@4` vs `zod@3` peer
+  conflict from `@browserbasehq/stagehand` (transitive dep of `@langchain/community`).
+- **`electron/test/subprocesses/service.test.ts` fails** because the `electron` path alias
+  in `vitest.config.ts` shadows the `electron` package mock. This is a pre-existing issue
+  on the `dev` branch — 4 of 5 test files (24 tests) pass.
+- **Prettier reports 2 pre-existing formatting issues** in `electron/subprocesses/openVINOBackendService.ts`
+  and `src/components/BackendOptions.vue` on the `dev` branch.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -292,17 +292,11 @@ User sends message → `textInference.ensureReadyForInference()` → IPC `ensure
 
 ## Cursor Cloud specific instructions
 
-### Service overview
-
-Only the **WebUI** (Electron + Vue.js frontend) is relevant for cloud-agent work. All
-commands run from `WebUI/`. Backend services (AI Backend, LlamaCPP, OpenVINO, ComfyUI,
-Ollama) require Intel GPU hardware and pre-built native binaries that are not available in
-the cloud VM — they will show as "notInstalled" at runtime, which is expected.
-
 ### Running the dev server
 
 ```bash
 cd /workspace/WebUI
+npm run fetch-external-resources   # first time only — downloads uv + 7zip binaries
 DISPLAY=:1 npm run dev
 ```
 
@@ -313,14 +307,28 @@ A virtual framebuffer (`Xvfb`) is already running on `:1`.
 
 The `ai-backend` and `llamacpp-backend` services work on Linux (Ubuntu x64):
 
-- Run `npm run fetch-external-resources` from `WebUI/` to download `uv` and `7zip` binaries
-  for the current platform (placed in `build/resources/`).
-- Start the Electron app with `DISPLAY=:1 npm run dev` and use the setup dialog to install
-  `AI Playground` (ai-backend) and `Llama.cpp - GGUF` (llamacpp-backend).
-- `ai-backend` runs the Python Flask server on port 59000 (health: `/healthy`).
+- Run `npm run fetch-external-resources` once to download `uv` and `7zip` binaries for
+  the current platform (placed in `build/resources/`).
+- Start the Electron app with `DISPLAY=:1 npm run dev`. On the setup dialog, click
+  **Install** next to `AI Playground` (ai-backend) and `Llama.cpp - GGUF` (llamacpp-backend).
+- `ai-backend` runs a Python Flask server on port 59000 (health: `GET /healthy`).
 - `llamacpp-backend` downloads the `ubuntu-x64` CPU build from GitHub releases and
-  provides on-demand LLM inference (health: `/health`).
+  provides on-demand LLM inference (health: `GET /health`).
 - ComfyUI and OpenVINO are not yet supported on Linux.
+
+### Testing inference end-to-end
+
+A small test model (`LFM2.5-350M-Q4_K_M.gguf`, ~255 MB) is registered in `models.json`.
+To test inference:
+
+1. Start the app, install both backends via the setup dialog, then click **Continue**.
+2. Open **Chat Settings**, select **LFM2.5-350M-Q4_K_M.gguf** from the Model dropdown.
+3. Type a message and send — the app auto-downloads the model from HuggingFace on first use.
+4. The llamacpp-backend will load the model and serve streaming responses.
+
+**Network requirement**: Model downloads redirect through `cas-bridge.xethub.hf.co`
+(HuggingFace Xet CDN). This domain must be in the egress allowlist. Allowlist changes
+only take effect on new VM sessions — a running VM will not pick up changes.
 
 ### Known issues
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -309,6 +309,19 @@ DISPLAY=:1 npm run dev
 The Vite dev server starts on `http://localhost:25413` and Electron opens automatically.
 A virtual framebuffer (`Xvfb`) is already running on `:1`.
 
+### Backend services on Linux
+
+The `ai-backend` and `llamacpp-backend` services work on Linux (Ubuntu x64):
+
+- Run `npm run fetch-external-resources` from `WebUI/` to download `uv` and `7zip` binaries
+  for the current platform (placed in `build/resources/`).
+- Start the Electron app with `DISPLAY=:1 npm run dev` and use the setup dialog to install
+  `AI Playground` (ai-backend) and `Llama.cpp - GGUF` (llamacpp-backend).
+- `ai-backend` runs the Python Flask server on port 59000 (health: `/healthy`).
+- `llamacpp-backend` downloads the `ubuntu-x64` CPU build from GitHub releases and
+  provides on-demand LLM inference (health: `/health`).
+- ComfyUI and OpenVINO are not yet supported on Linux.
+
 ### Known issues
 
 - **`npm install` requires `--legacy-peer-deps`** due to a `zod@4` vs `zod@3` peer

--- a/WebUI/build/scripts/build-paths.mts
+++ b/WebUI/build/scripts/build-paths.mts
@@ -57,10 +57,12 @@ export const GET_PIP_SCRIPT_URL = 'https://bootstrap.pypa.io/get-pip.py'
 export const SEVEN_ZR_EXE_URL = {
   win32: 'https://github.com/ip7z/7zip/releases/download/25.01/7zr.exe',
   darwin: 'https://github.com/ip7z/7zip/releases/download/25.01/7z2501-mac.tar.xz',
+  linux: 'https://github.com/ip7z/7zip/releases/download/25.01/7z2501-linux-x64.tar.xz',
 }
 export const UV_URL = {
   win32: 'https://github.com/astral-sh/uv/releases/download/0.9.5/uv-x86_64-pc-windows-msvc.zip',
   darwin: 'https://github.com/astral-sh/uv/releases/download/0.9.5/uv-aarch64-apple-darwin.tar.gz',
+  linux: 'https://github.com/astral-sh/uv/releases/download/0.9.5/uv-x86_64-unknown-linux-gnu.tar.gz',
 }
 
 /**
@@ -97,7 +99,7 @@ export interface BuildPaths {
 /**
  * Get complete build paths configuration
  */
-export function getBuildPaths(target: 'win32' | 'darwin'): BuildPaths {
+export function getBuildPaths(target: 'win32' | 'darwin' | 'linux'): BuildPaths {
   return {
     repoRoot: REPO_ROOT,
     buildDir: BUILD_DIR,
@@ -132,7 +134,7 @@ export function getBuildPaths(target: 'win32' | 'darwin'): BuildPaths {
  */
 export function logBuildPaths(): void {
   const target = z
-    .enum(['win32', 'darwin'])
+    .enum(['win32', 'darwin', 'linux'])
     .safeParse(process.env.TARGET_PLATFORM || process.platform)
   if (!target.success) {
     console.error(`❌ Unsupported TARGET_PLATFORM: ${target}`)

--- a/WebUI/build/scripts/fetch-external-resources.mts
+++ b/WebUI/build/scripts/fetch-external-resources.mts
@@ -14,7 +14,7 @@ import { execSync } from 'child_process'
 import AdmZip from 'adm-zip'
 
 const target = z
-  .enum(['win32', 'darwin'])
+  .enum(['win32', 'darwin', 'linux'])
   .safeParse(process.env.TARGET_PLATFORM || process.platform)
 if (!target.success) {
   console.error(`❌ Unsupported TARGET_PLATFORM: ${target}`)
@@ -134,10 +134,10 @@ async function main(): Promise<void> {
 
     // extract uv binary from downloaded archive and move to
 
-    // extract downloads if packed - handle tar.gz, tar.xz on darwin, zip on win32
+    // extract downloads if packed - handle tar.gz, tar.xz on darwin/linux, zip on win32
     for (const download of downloads) {
       if (
-        target.data === 'darwin' &&
+        (target.data === 'darwin' || target.data === 'linux') &&
         (download.filePath.endsWith('.tar.gz') || download.filePath.endsWith('.tar.xz'))
       ) {
         console.log(`📦 Extracting ${download.filePath}...`)
@@ -162,9 +162,13 @@ async function main(): Promise<void> {
       }
     }
 
-    // move uv-aarch64-apple-darwin/uv to resourcesDir/uv.exe on darwin
-    if (target.data === 'darwin') {
-      const uvBinaryPath = path.join(buildPaths.tmpDir, 'uv-aarch64-apple-darwin', 'uv')
+    // move uv binary to resourcesDir/uv.exe (all platforms use uv.exe name for consistency)
+    const uvSourcePaths: Record<string, string> = {
+      darwin: path.join(buildPaths.tmpDir, 'uv-aarch64-apple-darwin', 'uv'),
+      linux: path.join(buildPaths.tmpDir, 'uv-x86_64-unknown-linux-gnu', 'uv'),
+    }
+    if (target.data in uvSourcePaths) {
+      const uvBinaryPath = uvSourcePaths[target.data]
       const destinationPath = path.join(buildPaths.resourcesDir, 'uv.exe')
       if (existsSync(uvBinaryPath)) {
         renameSync(uvBinaryPath, destinationPath)
@@ -174,21 +178,14 @@ async function main(): Promise<void> {
       }
     }
 
-    // move 7zz to resourcesDir/7zr.exe on darwin
-    if (target.data === 'darwin') {
-      const sevenZrPath = path.join(buildPaths.tmpDir, '7zz')
-      const destinationPath = path.join(buildPaths.resourcesDir, '7zr.exe')
-      if (existsSync(sevenZrPath)) {
-        renameSync(sevenZrPath, destinationPath)
-        console.log(`✅ Moved ${sevenZrPath} to ${destinationPath}`)
-      } else {
-        console.error(`❌ 7zr binary not found: ${sevenZrPath}`)
-      }
+    // move 7zip binary to resourcesDir/7zr.exe (all platforms use 7zr.exe name for consistency)
+    const sevenZipSourcePaths: Record<string, string> = {
+      darwin: path.join(buildPaths.tmpDir, '7zz'),
+      linux: path.join(buildPaths.tmpDir, '7zz'),
+      win32: path.join(buildPaths.tmpDir, '7zr.exe'),
     }
-
-    // move 7zr.exe to resourcesDir/7zr.exe on win32
-    if (target.data === 'win32') {
-      const sevenZrPath = path.join(buildPaths.tmpDir, '7zr.exe')
+    {
+      const sevenZrPath = sevenZipSourcePaths[target.data]
       const destinationPath = path.join(buildPaths.resourcesDir, '7zr.exe')
       if (existsSync(sevenZrPath)) {
         renameSync(sevenZrPath, destinationPath)

--- a/WebUI/electron/subprocesses/aiBackendService.ts
+++ b/WebUI/electron/subprocesses/aiBackendService.ts
@@ -109,9 +109,16 @@ export class AiBackendService extends LongLivedPythonApiService {
     process: ChildProcess
     didProcessExitEarlyTracker: Promise<boolean>
   }> {
+    const pathSep = process.platform === 'win32' ? ';' : ':'
     const additionalEnvVariables = {
       VIRTUAL_ENV: this.pythonEnvDir,
-      PATH: `${path.join(this.pythonEnvDir, 'bin')};${path.join(this.pythonEnvDir, 'Scripts')};${path.join(this.pythonEnvDir, 'Library', 'bin')};${process.env.PATH};${path.join(this.git.dir, 'cmd')}`,
+      PATH: [
+        path.join(this.pythonEnvDir, 'bin'),
+        path.join(this.pythonEnvDir, 'Scripts'),
+        path.join(this.pythonEnvDir, 'Library', 'bin'),
+        process.env.PATH,
+        path.join(this.git.dir, 'cmd'),
+      ].join(pathSep),
       PYTHONNOUSERSITE: 'true',
       PYTHONIOENCODING: 'utf-8',
       HF_ENDPOINT: this.settings.huggingfaceEndpoint,

--- a/WebUI/electron/subprocesses/llamaCppBackendService.ts
+++ b/WebUI/electron/subprocesses/llamaCppBackendService.ts
@@ -14,7 +14,7 @@ import { binary, extract } from './tools.ts'
 const execAsync = promisify(exec)
 
 export const LLAMACPP_DEFAULT_PARAMETERS = '--gpu-layers 999 --log-prefix --jinja --no-mmap -fa off'
-const platformExtension = process.platform === 'darwin' ? 'tar.gz' : 'zip'
+const platformExtension = process.platform === 'win32' ? 'zip' : 'tar.gz'
 
 interface LlamaServerProcess {
   process: ChildProcess

--- a/WebUI/electron/subprocesses/llamaCppBackendService.ts
+++ b/WebUI/electron/subprocesses/llamaCppBackendService.ts
@@ -439,7 +439,12 @@ export class LlamaCppBackendService implements ApiService {
   }
 
   private async downloadLlamacpp(): Promise<void> {
-    const platformArch = process.platform === 'darwin' ? 'macos-arm64' : 'win-vulkan-x64'
+    const platformArchMap: Record<string, string> = {
+      darwin: 'macos-arm64',
+      linux: 'ubuntu-x64',
+      win32: 'win-vulkan-x64',
+    }
+    const platformArch = platformArchMap[process.platform] ?? 'win-vulkan-x64'
     const downloadUrl = `https://github.com/ggml-org/llama.cpp/releases/download/${this.version}/llama-${this.version}-bin-${platformArch}.${platformExtension}`
     this.appLogger.info(`Downloading Llamacpp from ${downloadUrl}`, this.name)
 

--- a/WebUI/external/models.json
+++ b/WebUI/external/models.json
@@ -1,5 +1,13 @@
 [
   {
+    "name": "LiquidAI/LFM2.5-350M-GGUF/LFM2.5-350M-Q4_K_M.gguf",
+    "type": "llamaCPP",
+    "supportsToolCalling": true,
+    "supportsVision": false,
+    "supportsReasoning": false,
+    "maxContextSize": 1024
+  },
+  {
     "name": "bartowski/Llama-3.2-3B-Instruct-GGUF/Llama-3.2-3B-Instruct-Q4_K_S.gguf",
     "type": "llamaCPP",
     "supportsToolCalling": true,

--- a/service/pyproject.toml
+++ b/service/pyproject.toml
@@ -19,6 +19,7 @@ index-strategy = "unsafe-best-match"
 required-environments = [
   "sys_platform == 'win32'",
   "sys_platform == 'darwin'",
+  "sys_platform == 'linux'",
 ]
 
 [tool.uv.sources]

--- a/service/uv.lock
+++ b/service/uv.lock
@@ -4,6 +4,7 @@ requires-python = "==3.12.*"
 required-markers = [
     "sys_platform == 'win32'",
     "sys_platform == 'darwin'",
+    "sys_platform == 'linux'",
 ]
 
 [[package]]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
**Description:**

Add Linux (Ubuntu x64) platform support so the `ai-backend` (Python Flask) and `llamacpp-backend` (native binary) services can be installed and run on Linux, in addition to the existing Windows and macOS support. Also adds a small test model (LFM2.5-350M) for inference testing.

**Related Issue:**

N/A — platform expansion to support Linux development environments.

**Changes Made:**

- `build-paths.mts`: Added Linux URLs for `uv` (x86_64-unknown-linux-gnu) and `7zip` (linux-x64) binaries; updated type signatures to accept `'linux'`.
- `fetch-external-resources.mts`: Added `linux` to the allowed target platforms; handle Linux tar.gz extraction and uv/7zip binary placement (same approach as darwin).
- `llamaCppBackendService.ts`: Added `linux: 'ubuntu-x64'` to the platform-arch download map; fixed `platformExtension` logic (`win32` → `.zip`, everything else → `.tar.gz`).
- `aiBackendService.ts`: Fixed PATH separator — uses `:` on Linux/macOS instead of Windows `;`.
- `service/pyproject.toml`: Added `sys_platform == 'linux'` to `required-environments`; regenerated `uv.lock`.
- `models.json`: Added `LiquidAI/LFM2.5-350M-GGUF/LFM2.5-350M-Q4_K_M.gguf` as a small test model (350M params, Q4_K_M quantization).
- `AGENTS.md`: Added Cursor Cloud specific instructions for Linux backend services, inference testing guide, and network requirements.

**Testing Done:**

- Verified `npm run fetch-external-resources` downloads and extracts uv + 7zip binaries correctly on Linux
- Verified `uv.exe` (Linux binary) runs and reports version `0.9.5`
- Installed `ai-backend` via Electron UI → Flask server running on `http://127.0.0.1:59000`, health check returns `{"health":"OK"}`
- Installed `llamacpp-backend` via Electron UI → Downloaded `ubuntu-x64` binary, extracted, version `b8555` detected
- Verified `llama-server` binary runs natively on Linux x64
- Navigated to main chat interface, selected LFM2.5-350M model, triggered download flow
- Model download blocked by egress restriction on `cas-bridge.xethub.hf.co` (HuggingFace Xet CDN) — domain has been added to allowlist but requires new VM session to take effect
- All lint checks pass, 24/24 tests pass (1 pre-existing test suite failure unrelated to changes)
- TypeScript type-check passes

**Screenshots:**

[AI Backend running on Linux](https://cursor.com/agents/bc-72eb7fd1-be8a-47dc-ae98-30912790da7c/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fai_backend_running.webp)
[Both backends installed and running](https://cursor.com/agents/bc-72eb7fd1-be8a-47dc-ae98-30912790da7c/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fboth_backends_running.webp)
[Main chat interface working](https://cursor.com/agents/bc-72eb7fd1-be8a-47dc-ae98-30912790da7c/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fchat_interface_working.webp)

**Demo:**

[demo_ai_playground_linux_backends.mp4](https://cursor.com/agents/bc-72eb7fd1-be8a-47dc-ae98-30912790da7c/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdemo_ai_playground_linux_backends.mp4)

**Checklist:**

- [x] I have tested the changes locally.
- [x] I have self-reviewed the code changes.
- [x] I have updated the documentation, if necessary.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-72eb7fd1-be8a-47dc-ae98-30912790da7c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-72eb7fd1-be8a-47dc-ae98-30912790da7c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added full Linux platform support, including backend service configuration and resource downloading.
  * Introduced LFM2.5-350M-Q4_K_M model with tool-calling capabilities.

* **Documentation**
  * Added detailed development and testing guides for Cursor Cloud workflows and Linux-specific setup procedures, including network requirements and known issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->