### PR TITLE
feat: enable AIPG_DEBUGGING_PORT in packaged builds + rewire --start-page flag

### DIFF
--- a/WebUI/electron/main.ts
+++ b/WebUI/electron/main.ts
@@ -1006,11 +1006,15 @@ function initEventHandle() {
     },
   )
 
-  /** Get command line parameters when launched from IPOS to decide the default home page */
-  ipcMain.handle('getInitialPage', (): ModeType => {
+  /** Get command line parameters when launched from IPOS to decide the default home page.
+   * Returns null when --start-page was not provided so the renderer can leave
+   * the persisted mode untouched; returns the validated ModeType (or 'chat' as
+   * a safe fallback for an invalid value) when it was. */
+  ipcMain.handle('getInitialPage', (): ModeType | null => {
     const validModes: ModeType[] = ['chat', 'imageGen', 'imageEdit', 'video']
     const startPageArg = process.argv.find((arg) => arg.startsWith('--start-page='))
-    const parsed = startPageArg?.split('=')[1]
+    if (!startPageArg) return null
+    const parsed = startPageArg.split('=')[1]
     return validModes.includes(parsed as ModeType) ? (parsed as ModeType) : 'chat'
   })
 

--- a/WebUI/electron/main.ts
+++ b/WebUI/electron/main.ts
@@ -1007,9 +1007,11 @@ function initEventHandle() {
   )
 
   /** Get command line parameters when launched from IPOS to decide the default home page */
-  ipcMain.handle('getInitialPage', () => {
+  ipcMain.handle('getInitialPage', (): ModeType => {
+    const validModes: ModeType[] = ['chat', 'imageGen', 'imageEdit', 'video']
     const startPageArg = process.argv.find((arg) => arg.startsWith('--start-page='))
-    return startPageArg ? startPageArg.split('=')[1] : 'create'
+    const parsed = startPageArg?.split('=')[1]
+    return validModes.includes(parsed as ModeType) ? (parsed as ModeType) : 'chat'
   })
 
   /** To check whether demo mode is enabled or not for AIPG */

--- a/WebUI/electron/main.ts
+++ b/WebUI/electron/main.ts
@@ -212,7 +212,7 @@ let langchainChild: UtilityProcess | null = null
 
 // 🚧 Use ['ENV_NAME'] avoid vite:define plugin - Vite@2.x
 const VITE_DEV_SERVER_URL = process.env['VITE_DEV_SERVER_URL']
-if (!app.isPackaged && process.env.AIPG_DEBUGGING_PORT) {
+if (process.env.AIPG_DEBUGGING_PORT) {
   app.commandLine.appendSwitch('remote-debugging-port', process.env.AIPG_DEBUGGING_PORT)
 }
 // const APP_TOOL_HEIGHT = 209;

--- a/WebUI/src/env.d.ts
+++ b/WebUI/src/env.d.ts
@@ -196,7 +196,7 @@ type electronAPI = {
   setIgnoreMouseEvents(ignore: boolean): void
   miniWindow(): void
   exitApp(): void
-  getInitialPage(): Promise<ModeType>
+  getInitialPage(): Promise<ModeType | null>
   getDemoModeSettings(): Promise<DemoModeSettings>
   saveImage(url: string): void
   saveImageToMediaInput(dataUri: string): Promise<string>

--- a/WebUI/src/env.d.ts
+++ b/WebUI/src/env.d.ts
@@ -152,8 +152,6 @@ type McpToolCallResult = {
   structuredContent?: unknown
 }
 
-// AipgPage type kept for backward compatibility with getInitialPage IPC handler
-type AipgPage = 'create' | 'enhance' | 'answer' | 'learn-more'
 type DemoModePage = 'chat' | 'imageGen' | 'imageEdit' | 'video'
 type WorkflowModeType = 'imageGen' | 'imageEdit' | 'video'
 type ModeType = 'chat' | WorkflowModeType
@@ -198,7 +196,7 @@ type electronAPI = {
   setIgnoreMouseEvents(ignore: boolean): void
   miniWindow(): void
   exitApp(): void
-  getInitialPage(): Promise<AipgPage>
+  getInitialPage(): Promise<ModeType>
   getDemoModeSettings(): Promise<DemoModeSettings>
   saveImage(url: string): void
   saveImageToMediaInput(dataUri: string): Promise<string>

--- a/WebUI/src/main.ts
+++ b/WebUI/src/main.ts
@@ -3,14 +3,23 @@ import App from './App.vue'
 import { createPinia } from 'pinia'
 import piniaPluginPersistedstate from 'pinia-plugin-persistedstate'
 import { useI18N } from './assets/js/store/i18n'
+import { usePromptStore } from './assets/js/store/promptArea'
 
-const settings = await window.electronAPI.getDemoModeSettings()
+const [settings, initialPage] = await Promise.all([
+  window.electronAPI.getDemoModeSettings(),
+  window.electronAPI.getInitialPage(),
+])
 window.__AIPG_DEMO_MODE__ = settings.isDemoModeEnabled
 
 const app = createApp(App)
 const pinia = createPinia()
 pinia.use(piniaPluginPersistedstate)
 app.use(pinia)
+
+if (initialPage !== 'chat') {
+  usePromptStore().setCurrentMode(initialPage)
+}
+
 const i18n = useI18N()
 i18n.init().then(() => {
   const languages = i18n.state

--- a/WebUI/src/main.ts
+++ b/WebUI/src/main.ts
@@ -16,7 +16,7 @@ const pinia = createPinia()
 pinia.use(piniaPluginPersistedstate)
 app.use(pinia)
 
-if (initialPage !== 'chat') {
+if (initialPage !== null) {
   usePromptStore().setCurrentMode(initialPage)
 }
 


### PR DESCRIPTION
## Summary

Two small patches for using AI Playground as a programmable demo target.
Coordinated with Markus via email on 2026-05-29.

### `feat(debug): enable AIPG_DEBUGGING_PORT in packaged builds`

Drops the `!app.isPackaged` guard around the existing env-var-gated
Chrome DevTools Protocol port. The env var itself stays opt-in
(off by default), so packaged builds gain the existing dev capability
without changing the default security posture.

Use case: an external controller process (an automation runner)
needs a stable, packaged build to attach CDP and observe / steer the
renderer in production-shaped environments.

### `feat(launcher): rewire --start-page flag to land on requested mode`

The `getInitialPage` IPC handler was returning the legacy `AipgPage`
vocabulary (`create | enhance | answer | learn-more`), which no longer
matches the renderer's `ModeType` (`chat | imageGen | imageEdit | video`).
The renderer never consumed the IPC result, so `--start-page` was
effectively dead in v3.x.

- main process: validate the parsed `--start-page=` value against
  `ModeType`, return `'chat'` as the safe fallback
- `env.d.ts`: switch `getInitialPage`'s return type to
  `Promise<ModeType>`, drop the now-unused `AipgPage` alias
- renderer entry: top-level `await getInitialPage()` alongside the
  existing `getDemoModeSettings()` call, then route the result through
  `promptStore.setCurrentMode()` so the mode change also picks up the
  last-used preset for that category

## Test plan

- [x] `npm run typecheck` clean against `tng/dev`
- [x] `npm run build` produces a clean NSIS installer
      (`AI Playground-3.1.1-beta.exe`, ~211MB)
- [x] Launching the packaged exe with `AIPG_DEBUGGING_PORT=9223`
      exposes the DevTools port; confirmed via CDP `/json/version`
- [x] `--start-page=imageGen` lands the renderer on Image Gen;
      `--start-page=chat` lands on Chat — both verified visually
      against the installed `3.1.1-beta` build

Both commits are DCO sign-off compliant.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved validation and error handling for initial page startup configuration.

* **Improvements**
  * Optimized concurrent loading of application settings and demo mode configuration during startup for faster initialization.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TNG/AI-Playground/pull/241?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->