### PR TITLE
linux poc identified gap fixes

### DIFF
--- a/WebUI/electron/subprocesses/openVINOBackendService.ts
+++ b/WebUI/electron/subprocesses/openVINOBackendService.ts
@@ -905,7 +905,10 @@ export class OpenVINOBackendService implements ApiService {
     if (process.platform !== 'linux') return
     if (devices.some((d) => d.id === 'NPU' || d.id.startsWith('NPU.'))) return
     try {
-      const { stdout } = await execAsync('lspci -nn -d 8086:')
+      // PCI class 1200 = Processing accelerators. NPU silicon is exposed there.
+      // Timeout matches the codebase pattern (other execAsync calls use timeout: 5000);
+      // 2s is plenty for `lspci` which reads from sysfs.
+      const { stdout } = await execAsync('lspci -nn -d 8086:', { timeout: 2000 })
       const hasNpuOnBus = /Processing accelerators \[1200\]/.test(stdout)
       if (!hasNpuOnBus) return
       this.appLogger.warn(
@@ -916,8 +919,13 @@ export class OpenVINOBackendService implements ApiService {
         this.name,
         true,
       )
-    } catch {
-      // lspci unavailable
+    } catch (error) {
+      // Best-effort probe. Log so real failures (missing binary, permissions,
+      // process killed by timeout) are diagnosable instead of silently swallowed.
+      this.appLogger.warn(
+        `NPU PCI probe skipped (lspci unavailable, timed out, or failed): ${error}`,
+        this.name,
+      )
     }
   }
 

--- a/WebUI/electron/subprocesses/openVINOBackendService.ts
+++ b/WebUI/electron/subprocesses/openVINOBackendService.ts
@@ -866,6 +866,7 @@ export class OpenVINOBackendService implements ApiService {
       const pythonDevices = await this.detectDevicesWithPython()
       if (pythonDevices) {
         this.applyDetectedDevices(pythonDevices)
+        await this.warnIfNpuSiliconMissingDriver(pythonDevices)
         this.updateStatus()
         return
       }
@@ -880,6 +881,7 @@ export class OpenVINOBackendService implements ApiService {
     try {
       const ovmsDevices = await this.detectDevicesWithOvms()
       this.applyDetectedDevices(ovmsDevices)
+      await this.warnIfNpuSiliconMissingDriver(ovmsDevices)
     } catch (error) {
       this.appLogger.error(`Failed to detect devices: ${error}`, this.name)
       // Fallback to default device on error
@@ -887,6 +889,36 @@ export class OpenVINOBackendService implements ApiService {
       this.sttDevices = [...defaultDevices]
     }
     this.updateStatus()
+  }
+
+  /**
+   * Linux-only: surface a warning when an Intel NPU is on the PCI bus
+   * (lspci class 1200, vendor 8086) but OpenVINO did not enumerate it.
+   * This happens when the kernel module `intel_vpu` is loaded (so /dev/accel/accel0
+   * exists) but the userspace stack from intel/linux-npu-driver is not installed.
+   * The Intel GPU APT repo does NOT carry these packages — they only ship as a
+   * release tarball on GitHub.
+   */
+  private async warnIfNpuSiliconMissingDriver(
+    devices: { id: string; name: string }[],
+  ): Promise<void> {
+    if (process.platform !== 'linux') return
+    if (devices.some((d) => d.id === 'NPU' || d.id.startsWith('NPU.'))) return
+    try {
+      const { stdout } = await execAsync('lspci -nn -d 8086:')
+      const hasNpuOnBus = /Processing accelerators \[1200\]/.test(stdout)
+      if (!hasNpuOnBus) return
+      this.appLogger.warn(
+        'Intel NPU detected on PCI bus but not enumerated by OpenVINO. ' +
+          'Install the NPU userspace driver from ' +
+          'https://github.com/intel/linux-npu-driver/releases ' +
+          '(packages: intel-driver-compiler-npu, intel-fw-npu, intel-level-zero-npu). ',
+        this.name,
+        true,
+      )
+    } catch {
+      // lspci unavailable
+    }
   }
 
   /**

--- a/docs/linux-intel-gpu-setup.md
+++ b/docs/linux-intel-gpu-setup.md
@@ -58,9 +58,14 @@ also renamed (the old `intel-level-zero-gpu` / `level-zero` names were the 22.04
 
 ```bash
 sudo apt-get update
-sudo apt-get install -y gpg-agent wget
+sudo apt-get install -y gpg-agent curl
 
-wget -qO - https://repositories.intel.com/gpu/intel-graphics.key \
+# Use curl (not wget): on corporate networks where http(s)_proxy is set but
+# no_proxy contains \`*.intel.com\`, wget silently bypasses the proxy for the
+# externally-hosted \`repositories.intel.com\` host (it resolves to AWS) and hangs.
+# curl with an explicit \`--proxy\` survives that.
+curl -fsSL ${http_proxy:+--proxy "$http_proxy"} \
+  https://repositories.intel.com/gpu/intel-graphics.key \
   | sudo gpg --dearmor --output /usr/share/keyrings/intel-graphics.gpg
 
 echo "deb [arch=amd64 signed-by=/usr/share/keyrings/intel-graphics.gpg] https://repositories.intel.com/gpu/ubuntu noble unified" \
@@ -80,7 +85,6 @@ sudo apt-get install -y \
   libze-intel-gpu1 \
   libze1 \
   intel-opencl-icd \
-  intel-metrics-discovery \
   clinfo
 ```
 
@@ -88,6 +92,8 @@ sudo apt-get install -y \
   `linuxHasLevelZeroRuntime()` and OpenVINO look for.
 - `libze-intel-gpu1` → Level Zero **GPU backend** for the Intel GPU.
 - `intel-opencl-icd` → OpenCL (an alternate path OpenVINO GPU can use).
+- `intel-metrics-discovery` is **omitted**: it is not in the
+  Noble \`unified\` component (and is not required for inference). Skip it.
 
 
 ### 2c. Install Vulkan (llama.cpp GPU build)
@@ -99,6 +105,54 @@ sudo apt-get install -y libvulkan1 mesa-vulkan-drivers vulkan-tools
 - `libvulkan1` → `libvulkan.so.1` loader.
 - `mesa-vulkan-drivers` → provides `libvulkan_intel.so` (the **ANV** driver that
   drives Arc/DG2 and Gen9+ iGPUs).
+
+### 2e. (Optional) Install the Intel NPU userspace driver
+
+Required only if your CPU has an integrated NPU (Meteor/Lunar/Panther/Arrow Lake)
+**and** you want OpenVINO to enumerate `NPU` as an inference target. Without it,
+`Core().available_devices` silently returns only `['CPU', 'GPU']` — even though
+`/dev/accel/accel0` is present and `intel_vpu` is loaded.
+
+The NPU userspace **is not in the GPU APT repo above**. It ships only as a
+release tarball on GitHub:
+
+```bash
+# Pick the latest tag from https://github.com/intel/linux-npu-driver/releases
+NPU_TAG=v1.33.0
+NPU_BUILD=v1.33.0.20260529-26625960453
+
+cd /tmp
+curl -fL ${http_proxy:+--proxy "$http_proxy"} \
+  -o linux-npu-driver.tar.gz \
+  "https://github.com/intel/linux-npu-driver/releases/download/${NPU_TAG}/linux-npu-driver-${NPU_BUILD}-ubuntu2404.tar.gz"
+
+mkdir -p linux-npu-driver && tar -xzf linux-npu-driver.tar.gz -C linux-npu-driver
+
+sudo apt install -y \
+  ./linux-npu-driver/intel-driver-compiler-npu_*.deb \
+  ./linux-npu-driver/intel-fw-npu_*.deb \
+  ./linux-npu-driver/intel-level-zero-npu_*.deb
+```
+
+Verify (after re-login so `render` group membership is active):
+
+```bash
+ls /usr/lib/x86_64-linux-gnu/libze_intel_npu.so*   # plugin must exist
+# Use the app's managed Python venv (system python3 won't have openvino):
+~/.local/share/ai-playground/resources/OpenVINO/.venv/bin/python3 -c \
+  "import openvino as ov; print(ov.Core().available_devices)"
+# Expected: ['CPU', 'GPU', 'NPU']
+```
+
+> **Kernel pairing.** The NPU userspace ABI is locked to the kernel `intel_vpu`
+> module. Panther Lake needs **kernel ≥ 6.10**; on older Ubuntu kernels
+> install `linux-generic-hwe-24.04`.
+
+> **Proxy.** GitHub release downloads redirect to AWS, which the
+> `*.intel.com` `no_proxy` rule does **not** cover. The `${http_proxy:+--proxy ...}`
+> form above forwards the proxy explicitly when one is set.
+
+---
 
 ### 2d. Render-node permissions
 
@@ -154,8 +208,29 @@ the GPU is actually live (`clinfo` lists the device, `/dev/dri` accessible)
 - **Arc (DG2)** needs a kernel with DG2 `i915` support. Ubuntu 24.04's 6.8
   kernel supports it out of the box. On older kernels you may need
   `i915.force_probe=<device-id>` on the kernel command line.
+- **Panther Lake / Lunar Lake / Arrow Lake** use the new **`xe`** kernel driver
+  (not `i915`). Needs **kernel ≥ 6.10** — install `linux-generic-hwe-24.04`
+  on Ubuntu 24.04 if your kernel is older.
 - Confirm the driver bound with `lspci -nnk` → `Kernel driver in use: i915`
   (or `xe`).
+
+#### Verifying live GPU usage (works on both `i915` and `xe`)
+
+`intel_gpu_top` (from `intel-gpu-tools`) does **not** support the `xe` driver
+yet. To see what's actually using the GPU on a `xe`-driven host, look at
+processes holding the render node:
+
+```bash
+sudo fuser -v /dev/dri/renderD128
+# Healthy AI-Playground inference shows: ovms + ai-playground.bin + python (ComfyUI)
+```
+
+For instantaneous frequency / busy-time on `xe`, read sysfs:
+
+```bash
+cat /sys/class/drm/card0/device/tile0/gt0/freq0/cur_freq      # GPU current MHz
+cat /sys/class/drm/card0/device/tile0/gt0/freq0/max_freq
+```
 
 ---
 

--- a/docs/linux-intel-gpu-setup.md
+++ b/docs/linux-intel-gpu-setup.md
@@ -106,6 +106,14 @@ sudo apt-get install -y libvulkan1 mesa-vulkan-drivers vulkan-tools
 - `mesa-vulkan-drivers` → provides `libvulkan_intel.so` (the **ANV** driver that
   drives Arc/DG2 and Gen9+ iGPUs).
 
+### 2d. Render-node permissions
+
+```bash
+sudo gpasswd -a "$USER" render
+sudo gpasswd -a "$USER" video
+# log out/in (or `newgrp render`) so the group membership applies
+```
+
 ### 2e. (Optional) Install the Intel NPU userspace driver
 
 Required only if your CPU has an integrated NPU (Meteor/Lunar/Panther/Arrow Lake)
@@ -147,20 +155,10 @@ ls /usr/lib/x86_64-linux-gnu/libze_intel_npu.so*   # plugin must exist
 > **Kernel pairing.** The NPU userspace ABI is locked to the kernel `intel_vpu`
 > module. Panther Lake needs **kernel ≥ 6.10**; on older Ubuntu kernels
 > install `linux-generic-hwe-24.04`.
-
+>
 > **Proxy.** GitHub release downloads redirect to AWS, which the
 > `*.intel.com` `no_proxy` rule does **not** cover. The `${http_proxy:+--proxy ...}`
 > form above forwards the proxy explicitly when one is set.
-
----
-
-### 2d. Render-node permissions
-
-```bash
-sudo gpasswd -a "$USER" render
-sudo gpasswd -a "$USER" video
-# log out/in (or `newgrp render`) so the group membership applies
-```
 
 ---
 
@@ -214,7 +212,7 @@ the GPU is actually live (`clinfo` lists the device, `/dev/dri` accessible)
 - Confirm the driver bound with `lspci -nnk` → `Kernel driver in use: i915`
   (or `xe`).
 
-#### Verifying live GPU usage (works on both `i915` and `xe`)
+### 4a. Verifying live GPU usage (works on both `i915` and `xe`)
 
 `intel_gpu_top` (from `intel-gpu-tools`) does **not** support the `xe` driver
 yet. To see what's actually using the GPU on a `xe`-driven host, look at

--- a/readme.md
+++ b/readme.md
@@ -66,11 +66,25 @@ cd AI-Playground
 
 ### Install Node.js Dependencies
 
-1. Install the Node.js development environment from [Node.js](https://nodejs.org/en/download).
+1. Install the **Node.js ≥ 20** development environment.
+
+   - **Windows / macOS:** download the installer from [Node.js](https://nodejs.org/en/download).
+   - **Ubuntu 24.04 / Debian:** the distro's `apt install nodejs` ships Node 18
+     (no `npm`) and is **too old**. Install Node 22 LTS via NodeSource instead:
+
+     ```bash
+     curl -fsSL https://deb.nodesource.com/setup_22.x | sudo -E bash -
+     sudo apt install -y nodejs
+     node --version    # expect: v22.x
+     npm  --version    # expect: 10.x
+     ```
+
+     Behind a corporate proxy that intercepts `deb.nodesource.com`, prefix the
+     `curl` with `--proxy "$http_proxy"` and ensure `https_proxy` is exported.
 
 2. Navigate to the `WebUI` directory and install all Node.js dependencies:
 
-```cmd
+```bash
 cd WebUI
 npm install
 ```
@@ -201,6 +215,25 @@ If your network blocks the downloads entirely, you can also pre-place the build
 tools manually: drop the extracted `uv`/`7zip` binaries into
 `WebUI/build/resources/` (the fetch script skips any file already present)
 before running the build.
+
+#### Corporate proxy + Intel-owned external hosts
+
+A common gotcha on Intel networks: `apt` and `curl` honor `no_proxy` exactly,
+but a **broad** entry like `no_proxy=*.intel.com` will **also** match the
+externally-hosted CDN `repositories.intel.com` (resolves to AWS), causing
+`apt update` to hang trying to reach it directly through the corporate firewall.
+
+Work around it by **scoping the proxy override per-host** rather than rewriting
+`no_proxy`:
+
+```bash
+# /etc/apt/apt.conf.d/99-intel-proxy
+Acquire::http::Proxy::repositories.intel.com  "http://proxy.example.com:port";
+Acquire::https::Proxy::repositories.intel.com "http://proxy.example.com:port";
+```
+
+For interactive `curl` calls (e.g. fetching the NPU driver tarball from
+`github.com` which redirects to AWS), pass `--proxy "$http_proxy"` explicitly.
 
 ## Model Support
 AI Playground does not ship with any generative AI models but does make models available for all features either directly from the interface or indirectly by the users downloading models from HuggingFace.co or CivitAI.com and placing them in the appropriate model folder. 


### PR DESCRIPTION
**Description:**

GAPS FIXED:
GAP-1: Node ≥ 20 requirement documented with NodeSource commands
GAP-2: curl with proxy support replaces wget
GAP-3: intel-metrics-discovery removed from required list
GAP-4: Proxy documentation for repositories.intel.com trap
GAP-6: xe driver GPU monitoring via fuser and sysfs
GAP-7: Complete NPU driver installation documentation
GAP-8: NPU detection warning in OpenVINO backend service

**Related Issue:**

If this pull request is related to any existing issue, please mention the issue number here.

**Changes Made:**

Please list down the specific changes made in this pull request.

**Testing Done:**

NPU detected and working: ['CPU', 'GPU', 'NPU']
Documentation tested
Code changes compile successfully

**Screenshots:**

If applicable, please provide screenshots or GIFs or videos to visually demonstrate the changes made.

**Checklist:**

- [x] I have tested the changes locally.
- [x] I have self-reviewed the code changes.
- [x] I have updated the documentation, if necessary.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Added warnings when Intel NPU hardware is detected on Linux but not recognized by the system.

* **Documentation**
  * Updated Ubuntu 24.04 GPU driver installation steps.
  * Added Intel NPU driver setup instructions.
  * Clarified Node.js version requirements (≥20) with platform-specific guidance.
  * Enhanced corporate proxy configuration documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->