### PR TITLE
Adding MIT License to Debian Package

### DIFF
--- a/WebUI/build/build-config.json
+++ b/WebUI/build/build-config.json
@@ -150,6 +150,8 @@
     "artifactName": "${productName}-${version}.${ext}",
     "category": "Utility",
     "synopsis": "AI inference desktop app for Intel GPUs",
+    "vendor": "Intel Corporation",
+    "maintainer": "Intel Corporation <webadmin@linux.intel.com>",
     "executableArgs": ["--no-sandbox"],
     "desktop": {
       "entry": {

--- a/WebUI/package.json
+++ b/WebUI/package.json
@@ -2,10 +2,11 @@
   "name": "ai-playground",
   "private": true,
   "version": "3.1.2-beta",
+  "license": "MIT",
   "homepage": "https://github.com/intel/AI-Playground",
   "author": {
-    "name": "TODO",
-    "email": "TODO"
+    "name": "Intel Corporation",
+    "email": "webadmin@linux.intel.com"
   },
   "scripts": {
     "ensure-electron": "node ./build/scripts/ensure-electron.mjs",


### PR DESCRIPTION
**Description:**

The license field is set during package build.
During build electron-builder reads the license from `package.json`

**Related Issue:**

If this pull request is related to any existing issue, please mention the issue number here.

**Changes Made:**

Please list down the specific changes made in this pull request.

**Testing Done:**

Please describe the testing that has been done to ensure the changes made in this pull request are functioning as expected.

**Screenshots:**

If applicable, please provide screenshots or GIFs or videos to visually demonstrate the changes made.

**Checklist:**

- [ ] I have tested the changes locally.
- [ ] I have self-reviewed the code changes.
- [ ] I have updated the documentation, if necessary.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated app/package metadata with official Intel branding and maintainer details.
  * Added license information to package metadata.
  * Included Linux package vendor and maintainer details in the build configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->