### PR TITLE
Fix ReActor face swap: models downloaded as nested dir instead of fla…

### DIFF
--- a/service/model_downloader.py
+++ b/service/model_downloader.py
@@ -403,9 +403,13 @@ class HFPlaygroundDownloader:
             self.save_path, utils.repo_local_root_dir_name(self.repo_id)
         )
         move_to_flat_structure = False
+        # face restore and insightface models must land as a single flat *file*
+        # named "<owner>---<repo>---<file>" so the reactor node can load them.
+        flatten_to_single_file = False
         # face restore and insightface model need to be in a flat structure to work with reactor node
         if "facerestore" in self.save_path or "insightface" in self.save_path:
             move_to_flat_structure = True
+            flatten_to_single_file = True
             desired_repo_root_dir_name = path.abspath(
                 path.join(self.save_path, self.repo_id.replace("/", "---"))
             )
@@ -418,10 +422,20 @@ class HFPlaygroundDownloader:
                 os.makedirs(desired_repo_root_dir_name)
         try:
             if os.path.exists(desired_repo_root_dir_name) or move_to_flat_structure:
+                if flatten_to_single_file:
+                    # The reactor node expects the flat name to be the file itself,
+                    # not a directory containing it. Clear any stale directory left
+                    # by an earlier (broken) download before moving the file into place.
+                    utils.remove_existing_filesystem_resource(desired_repo_root_dir_name)
                 for item in os.listdir(self.save_path_tmp):
+                    dst = (
+                        desired_repo_root_dir_name
+                        if flatten_to_single_file
+                        else os.path.join(desired_repo_root_dir_name, item)
+                    )
                     _merge_move(
                         os.path.join(self.save_path_tmp, item),
-                        os.path.join(desired_repo_root_dir_name, item),
+                        dst,
                     )
                 shutil.rmtree(self.save_path_tmp)
             else:

--- a/service/tests/test_model_downloader.py
+++ b/service/tests/test_model_downloader.py
@@ -1,10 +1,30 @@
 import os
 import sys
+import types
 import unittest
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 import utils
+
+
+def _install_heavy_import_stubs():
+    """Stub third-party deps so model_downloader imports in a minimal test env."""
+    if "psutil" not in sys.modules:
+        psutil = types.ModuleType("psutil")
+        common = types.ModuleType("psutil._common")
+        common.bytes2human = lambda n: str(n)
+        psutil._common = common
+        sys.modules["psutil"] = psutil
+        sys.modules["psutil._common"] = common
+    if "requests" not in sys.modules:
+        sys.modules["requests"] = types.ModuleType("requests")
+    if "huggingface_hub" not in sys.modules:
+        hub = types.ModuleType("huggingface_hub")
+        hub.HfFileSystem = object
+        hub.hf_hub_url = lambda **kwargs: ""
+        hub.model_info = lambda *args, **kwargs: None
+        sys.modules["huggingface_hub"] = hub
 
 
 class TestHFChunkHttpOk(unittest.TestCase):
@@ -16,6 +36,72 @@ class TestHFChunkHttpOk(unittest.TestCase):
         self.assertTrue(utils.hf_chunk_http_ok(200, 1))
         self.assertTrue(utils.hf_chunk_http_ok(206, 1))
         self.assertFalse(utils.hf_chunk_http_ok(404, 1))
+
+
+class TestMoveToDesiredPositionFlatStructure(unittest.TestCase):
+    """Reactor (faceswap/facerestore) models must land as a single flat *file*
+    named "<owner>---<repo>---<file>", not a directory containing that file.
+    Regression test for the reactor node failing with
+    "model_file ...inswapper_128.onnx should be a file".
+    """
+
+    def _make_downloader(self, save_path, repo_id):
+        _install_heavy_import_stubs()
+        import model_downloader
+
+        dl = model_downloader.HFPlaygroundDownloader.__new__(
+            model_downloader.HFPlaygroundDownloader
+        )
+        dl.repo_id = repo_id
+        dl.save_path = save_path
+        dl.save_path_tmp = os.path.join(save_path, "tmp")
+        os.makedirs(dl.save_path_tmp, exist_ok=True)
+        return dl
+
+    def test_insightface_model_becomes_flat_file(self):
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as tmp:
+            save_path = os.path.join(tmp, "insightface")
+            os.makedirs(save_path)
+            repo_id = "Aitrepreneur/insightface/inswapper_128.onnx"
+            dl = self._make_downloader(save_path, repo_id)
+            # Simulate the downloaded file sitting in the tmp staging dir.
+            with open(os.path.join(dl.save_path_tmp, "inswapper_128.onnx"), "wb") as f:
+                f.write(b"weights")
+
+            dl.move_to_desired_position()
+
+            flat = os.path.join(
+                save_path, "Aitrepreneur---insightface---inswapper_128.onnx"
+            )
+            self.assertTrue(os.path.isfile(flat), "flat name must be a file")
+            self.assertFalse(os.path.exists(dl.save_path_tmp))
+
+    def test_stale_directory_is_replaced_by_file(self):
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as tmp:
+            save_path = os.path.join(tmp, "insightface")
+            os.makedirs(save_path)
+            repo_id = "Aitrepreneur/insightface/inswapper_128.onnx"
+            flat = os.path.join(
+                save_path, "Aitrepreneur---insightface---inswapper_128.onnx"
+            )
+            # An earlier broken download left the flat name as a *directory*.
+            os.makedirs(flat)
+            with open(os.path.join(flat, "inswapper_128.onnx"), "wb") as f:
+                f.write(b"stale")
+
+            dl = self._make_downloader(save_path, repo_id)
+            with open(os.path.join(dl.save_path_tmp, "inswapper_128.onnx"), "wb") as f:
+                f.write(b"weights")
+
+            dl.move_to_desired_position()
+
+            self.assertTrue(os.path.isfile(flat))
+            with open(flat, "rb") as f:
+                self.assertEqual(f.read(), b"weights")
 
 
 if __name__ == "__main__":

