### PR TITLE
Adjust product mode selector typography

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -293,12 +293,18 @@ User sends message → `textInference.ensureReadyForInference()` → IPC `ensure
 
 ```bash
 cd /workspace/WebUI
-npm run fetch-external-resources   # first time only — downloads uv + 7zip binaries
+npm run fetch-external-resources   # required on Linux if `build/resources/uv.exe` is missing
 DISPLAY=:1 npm run dev
 ```
 
 The Vite dev server starts on `http://localhost:25413` and Electron opens automatically.
 A virtual framebuffer (`Xvfb`) is already running on `:1`.
+
+**Linux prerequisite (don’t skip):**
+
+- If you see errors like `UV executable not found`, run `npm run fetch-external-resources` from `WebUI/`.
+- This downloads platform binaries into `build/resources/` (notably `uv.exe` and `7zr.exe`) which are required
+  for the `ai-backend` setup during `npm run dev`.
 
 ### Backend services on Linux
 

--- a/WebUI/src/App.vue
+++ b/WebUI/src/App.vue
@@ -16,7 +16,7 @@
   >
     <div class="flex items-center">
       <h1 class="select-none flex gap-2 items-baseline">
-        <span style="color: #00c4fa">AI</span>
+        <span class="text-[#00c4fa]">AI</span>
         <span>PLAYGROUND</span>
         <span v-if="productModeStore.productMode" class="text-muted-foreground/60 font-medium">{{
           productModeStore.productMode === 'essentials' ? 'essentials' : 'studio'

--- a/WebUI/src/components/ProductModeSelector.vue
+++ b/WebUI/src/components/ProductModeSelector.vue
@@ -38,29 +38,39 @@
           </div>
 
           <div class="flex-1 min-w-0">
-            <div class="flex items-baseline gap-2 flex-wrap">
-              <span class="text-lg font-bold">{{ option.title }}</span>
-              <span v-if="option.subtitle" class="text-lg font-bold text-muted-foreground">{{
-                option.subtitle
-              }}</span>
+            <div class="flex items-start justify-between gap-4 flex-wrap">
+              <div class="flex items-baseline gap-2 flex-wrap min-w-0">
+                <span class="text-lg font-bold text-[#00c4fa] tracking-tight -mr-1">{{ option.titleOne }}</span>
+                <span class="text-lg font-bold tracking-tight">{{ option.titleTwo }}</span>
+                <span
+                  v-if="option.subtitle"
+                  class="text-lg font-medium text-muted-foreground tracking-tight"
+                >
+                  {{ option.subtitle }}
+                </span>
+              </div>
+
               <span
                 v-if="recommendedMode === option.mode"
-                class="ml-1 text-sm font-semibold text-green-500"
+                class="text-xs font-semibold uppercase tracking-wider text-green-600 dark:text-green-500"
               >
                 Recommended
               </span>
               <span
                 v-else-if="option.mode === 'studio' && recommendedMode === 'essentials'"
-                class="ml-1 text-sm font-semibold text-amber-500"
+                class="text-xs font-semibold uppercase tracking-wider text-amber-500"
               >
                 Insufficient Hardware Detected
               </span>
             </div>
 
-            <p class="text-sm text-muted-foreground pt-1">{{ option.description }}</p>
+            <p class="text-sm text-foreground pt-1">{{ option.description }}</p>
 
-            <ul class="text-sm text-muted-foreground pt-2 pl-4 list-disc space-y-0.5">
-              <li v-for="(feature, idx) in option.features" :key="idx">{{ feature }}</li>
+            <ul class="text-sm pt-3 pl-5 list-disc space-y-1">
+              <li v-for="(feature, idx) in option.features" :key="idx">
+                <span class="text-foreground font-medium">{{ feature.label }}</span>
+                <span class="text-foreground/90">{{ feature.detail }}</span>
+              </li>
             </ul>
 
             <p class="text-xs text-muted-foreground pt-2 italic">
@@ -125,28 +135,36 @@ watch(
 const modeOptions = [
   {
     mode: 'essentials' as ProductMode,
-    title: 'AI Playground',
+    titleOne: 'AI',
+    titleTwo: 'PLAYGROUND',
     subtitle: 'essentials',
     description:
       'Focused feature set, purpose built for low power, lightweight, and power efficient Intel Core AI PCs.',
     features: [
-      'Chat: Knowledge chat, document search, and analysis',
-      'Image Gen: Draft, HD, and Manual image generation modes',
-      'Image Edit: Upscale, SketchToPhoto, Inpaint, Outpaint',
+      { label: 'Chat:', detail: ' Knowledge chat, document search, and analysis' },
+      { label: 'Image Gen:', detail: ' Draft, HD, and Manual image generation modes' },
+      { label: 'Image Edit:', detail: ' Upscale, SketchToPhoto, Inpaint, Outpaint' },
     ],
     supportedHardware: 'Intel® Core™ Series 3 with 12GB RAM',
   },
   {
     mode: 'studio' as ProductMode,
-    title: 'AI Playground',
+    titleOne: 'AI',
+    titleTwo: 'PLAYGROUND',
     subtitle: 'studio',
     description:
       'Full feature set of demanding offline AI workloads across chat, vision, image and video, targeting the GPU.',
     features: [
-      'Chat: Advanced chat with reasoning, vision, agentic, and multi-modal chat.',
-      'Image Gen: Advanced image gen with high realism and prompt adherence',
-      'Image Edit: Semantic prompt driven image editing, style control, and 3D model generation',
-      'Video Generation Support',
+      {
+        label: 'Chat:',
+        detail: ' Advanced chat with reasoning, vision, agentic, and multi-modal chat.',
+      },
+      { label: 'Image Gen:', detail: ' Advanced image gen with high realism and prompt adherence' },
+      {
+        label: 'Image Edit:',
+        detail: ' Semantic prompt driven image editing, style control, and 3D model generation',
+      },
+      { label: 'Video:', detail: ' Video Generation Support' },
     ],
     supportedHardware:
       'Intel® Core™ Ultra Series 3, Series 2V/2H, Series 1H with 16GB RAM; Intel Arc GPU Series A & B with 8GB of vRAM',


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
**Description:**

Adjust the Product Mode selection UI typography/layout to better match the desired Installation Manager design while keeping theme-aligned container styling.

Also document the required Linux dev prerequisite to fetch `uv`/`7zip` resources.

**Related Issue:**

N/A

**Changes Made:**

- Updated `WebUI/src/components/ProductModeSelector.vue` to:
  - Align header content (title/subtitle left, status badge right)
  - Use uppercase tracking for status badges (Recommended / Insufficient Hardware Detected)
  - Emphasize feature list labels (e.g., “Chat:”, “Image Gen:”) with heavier weight
- Updated `AGENTS.md` to explicitly call out `npm run fetch-external-resources` as required for Linux dev runs (fixes “UV executable not found” failures).

**Testing Done:**

- `npm run lint:ci`
- `npm run format:ci`

**Screenshots:**

- Product mode selector (dev): `/opt/cursor/artifacts/screenshots/product-mode-selector.png`

**Checklist:**

- [x] I have tested the changes locally.
- [x] I have self-reviewed the code changes.
- [x] I have updated the documentation, if necessary.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d6cfd5d8-8aff-4221-866a-45d5c32db186"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d6cfd5d8-8aff-4221-866a-45d5c32db186"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