--- a/service/utils.py
+++ b/service/utils.py
@@ -105,16 +105,18 @@ def check_model_exists_with_path(type: str, repo_id: str, model_path: str) -> bo
     
     if type == 'faceswap' or type == 'facerestore':
         storage_path = os.path.join(model_path, flat_repo_local_dir_name(repo_id))
-        
-        # Check if model exists in storage
-        if not os.path.exists(storage_path):
+
+        # Check if model exists in storage. The reactor node requires the flat name
+        # to be the model file itself; a directory (left by an older broken download)
+        # does not count and must trigger a re-download.
+        if not os.path.isfile(storage_path):
             return False
-        
+
         # For faceswap/facerestore, also check and restore to ComfyUI directory
         comfy_ui_path = get_comfyui_faceswap_facerestore_path(type, repo_id)
-        
+
         # If not in ComfyUI directory, restore from storage
-        if not os.path.exists(comfy_ui_path):
+        if not os.path.isfile(comfy_ui_path):
             logging.info(f'Restoring {type} model {repo_id} from storage to ComfyUI directory')
             copy_faceswap_facerestore_to_comfyui(type, repo_id, model_path)
         
@@ -168,17 +170,18 @@ def check_comfyui_model_exists(type: str, repo_id: str) -> bool:
     if type == 'faceswap' or type == 'facerestore':
         # Check ComfyUI's models directory first
         comfy_ui_path = get_comfyui_faceswap_facerestore_path(type, repo_id)
-        
-        # If exists in ComfyUI directory, return True
-        if os.path.exists(comfy_ui_path):
+
+        # If the model file exists in ComfyUI directory, return True. A directory of
+        # the same name (left by an older broken download) does not count.
+        if os.path.isfile(comfy_ui_path):
             return True
-        
+
         # If not in ComfyUI directory, check storage and restore if found
         model_dir = config.comfy_ui_model_paths.get(type)
         flat_name = flat_repo_local_dir_name(repo_id)
         storage_path = os.path.join(os.path.abspath(model_dir), flat_name)
-        
-        if os.path.exists(storage_path):
+
+        if os.path.isfile(storage_path):
             # Restore from storage to ComfyUI directory
             logging.info(f'Restoring {type} model {repo_id} from storage to ComfyUI directory')
             if copy_faceswap_facerestore_to_comfyui(type, repo_id):


### PR DESCRIPTION
…t file

A prior _merge_move change nested faceswap/facerestore models inside a directory (Aitrepreneur---...---inswapper_128.onnx/inswapper_128.onnx) instead of naming the flat file itself, so ReActor's osp.isfile() failed. Existence checks using os.path.exists treated the stale dir as present, blocking re-download.

- model_downloader: move reactor models to the flat name directly, clearing any stale directory first
- utils: require isfile (not exists) so broken installs self-heal
- add regression tests

**Description:**

Please provide a brief description of the changes made in this pull request.

**Related Issue:**

If this pull request is related to any existing issue, please mention the issue number here.

**Changes Made:**

Please list down the specific changes made in this pull request.

**Testing Done:**

Please describe the testing that has been done to ensure the changes made in this pull request are functioning as expected.

**Screenshots:**

If applicable, please provide screenshots or GIFs or videos to visually demonstrate the changes made.

**Checklist:**

- [ ] I have tested the changes locally.
- [ ] I have self-reviewed the code changes.
- [ ] I have updated the documentation, if necessary.
