### PR TITLE
Contextual help mode (? toggle), ported to dev-leslie with fixes

### DIFF
--- a/WebUI/electron/test/help/helpTopics.test.ts
+++ b/WebUI/electron/test/help/helpTopics.test.ts
@@ -1,0 +1,176 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import {
+  HELP_PANEL_ID,
+  HELP_TOGGLE_ID,
+  HELP_TOPICS,
+  getHelpTopic,
+  resolveHelpTarget,
+} from '@/assets/js/help/helpTopics'
+import { TOUR_STEPS, TOUR_STEPS_ALTERNATIVE } from '@/assets/js/help/tourSteps'
+
+// Anchors the demo tour uses that are intentionally not click-to-learn targets.
+const TOUR_ONLY_ANCHORS = new Set(['#demo-buttons-group'])
+
+describe('help topic registry', () => {
+  it('gives every demo-tour anchor a click-to-learn topic', () => {
+    const anchors = [...TOUR_STEPS, ...TOUR_STEPS_ALTERNATIVE]
+      .map((step) => step.id)
+      .filter((id) => !TOUR_ONLY_ANCHORS.has(id))
+
+    expect(anchors.length).toBeGreaterThan(0)
+    for (const anchor of anchors) {
+      expect(
+        getHelpTopic(anchor.replace('#', '')),
+        `missing help topic for ${anchor}`,
+      ).toBeDefined()
+    }
+  })
+
+  it('gives every topic a title and a body', () => {
+    for (const [id, topic] of Object.entries(HELP_TOPICS)) {
+      expect(topic.title, `${id} title`).toBeTruthy()
+      expect(topic.body, `${id} body`).toBeTruthy()
+    }
+  })
+
+  it('does not resolve inherited Object properties as topics', () => {
+    expect(getHelpTopic('constructor')).toBeUndefined()
+    expect(getHelpTopic('toString')).toBeUndefined()
+  })
+})
+
+// `resolveHelpTarget` only reads `id`, `getAttribute` and `parentElement`, so a
+// minimal stand-in keeps it covered under vitest's `node` environment. The repo
+// ships no DOM test environment and adding one would rewrite the whole lockfile,
+// which npm re-resolves from scratch on any install.
+type Attrs = Record<string, string>
+
+type StubElement = {
+  id: string
+  parentElement: StubElement | null
+  getAttribute: (name: string) => string | null
+  __isStubElement: true
+}
+
+function makeElement(attrs: Attrs = {}): StubElement {
+  const { id = '', ...rest } = attrs
+  return {
+    id,
+    parentElement: null,
+    getAttribute: (name) => rest[name] ?? null,
+    __isStubElement: true,
+  }
+}
+
+/** Stands in for the DOM constructor so the `instanceof HTMLElement` guard passes. */
+const HTMLElementStub = {
+  [Symbol.hasInstance]: (value: unknown) =>
+    typeof value === 'object' && value !== null && '__isStubElement' in value,
+}
+
+const documentBody = makeElement({ id: 'stub-body' })
+
+/** The stub replaces `globalThis.HTMLElement`, so it is a valid target at runtime. */
+function target(el: StubElement): EventTarget {
+  return el as unknown as EventTarget
+}
+
+/** Builds an outermost-to-innermost chain under `document.body`, returning the leaf. */
+function chain(...levels: Attrs[]): StubElement {
+  const nodes = levels.map(makeElement)
+  nodes.forEach((node, i) => {
+    node.parentElement = i === 0 ? documentBody : nodes[i - 1]
+  })
+  return nodes[nodes.length - 1]
+}
+
+beforeAll(() => {
+  Object.assign(globalThis, { HTMLElement: HTMLElementStub, document: { body: documentBody } })
+})
+
+afterAll(() => {
+  Reflect.deleteProperty(globalThis, 'HTMLElement')
+  Reflect.deleteProperty(globalThis, 'document')
+})
+
+describe('resolveHelpTarget', () => {
+  it('resolves a static topic from an element id', () => {
+    expect(resolveHelpTarget(target(chain({ id: 'send-button' })))).toMatchObject({
+      kind: 'static',
+      topicId: 'send-button',
+    })
+  })
+
+  it('walks up to the nearest annotated ancestor', () => {
+    const resolved = resolveHelpTarget(target(chain({ id: 'mode-buttons' }, {}, { id: 'leaf' })))
+    expect(resolved).toMatchObject({ kind: 'static', topicId: 'mode-buttons' })
+    expect((resolved as unknown as { element: StubElement }).element.id).toBe('mode-buttons')
+  })
+
+  it('prefers data-aipg-help over the element id', () => {
+    const el = chain({ id: 'send-button', 'data-aipg-help': 'prompt-input' })
+    expect(resolveHelpTarget(target(el))).toMatchObject({
+      kind: 'static',
+      topicId: 'prompt-input',
+    })
+  })
+
+  it('resolves a preset tile to its preset name', () => {
+    const thumb = chain({ 'data-aipg-preset-name': 'Line Art' }, { id: 'thumb' })
+    expect(resolveHelpTarget(target(thumb))).toMatchObject({
+      kind: 'preset',
+      presetName: 'Line Art',
+    })
+  })
+
+  it('resolves a variant tile using the internal variant name', () => {
+    const label = chain(
+      { 'data-aipg-preset-name': 'Line Art', 'data-aipg-variant-name': 'ov-fast' },
+      { id: 'label' },
+    )
+    expect(resolveHelpTarget(target(label))).toMatchObject({
+      kind: 'preset-variant',
+      presetName: 'Line Art',
+      variantName: 'ov-fast',
+    })
+  })
+
+  it('prefers the innermost preset annotation over an enclosing static topic', () => {
+    const tile = chain(
+      { 'data-aipg-help': 'preset-selector' },
+      { 'data-aipg-preset-name': 'Line Art' },
+    )
+    expect(resolveHelpTarget(target(tile))).toMatchObject({
+      kind: 'preset',
+      presetName: 'Line Art',
+    })
+  })
+
+  it('prefers the preset annotation when one element carries both', () => {
+    const both = chain({ 'data-aipg-help': 'preset-selector', 'data-aipg-preset-name': 'Line Art' })
+    expect(resolveHelpTarget(target(both))).toMatchObject({
+      kind: 'preset',
+      presetName: 'Line Art',
+    })
+  })
+
+  it('falls back to the enclosing static topic outside a preset tile', () => {
+    const row = chain({ 'data-aipg-help': 'preset-selector' })
+    expect(resolveHelpTarget(target(row))).toMatchObject({
+      kind: 'static',
+      topicId: 'preset-selector',
+    })
+  })
+
+  it('never explains help mode itself', () => {
+    expect(resolveHelpTarget(target(chain({ id: HELP_TOGGLE_ID })))).toBeNull()
+    const gotIt = chain({ id: HELP_PANEL_ID }, { 'data-aipg-help': 'send-button' })
+    expect(resolveHelpTarget(target(gotIt))).toBeNull()
+  })
+
+  it('returns null for unannotated elements and non-elements', () => {
+    expect(resolveHelpTarget(target(chain({}, { id: 'plain' })))).toBeNull()
+    expect(resolveHelpTarget(null)).toBeNull()
+    expect(resolveHelpTarget('not an element' as unknown as EventTarget)).toBeNull()
+  })
+})

--- a/WebUI/electron/test/help/helpTopics.test.ts
+++ b/WebUI/electron/test/help/helpTopics.test.ts
@@ -6,16 +6,15 @@ import {
   getHelpTopic,
   resolveHelpTarget,
 } from '@/assets/js/help/helpTopics'
-import { TOUR_STEPS, TOUR_STEPS_ALTERNATIVE } from '@/assets/js/help/tourSteps'
+import { TOUR_ONLY_ANCHORS, TOUR_STEPS, TOUR_STEPS_ALTERNATIVE } from '@/assets/js/help/tourSteps'
 
-// Anchors the demo tour uses that are intentionally not click-to-learn targets.
-const TOUR_ONLY_ANCHORS = new Set(['#demo-buttons-group'])
+const tourOnly = new Set<string>(TOUR_ONLY_ANCHORS)
 
 describe('help topic registry', () => {
   it('gives every demo-tour anchor a click-to-learn topic', () => {
     const anchors = [...TOUR_STEPS, ...TOUR_STEPS_ALTERNATIVE]
       .map((step) => step.id)
-      .filter((id) => !TOUR_ONLY_ANCHORS.has(id))
+      .filter((id) => !tourOnly.has(id))
 
     expect(anchors.length).toBeGreaterThan(0)
     for (const anchor of anchors) {
@@ -23,6 +22,18 @@ describe('help topic registry', () => {
         getHelpTopic(anchor.replace('#', '')),
         `missing help topic for ${anchor}`,
       ).toBeDefined()
+    }
+  })
+
+  // The tour may point at help mode's own chrome; the click-to-learn layer must not,
+  // or clicking the toggle in help mode would try to explain the toggle.
+  it('keeps tour-only anchors out of the click-to-learn topics', () => {
+    expect(TOUR_ONLY_ANCHORS.length).toBeGreaterThan(0)
+    for (const anchor of TOUR_ONLY_ANCHORS) {
+      expect(
+        getHelpTopic(anchor.replace('#', '')),
+        `${anchor} should not be a help topic`,
+      ).toBeUndefined()
     }
   })
 

--- a/WebUI/electron/test/help/presetHelp.test.ts
+++ b/WebUI/electron/test/help/presetHelp.test.ts
@@ -1,0 +1,138 @@
+import { describe, expect, it } from 'vitest'
+import {
+  extendedDescriptionText,
+  findPresetByName,
+  helpTopicFromPreset,
+  helpTopicFromPresetVariant,
+} from '@/assets/js/help/presetHelp'
+import type { Preset } from '@/assets/js/store/presets'
+
+function makePreset(overrides: Partial<Preset> = {}): Preset {
+  return {
+    type: 'comfy',
+    name: 'Line Art',
+    backend: 'comfyui',
+    displayPriority: 0,
+    tags: [],
+    settings: [],
+    comfyUiApiWorkflow: {},
+    ...overrides,
+  } as unknown as Preset
+}
+
+describe('extendedDescriptionText', () => {
+  it('returns the plain string form as-is', () => {
+    expect(extendedDescriptionText(makePreset({ extendedDescription: 'How to use it' }))).toBe(
+      'How to use it',
+    )
+  })
+
+  it('picks the entry for the requested variant', () => {
+    const preset = makePreset({ extendedDescription: { fast: 'Quick draft', quality: 'Slow' } })
+    expect(extendedDescriptionText(preset, 'quality')).toBe('Slow')
+  })
+
+  it('falls back to the first entry when the variant has no text', () => {
+    const preset = makePreset({ extendedDescription: { fast: 'Quick draft' } })
+    expect(extendedDescriptionText(preset, 'unknown-variant')).toBe('Quick draft')
+  })
+
+  it('tolerates a missing preset or missing description', () => {
+    expect(extendedDescriptionText(null)).toBeUndefined()
+    expect(extendedDescriptionText(makePreset())).toBeUndefined()
+  })
+})
+
+describe('helpTopicFromPreset', () => {
+  it('combines description, extended description and tags', () => {
+    const preset = makePreset({
+      description: 'Turns photos into line art.',
+      extendedDescription: 'Drop in a photo, then hit send.',
+      tags: ['fast', 'stylize'],
+    })
+    const topic = helpTopicFromPreset(preset, 'Line Art')
+    expect(topic.title).toBe('Line Art')
+    expect(topic.body).toContain('Turns photos into line art.')
+    expect(topic.body).toContain('Drop in a photo, then hit send.')
+    expect(topic.body).toContain('Tags: fast, stylize')
+  })
+
+  it('does not repeat the description when the extended text is identical', () => {
+    const preset = makePreset({ description: 'Same text', extendedDescription: 'Same text' })
+    const occurrences = helpTopicFromPreset(preset, 'Line Art').body.split('Same text').length - 1
+    expect(occurrences).toBe(1)
+  })
+
+  it('falls back to the DOM-provided name when the preset is not loaded', () => {
+    expect(helpTopicFromPreset(null, 'Some Preset').title).toBe('Some Preset')
+  })
+})
+
+describe('helpTopicFromPresetVariant', () => {
+  // Regression: variant help used to be looked up by the *display* label, so any
+  // variant with a `displayName` silently lost its title and extended description.
+  it('resolves a variant by internal name even when it has a display label', () => {
+    const preset = makePreset({
+      name: 'Line Art',
+      variants: [{ name: 'ov-fast', displayName: 'Fast', overrides: {} }],
+      extendedDescription: { 'ov-fast': 'OpenVINO fast path' },
+    } as Partial<Preset>)
+
+    const topic = helpTopicFromPresetVariant(preset, 'Line Art', 'ov-fast')
+    expect(topic.title).toBe('Line Art — ov-fast')
+    expect(topic.body).toContain('OpenVINO fast path')
+  })
+
+  // Guards the binding contract in VariantSelector.vue: it must publish
+  // `option.value` (internal name), never `option.name` (display label). A label
+  // misses the extendedDescription map, and the fallback-to-first then quietly
+  // describes a different variant, which is the bug this documents.
+  it('describes the wrong variant when handed a display label', () => {
+    const preset = makePreset({
+      name: 'Line Art',
+      variants: [
+        { name: 'ov-quality', displayName: 'Quality', overrides: {} },
+        { name: 'ov-fast', displayName: 'Fast', overrides: {} },
+      ],
+      extendedDescription: { 'ov-quality': 'Slow and detailed', 'ov-fast': 'Quick draft' },
+    } as Partial<Preset>)
+
+    expect(helpTopicFromPresetVariant(preset, 'Line Art', 'ov-fast').body).toContain('Quick draft')
+
+    const byLabel = helpTopicFromPresetVariant(preset, 'Line Art', 'Fast')
+    expect(byLabel.body).toContain('Slow and detailed')
+    expect(byLabel.body).not.toContain('Quick draft')
+  })
+
+  it('falls back to the base description when the variant has no extended text', () => {
+    const preset = makePreset({
+      description: 'Base blurb',
+      variants: [{ name: 'fast', overrides: {} }],
+    } as Partial<Preset>)
+    expect(helpTopicFromPresetVariant(preset, 'Line Art', 'fast').body).toContain('Base blurb')
+  })
+
+  it('degrades gracefully when the preset is not loaded', () => {
+    const topic = helpTopicFromPresetVariant(null, 'Line Art', 'fast')
+    expect(topic.title).toBe('fast')
+    expect(topic.body).toContain('Line Art')
+  })
+})
+
+describe('findPresetByName', () => {
+  const chat = makePreset({ type: 'chat', name: 'Sketch' })
+  const comfy = makePreset({ type: 'comfy', name: 'Sketch' })
+
+  it('prefers the type matching the active mode when names collide', () => {
+    expect(findPresetByName([chat, comfy], 'Sketch', 'comfy')).toBe(comfy)
+    expect(findPresetByName([chat, comfy], 'Sketch', 'chat')).toBe(chat)
+  })
+
+  it('falls back to the only match when the preferred type is absent', () => {
+    expect(findPresetByName([chat], 'Sketch', 'comfy')).toBe(chat)
+  })
+
+  it('returns null for an unknown name', () => {
+    expect(findPresetByName([chat, comfy], 'Nope', 'chat')).toBeNull()
+  })
+})

--- a/WebUI/src/App.vue
+++ b/WebUI/src/App.vue
@@ -68,6 +68,17 @@
         </button>
       </div>
       <button
+        v-if="globalSetup.loadingState === 'running'"
+        id="contextual-help-toggle"
+        type="button"
+        class="flex size-7 items-center justify-center rounded-full border border-border text-sm font-bold text-foreground transition-colors hover:bg-muted"
+        :class="{ 'bg-primary text-primary-foreground border-primary': contextualHelp.active }"
+        title="What's this? Click, then click a control to learn about it."
+        @click="contextualHelp.toggle()"
+      >
+        ?
+      </button>
+      <button
         v-if="!demoMode.enabled"
         :title="languages.COM_MINI"
         @click="miniWindow"
@@ -250,6 +261,7 @@
     <DemoModeOverlayDriverJsRef ref="demoModeOverlayDriverJs" />
     <DemoModeNotificationDots />
     <DemoModeAutoresetDialog v-if="demoMode.showResetDialog" />
+    <ContextualHelpLayer />
   </main>
 
   <footer
@@ -339,11 +351,14 @@ import DemoModeAutoresetDialog from '@/components/DemoModeAutoresetDialog.vue'
 import HomeAgentToggle from '@/components/HomeAgentToggle.vue'
 import MockChannelPanel from '@/components/MockChannelPanel.vue'
 import { useHomeAgent } from '@/assets/js/store/homeAgent'
+import ContextualHelpLayer from '@/components/ContextualHelpLayer.vue'
+import { useContextualHelp } from '@/assets/js/store/contextualHelp'
 
 const theme = useTheme()
 const globalSetup = useGlobalSetup()
 const productModeStore = useProductMode()
 const demoMode = useDemoMode()
+const contextualHelp = useContextualHelp()
 const dialogStore = useDialogStore()
 const promptStore = usePromptStore()
 const uiStore = useUIStore()

--- a/WebUI/src/App.vue
+++ b/WebUI/src/App.vue
@@ -53,20 +53,6 @@
       >
         <ServerStackIcon class="size-6 text-foreground"></ServerStackIcon>
       </button>
-      <div
-        id="demo-buttons-group"
-        v-if="demoMode.enabled && globalSetup.loadingState === 'running'"
-        class="flex gap-2"
-      >
-        <button
-          id="demo-need-help-button"
-          class="bg-demo-button text-white px-3 rounded text-xs cursor-pointer"
-          style="height: 30px; min-width: 90px"
-          @click="triggerHelpForCurrentMode(true)"
-        >
-          {{ languages.DEMO_NEED_HELP }}
-        </button>
-      </div>
       <button
         v-if="globalSetup.loadingState === 'running'"
         id="contextual-help-toggle"
@@ -511,14 +497,6 @@ function openSpecificSettings() {
 function openAppSettings() {
   if (demoMode.triggerFirstTimeHelp('app-settings-button')) return
   showAppSettings.value = true
-}
-
-function triggerHelpForCurrentMode(_force = false) {
-  demoModeOverlayDriverJs.value?.triggerContextHelp?.(
-    promptStore.getCurrentMode(),
-    showAppSettings.value,
-    showSpecificSettings.value,
-  )
 }
 
 function startTour() {

--- a/WebUI/src/App.vue
+++ b/WebUI/src/App.vue
@@ -74,6 +74,8 @@
         class="flex size-7 items-center justify-center rounded-full border border-border text-sm font-bold text-foreground transition-colors hover:bg-muted"
         :class="{ 'bg-primary text-primary-foreground border-primary': contextualHelp.active }"
         title="What's this? Click, then click a control to learn about it."
+        aria-label="Toggle help mode"
+        :aria-pressed="contextualHelp.active"
         @click="contextualHelp.toggle()"
       >
         ?

--- a/WebUI/src/assets/js/help/helpTopics.ts
+++ b/WebUI/src/assets/js/help/helpTopics.ts
@@ -14,6 +14,7 @@ export type HelpTopicId =
   | 'app-settings-button'
   | 'app-settings-sidebar'
   | 'show-history-button'
+  | 'preset-selector'
 
 export type HelpTopic = {
   title: string
@@ -82,6 +83,10 @@ export const HELP_TOPICS: Record<HelpTopicId, HelpTopic> = {
     title: 'History',
     body: 'Reopen past chat and generation history across modes.',
   },
+  'preset-selector': {
+    title: 'Presets',
+    body: 'Each tile is a preset tuned for a task (chat model, image workflow, etc.). Click a tile to select it; use help mode on a tile to read what that preset does.',
+  },
 }
 
 export function getHelpTopic(id: string): HelpTopic | undefined {
@@ -89,28 +94,52 @@ export function getHelpTopic(id: string): HelpTopic | undefined {
 }
 
 const MODE_BUTTON_PREFIX = 'mode-button-'
+const PRESET_NAME_ATTR = 'data-aipg-preset-name'
+const VARIANT_NAME_ATTR = 'data-aipg-variant-name'
 
-export function resolveHelpTarget(from: EventTarget | null): {
-  topicId: HelpTopicId
-  element: HTMLElement
-} | null {
+export type HelpResolveResult =
+  | { element: HTMLElement; kind: 'static'; topicId: HelpTopicId }
+  | { element: HTMLElement; kind: 'preset'; presetName: string }
+  | { element: HTMLElement; kind: 'preset-variant'; presetName: string; variantName: string }
+
+export function resolveHelpTarget(from: EventTarget | null): HelpResolveResult | null {
   let el = from instanceof HTMLElement ? from : null
   while (el && el !== document.body) {
     if (el.id === 'contextual-help-toggle' || el.closest('#contextual-help-panel')) {
       return null
     }
+
+    const variantName = el.getAttribute(VARIANT_NAME_ATTR)
+    const presetNameFromEl = el.getAttribute(PRESET_NAME_ATTR)
+    if (variantName && presetNameFromEl) {
+      return {
+        kind: 'preset-variant',
+        element: el,
+        presetName: presetNameFromEl,
+        variantName,
+      }
+    }
+
+    const presetHost = el.closest(`[${PRESET_NAME_ATTR}]`) as HTMLElement | null
+    if (presetHost) {
+      const presetName = presetHost.getAttribute(PRESET_NAME_ATTR)
+      if (presetName) {
+        return { kind: 'preset', element: presetHost, presetName }
+      }
+    }
+
     const attr = el.getAttribute('data-aipg-help')
     if (attr && getHelpTopic(attr)) {
-      return { topicId: attr as HelpTopicId, element: el }
+      return { kind: 'static', topicId: attr as HelpTopicId, element: el }
     }
     if (el.id && getHelpTopic(el.id)) {
-      return { topicId: el.id as HelpTopicId, element: el }
+      return { kind: 'static', topicId: el.id as HelpTopicId, element: el }
     }
     if (el.id === 'mode-buttons') {
-      return { topicId: 'mode-buttons', element: el }
+      return { kind: 'static', topicId: 'mode-buttons', element: el }
     }
     if (el.id.startsWith(MODE_BUTTON_PREFIX) && getHelpTopic(el.id)) {
-      return { topicId: el.id as HelpTopicId, element: el }
+      return { kind: 'static', topicId: el.id as HelpTopicId, element: el }
     }
     el = el.parentElement
   }

--- a/WebUI/src/assets/js/help/helpTopics.ts
+++ b/WebUI/src/assets/js/help/helpTopics.ts
@@ -1,0 +1,122 @@
+export type HelpTopicId =
+  | 'prompt-input'
+  | 'plus-icon'
+  | 'mode-buttons'
+  | 'mode-button-chat'
+  | 'mode-button-imageGen'
+  | 'mode-button-imageEdit'
+  | 'mode-button-video'
+  | 'send-button'
+  | 'camera-button'
+  | 'microphone-button'
+  | 'advanced-settings-button'
+  | 'advanced-settings-sidebar'
+  | 'app-settings-button'
+  | 'app-settings-sidebar'
+  | 'show-history-button'
+
+export type HelpTopic = {
+  title: string
+  body: string
+}
+
+/** POC copy — aligned with demo tour text; move to i18n when productizing. */
+export const HELP_TOPICS: Record<HelpTopicId, HelpTopic> = {
+  'prompt-input': {
+    title: 'Unified Prompt',
+    body: 'Write prompts here for every mode. Attach images or documents (plus icon or drag-and-drop) to guide chat, image edit, or other workflows.',
+  },
+  'plus-icon': {
+    title: 'Add images or documents',
+    body: 'Load files into the prompt or drag and drop onto the field. In Chat, ask about documents or images. For Image Edit, add images to edit. Use Prompt Settings presets (Vision, RAG, etc.) if a file type is not supported.',
+  },
+  'mode-buttons': {
+    title: 'Pick your mode',
+    body: 'These buttons switch what you generate: Chat, Image Gen, Image Edit, or Video. Each mode has its own presets and settings.',
+  },
+  'mode-button-chat': {
+    title: 'Chat mode',
+    body: 'Ask questions like a typical AI chat. In Prompt Settings, choose models and options such as RAG, reasoning, or vision.',
+  },
+  'mode-button-imageGen': {
+    title: 'Image Gen mode',
+    body: 'Describe a scene, character, or style to generate images. Presets in Prompt Settings control quality, speed, and look.',
+  },
+  'mode-button-imageEdit': {
+    title: 'Image Edit mode',
+    body: 'Edit photos by describing changes. Use presets to upscale, inpaint, outpaint, create 3D from images, and more.',
+  },
+  'mode-button-video': {
+    title: 'Video mode',
+    body: 'Create short video clips from text prompts, optionally guided by reference images or video.',
+  },
+  'send-button': {
+    title: 'Send',
+    body: 'Starts generation for the current mode. While a run is in progress this becomes Stop.',
+  },
+  'camera-button': {
+    title: 'Camera',
+    body: 'Capture a photo from your camera and attach it to the prompt for vision-capable chat models.',
+  },
+  'microphone-button': {
+    title: 'Microphone',
+    body: 'Record speech into the prompt after Speech to Text is enabled in App Settings.',
+  },
+  'advanced-settings-button': {
+    title: 'Prompt settings',
+    body: 'Mode-specific presets and options: model, tokens, aspect ratio, seeds, and more. This is where you tune each workflow.',
+  },
+  'advanced-settings-sidebar': {
+    title: 'Prompt settings panel',
+    body: 'Browse presets and adjust parameters for the active mode. Changes apply to the next generation.',
+  },
+  'app-settings-button': {
+    title: 'App settings',
+    body: 'Language, theme, backend installation, speech mode, and other application-wide options.',
+  },
+  'app-settings-sidebar': {
+    title: 'App settings panel',
+    body: 'Configure backends, appearance, and global features from this sidebar.',
+  },
+  'show-history-button': {
+    title: 'History',
+    body: 'Reopen past chat and generation history across modes.',
+  },
+}
+
+export function getHelpTopic(id: string): HelpTopic | undefined {
+  return HELP_TOPICS[id as HelpTopicId]
+}
+
+const MODE_BUTTON_PREFIX = 'mode-button-'
+
+export function resolveHelpTarget(from: EventTarget | null): {
+  topicId: HelpTopicId
+  element: HTMLElement
+} | null {
+  let el = from instanceof HTMLElement ? from : null
+  while (el && el !== document.body) {
+    if (el.id === 'contextual-help-toggle' || el.closest('#contextual-help-panel')) {
+      return null
+    }
+    const attr = el.getAttribute('data-aipg-help')
+    if (attr && getHelpTopic(attr)) {
+      return { topicId: attr as HelpTopicId, element: el }
+    }
+    if (el.id && getHelpTopic(el.id)) {
+      return { topicId: el.id as HelpTopicId, element: el }
+    }
+    if (el.id === 'mode-buttons') {
+      return { topicId: 'mode-buttons', element: el }
+    }
+    if (el.id.startsWith(MODE_BUTTON_PREFIX) && getHelpTopic(el.id)) {
+      return { topicId: el.id as HelpTopicId, element: el }
+    }
+    el = el.parentElement
+  }
+  return null
+}
+
+export function isHelpAnnotatedElement(el: HTMLElement): boolean {
+  return resolveHelpTarget(el) !== null
+}

--- a/WebUI/src/assets/js/help/helpTopics.ts
+++ b/WebUI/src/assets/js/help/helpTopics.ts
@@ -1,3 +1,8 @@
+/**
+ * Canonical list of DOM ids that carry help copy. The demo-mode tour
+ * (`tourSteps.ts`) anchors its steps to the same ids, so keeping the list in one
+ * place is what stops the two surfaces from drifting apart.
+ */
 export type HelpTopicId =
   | 'prompt-input'
   | 'plus-icon'
@@ -21,7 +26,12 @@ export type HelpTopic = {
   body: string
 }
 
-/** POC copy — aligned with demo tour text; move to i18n when productizing. */
+/**
+ * Short "what is this" copy for click-to-learn help mode. The demo tour uses the
+ * longer, guided-narration variants in `tourSteps.ts` for the same anchors.
+ *
+ * POC copy — move to i18n (`src/assets/i18n/*.json`) when productizing.
+ */
 export const HELP_TOPICS: Record<HelpTopicId, HelpTopic> = {
   'prompt-input': {
     title: 'Unified Prompt',
@@ -90,10 +100,15 @@ export const HELP_TOPICS: Record<HelpTopicId, HelpTopic> = {
 }
 
 export function getHelpTopic(id: string): HelpTopic | undefined {
-  return HELP_TOPICS[id as HelpTopicId]
+  return Object.prototype.hasOwnProperty.call(HELP_TOPICS, id)
+    ? HELP_TOPICS[id as HelpTopicId]
+    : undefined
 }
 
-const MODE_BUTTON_PREFIX = 'mode-button-'
+export const HELP_TOGGLE_ID = 'contextual-help-toggle'
+export const HELP_PANEL_ID = 'contextual-help-panel'
+
+const HELP_ATTR = 'data-aipg-help'
 const PRESET_NAME_ATTR = 'data-aipg-preset-name'
 const VARIANT_NAME_ATTR = 'data-aipg-variant-name'
 
@@ -102,50 +117,38 @@ export type HelpResolveResult =
   | { element: HTMLElement; kind: 'preset'; presetName: string }
   | { element: HTMLElement; kind: 'preset-variant'; presetName: string; variantName: string }
 
-export function resolveHelpTarget(from: EventTarget | null): HelpResolveResult | null {
-  let el = from instanceof HTMLElement ? from : null
-  while (el && el !== document.body) {
-    if (el.id === 'contextual-help-toggle' || el.closest('#contextual-help-panel')) {
-      return null
-    }
-
-    const variantName = el.getAttribute(VARIANT_NAME_ATTR)
-    const presetNameFromEl = el.getAttribute(PRESET_NAME_ATTR)
-    if (variantName && presetNameFromEl) {
-      return {
-        kind: 'preset-variant',
-        element: el,
-        presetName: presetNameFromEl,
-        variantName,
-      }
-    }
-
-    const presetHost = el.closest(`[${PRESET_NAME_ATTR}]`) as HTMLElement | null
-    if (presetHost) {
-      const presetName = presetHost.getAttribute(PRESET_NAME_ATTR)
-      if (presetName) {
-        return { kind: 'preset', element: presetHost, presetName }
-      }
-    }
-
-    const attr = el.getAttribute('data-aipg-help')
-    if (attr && getHelpTopic(attr)) {
-      return { kind: 'static', topicId: attr as HelpTopicId, element: el }
-    }
-    if (el.id && getHelpTopic(el.id)) {
-      return { kind: 'static', topicId: el.id as HelpTopicId, element: el }
-    }
-    if (el.id === 'mode-buttons') {
-      return { kind: 'static', topicId: 'mode-buttons', element: el }
-    }
-    if (el.id.startsWith(MODE_BUTTON_PREFIX) && getHelpTopic(el.id)) {
-      return { kind: 'static', topicId: el.id as HelpTopicId, element: el }
-    }
-    el = el.parentElement
+function isOwnChrome(from: HTMLElement): boolean {
+  for (let el: HTMLElement | null = from; el; el = el.parentElement) {
+    if (el.id === HELP_TOGGLE_ID || el.id === HELP_PANEL_ID) return true
   }
-  return null
+  return false
 }
 
-export function isHelpAnnotatedElement(el: HTMLElement): boolean {
-  return resolveHelpTarget(el) !== null
+/**
+ * Walks up from an event target to the nearest element carrying help metadata.
+ * Own chrome (the toggle and the panel) resolves to `null` so help mode never
+ * explains itself.
+ */
+export function resolveHelpTarget(from: EventTarget | null): HelpResolveResult | null {
+  if (!(from instanceof HTMLElement)) return null
+  if (isOwnChrome(from)) return null
+
+  for (let el: HTMLElement | null = from; el && el !== document.body; el = el.parentElement) {
+    // A variant tile carries both attributes; the variant name is the internal
+    // name, not the display label, so preset lookups line up.
+    const presetName = el.getAttribute(PRESET_NAME_ATTR)
+    const variantName = el.getAttribute(VARIANT_NAME_ATTR)
+    if (presetName && variantName) {
+      return { kind: 'preset-variant', element: el, presetName, variantName }
+    }
+    if (presetName) {
+      return { kind: 'preset', element: el, presetName }
+    }
+
+    const topicId = el.getAttribute(HELP_ATTR) ?? el.id
+    if (getHelpTopic(topicId)) {
+      return { kind: 'static', topicId: topicId as HelpTopicId, element: el }
+    }
+  }
+  return null
 }

--- a/WebUI/src/assets/js/help/presetHelp.ts
+++ b/WebUI/src/assets/js/help/presetHelp.ts
@@ -1,0 +1,67 @@
+import type { Preset } from '@/assets/js/store/presets'
+import type { HelpTopic } from '@/assets/js/help/helpTopics'
+
+/**
+ * The preset's how-to text. `extendedDescription` is either a single string or a
+ * map keyed by *internal* variant name; when the requested variant has no entry we
+ * fall back to the first one so there is always something to show.
+ */
+export function extendedDescriptionText(
+  preset: Preset | null | undefined,
+  variantName?: string | null,
+): string | undefined {
+  const raw = preset?.extendedDescription
+  if (raw == null) return undefined
+  if (typeof raw === 'string') return raw
+  if (variantName && variantName in raw) return raw[variantName]
+  const first = Object.values(raw)[0]
+  return typeof first === 'string' ? first : undefined
+}
+
+export function helpTopicFromPreset(preset: Preset | null | undefined, presetName: string): HelpTopic {
+  if (!preset) {
+    return {
+      title: presetName,
+      body: 'Preset for the current mode. Click to select it, then adjust model and workflow options in the panel below.',
+    }
+  }
+
+  const parts: string[] = []
+  if (preset.description) parts.push(preset.description)
+  const extended = extendedDescriptionText(preset)
+  if (extended && extended !== preset.description) parts.push(extended)
+  if (preset.tags.length > 0) {
+    parts.push(`Tags: ${preset.tags.join(', ')}`)
+  }
+
+  return {
+    title: preset.name,
+    body:
+      parts.join('\n\n') ||
+      `Use the ${preset.name} preset for this workflow. Select it to load its default settings.`,
+  }
+}
+
+export function helpTopicFromPresetVariant(
+  preset: Preset | null | undefined,
+  presetName: string,
+  variantName: string,
+): HelpTopic {
+  if (!preset) {
+    return {
+      title: variantName,
+      body: `Variant of ${presetName}. Select to apply this configuration.`,
+    }
+  }
+
+  const variant = preset.variants?.find((v) => v.name === variantName)
+  const parts: string[] = [`Variant of ${preset.name}.`]
+  const extended = extendedDescriptionText(preset, variantName)
+  if (extended) parts.push(extended)
+  else if (preset.description) parts.push(preset.description)
+
+  return {
+    title: variant ? `${preset.name} — ${variant.name}` : variantName,
+    body: parts.join('\n\n'),
+  }
+}

--- a/WebUI/src/assets/js/help/presetHelp.ts
+++ b/WebUI/src/assets/js/help/presetHelp.ts
@@ -18,7 +18,10 @@ export function extendedDescriptionText(
   return typeof first === 'string' ? first : undefined
 }
 
-export function helpTopicFromPreset(preset: Preset | null | undefined, presetName: string): HelpTopic {
+export function helpTopicFromPreset(
+  preset: Preset | null | undefined,
+  presetName: string,
+): HelpTopic {
   if (!preset) {
     return {
       title: presetName,
@@ -40,6 +43,20 @@ export function helpTopicFromPreset(preset: Preset | null | undefined, presetNam
       parts.join('\n\n') ||
       `Use the ${preset.name} preset for this workflow. Select it to load its default settings.`,
   }
+}
+
+/**
+ * Presets are addressed by name in the DOM, and a chat preset can share a name with
+ * a comfy one, so prefer the type that matches the mode the user is looking at.
+ */
+export function findPresetByName(
+  presets: Preset[],
+  name: string,
+  preferredType?: 'chat' | 'comfy',
+): Preset | null {
+  const matches = presets.filter((p) => p.name === name)
+  if (matches.length === 0) return null
+  return matches.find((p) => p.type === preferredType) ?? matches[0]
 }
 
 export function helpTopicFromPresetVariant(

--- a/WebUI/src/assets/js/help/tourSteps.ts
+++ b/WebUI/src/assets/js/help/tourSteps.ts
@@ -1,11 +1,14 @@
 import type { HelpTopicId } from '@/assets/js/help/helpTopics'
 
 /**
- * Anchors the demo tour uses that are not click-to-learn help targets.
- * Everything else must be a `HelpTopicId`, so renaming an id in one surface
- * fails type-check in the other instead of silently orphaning a step.
+ * Anchors the demo tour uses that are deliberately not click-to-learn targets.
+ * The help toggle is one: help mode refuses to explain its own chrome. Everything
+ * else must be a `HelpTopicId`, so renaming an id in one surface fails type-check
+ * in the other instead of silently orphaning a step.
  */
-type TourOnlyAnchor = '#demo-buttons-group'
+export const TOUR_ONLY_ANCHORS = ['#contextual-help-toggle'] as const
+
+type TourOnlyAnchor = (typeof TOUR_ONLY_ANCHORS)[number]
 
 export type TourStep = {
   id: `#${HelpTopicId}` | TourOnlyAnchor
@@ -14,13 +17,13 @@ export type TourStep = {
   align?: 'start' | 'center' | 'end'
 }
 
-/** Guided-narration copy for the demo-mode walkthrough (`Need Help` → full tour). */
+/** Guided-narration copy for the demo-mode walkthrough, auto-started in demo mode. */
 export const TOUR_STEPS: TourStep[] = [
   {
-    id: '#demo-buttons-group',
+    id: '#contextual-help-toggle',
     title: 'Welcome to Intel AI-Playground!',
     descr:
-      'Intel AI-Playground is a generative AI app that provides local-powered chat, image, and video capabilities. You can get context-specific help with the "Need Help" button. Click "Next" or press "Right" to start the tour.',
+      'Intel AI-Playground is a generative AI app that provides local-powered chat, image, and video capabilities. Whenever you want to know what something does, click this "?" button and then click the control — help mode explains it without changing anything. Click "Next" or press "Right" to start the tour.',
   },
   {
     id: '#mode-buttons',

--- a/WebUI/src/assets/js/help/tourSteps.ts
+++ b/WebUI/src/assets/js/help/tourSteps.ts
@@ -1,0 +1,109 @@
+import type { HelpTopicId } from '@/assets/js/help/helpTopics'
+
+/**
+ * Anchors the demo tour uses that are not click-to-learn help targets.
+ * Everything else must be a `HelpTopicId`, so renaming an id in one surface
+ * fails type-check in the other instead of silently orphaning a step.
+ */
+type TourOnlyAnchor = '#demo-buttons-group'
+
+export type TourStep = {
+  id: `#${HelpTopicId}` | TourOnlyAnchor
+  title: string
+  descr: string
+  align?: 'start' | 'center' | 'end'
+}
+
+/** Guided-narration copy for the demo-mode walkthrough (`Need Help` → full tour). */
+export const TOUR_STEPS: TourStep[] = [
+  {
+    id: '#demo-buttons-group',
+    title: 'Welcome to Intel AI-Playground!',
+    descr:
+      'Intel AI-Playground is a generative AI app that provides local-powered chat, image, and video capabilities. You can get context-specific help with the "Need Help" button. Click "Next" or press "Right" to start the tour.',
+  },
+  {
+    id: '#mode-buttons',
+    title: 'Pick your Mode',
+    descr:
+      'Here are multiple mode buttons, that define the type of content you are generating. Select any one of these modes later to explore each. Little dots generally indicate additional help is available when clicking the first time.',
+  },
+  {
+    id: '#prompt-input',
+    title: 'Unified Prompt',
+    descr:
+      'This is your Prompt field. This is the core experience of AI Playground, across all features of the app. This is where you write a prompt, add images or documents to guide your content, and select modes for the type of content you want to generate.',
+  },
+  {
+    id: '#send-button',
+    title: 'Ready to start?',
+    descr:
+      'This is the magic button that will start a generation. Select a mode like Chat, enter a question and click this button to get your first response.',
+    align: 'end',
+  },
+]
+
+/** Per-control copy used by the mini tours triggered from individual buttons. */
+export const TOUR_STEPS_ALTERNATIVE: TourStep[] = [
+  {
+    id: '#plus-icon',
+    title: 'Add Images or Documents',
+    descr:
+      "The PLUS icon allows you to load content like documents or images to the prompt. Alternatively you can also drag and drop content here. When added this content is part of your generation. In Chat mode you can ask questions about a document or an image. For Image Edit you can add images you want to edit. Note: If you're not able to load a certain type of document, check Prompt Settings as you might need to select a preset like Vision to support images, or RAG to support text documents",
+  },
+  {
+    id: '#mode-button-chat',
+    title: 'Chat Mode',
+    descr:
+      'Chat works like a typical AI chat. You can type questions to get information on almost any topic you can imagine. In the settings you can select from a variety of chat options where you can do document search, work with Reasoning or Vision models, and more. Click the prompt input to see a sample prompt!',
+  },
+  {
+    id: '#mode-button-imageGen',
+    title: 'Image Mode',
+    descr:
+      "The Image Gen mode allows you to generate images from text you enter. Describe a scene or character and style (photographic, watercolor, etc), you wish to generate, and have watching your ideas come to life. When in this mode, you'll find ready to go presets in the Prompt Settings that allow you to create images using generative models to achieve different levels of realism and generation times. Click the prompt input to see a sample prompt!",
+  },
+  {
+    id: '#mode-button-imageEdit',
+    title: 'Image Edit Mode',
+    descr:
+      'The Image Edit mode allows you to edit existing images or photos, often by describing what to change. Simply drag in a photo, select an editing Preset in Prompt Settings where you can upscale images, edit images with precision, generate 3D models from images, and more. An input image is already pre-selected for you. Click the prompt input to see a sample prompt!',
+  },
+  {
+    id: '#mode-button-video',
+    title: 'Video Mode',
+    descr:
+      'Video generation allows you to create short video clips from your imagination either from prompt or guided by images and video.',
+  },
+  {
+    id: '#microphone-button',
+    title: 'Mic Button',
+    descr:
+      "The Mic button is only active after you've selected and turned on Speech Mode in app settings.When done you simply click this icon, start talking in a language you're comfortable speaking, then click again. You'll see your speech written out as text in the prompt field.",
+  },
+  {
+    id: '#camera-button',
+    title: 'Camera Button',
+    descr:
+      'Click this button to capture an image from your camera. The captured image will be added to your prompt for vision-capable models to analyze.',
+  },
+  {
+    id: '#advanced-settings-button',
+    title: 'Prompt Settings',
+    descr:
+      'Each mode has prompt settings specific to the mode of content you are generating. Here you will find ready to go preset to do targeted tasks. Each preset is already dialed in to go, but you choose to adjust options and own values from Max Tokens in Chat, to Aspect Ratio settings for Image Gen. Prompt settings is at the heart of getting AI Playground to do what you want it to do. Select a Mode and explore what our Prompt Settings have to offer.',
+    align: 'end',
+  },
+  {
+    id: '#app-settings-button',
+    title: 'Application Settings',
+    descr:
+      "Select this gear icon to see a list of application-level settings, from to language options, installation manager, and speech mode. You'll find important application settings here. Click here and select the Theme menu to give AI Playground different looks.",
+  },
+  {
+    id: '#show-history-button',
+    title: 'History Panel',
+    descr:
+      "The History Panel keeps track of all that you've generated. History will show you the latest content from each mode you used. Use this to scroll back through and revisit previous discussion and content generated from AI Playground.",
+  },
+]

--- a/WebUI/src/assets/js/store/contextualHelp.ts
+++ b/WebUI/src/assets/js/store/contextualHelp.ts
@@ -1,6 +1,6 @@
 import { acceptHMRUpdate, defineStore } from 'pinia'
 import { computed, ref } from 'vue'
-import { getHelpTopic, type HelpTopicId } from '@/assets/js/help/helpTopics'
+import { getHelpTopic, type HelpTopic, type HelpTopicId } from '@/assets/js/help/helpTopics'
 
 export type HelpPanelAnchor = {
   top: number
@@ -12,10 +12,11 @@ export type HelpPanelAnchor = {
 export const useContextualHelp = defineStore('contextualHelp', () => {
   const active = ref(false)
   const panelTopicId = ref<HelpTopicId | null>(null)
+  const panelTopicDynamic = ref<HelpTopic | null>(null)
   const anchor = ref<HelpPanelAnchor | null>(null)
 
-  const panelTopic = computed(() =>
-    panelTopicId.value ? getHelpTopic(panelTopicId.value) : undefined,
+  const panelTopic = computed(
+    () => panelTopicDynamic.value ?? (panelTopicId.value ? getHelpTopic(panelTopicId.value) : undefined),
   )
 
   function setAnchorFromElement(el: HTMLElement) {
@@ -28,13 +29,21 @@ export const useContextualHelp = defineStore('contextualHelp', () => {
     }
   }
 
-  function openPanel(topicId: HelpTopicId, el: HTMLElement) {
+  function openPanelForTopic(el: HTMLElement, topic: HelpTopic) {
+    panelTopicId.value = null
+    panelTopicDynamic.value = topic
+    setAnchorFromElement(el)
+  }
+
+  function openPanel(el: HTMLElement, topicId: HelpTopicId) {
+    panelTopicDynamic.value = null
     panelTopicId.value = topicId
     setAnchorFromElement(el)
   }
 
   function closePanel() {
     panelTopicId.value = null
+    panelTopicDynamic.value = null
     anchor.value = null
   }
 
@@ -55,9 +64,11 @@ export const useContextualHelp = defineStore('contextualHelp', () => {
   return {
     active,
     panelTopicId,
+    panelTopicDynamic,
     anchor,
     panelTopic,
     openPanel,
+    openPanelForTopic,
     closePanel,
     activate,
     deactivate,

--- a/WebUI/src/assets/js/store/contextualHelp.ts
+++ b/WebUI/src/assets/js/store/contextualHelp.ts
@@ -1,0 +1,70 @@
+import { acceptHMRUpdate, defineStore } from 'pinia'
+import { computed, ref } from 'vue'
+import { getHelpTopic, type HelpTopicId } from '@/assets/js/help/helpTopics'
+
+export type HelpPanelAnchor = {
+  top: number
+  left: number
+  width: number
+  height: number
+}
+
+export const useContextualHelp = defineStore('contextualHelp', () => {
+  const active = ref(false)
+  const panelTopicId = ref<HelpTopicId | null>(null)
+  const anchor = ref<HelpPanelAnchor | null>(null)
+
+  const panelTopic = computed(() =>
+    panelTopicId.value ? getHelpTopic(panelTopicId.value) : undefined,
+  )
+
+  function setAnchorFromElement(el: HTMLElement) {
+    const rect = el.getBoundingClientRect()
+    anchor.value = {
+      top: rect.top,
+      left: rect.left,
+      width: rect.width,
+      height: rect.height,
+    }
+  }
+
+  function openPanel(topicId: HelpTopicId, el: HTMLElement) {
+    panelTopicId.value = topicId
+    setAnchorFromElement(el)
+  }
+
+  function closePanel() {
+    panelTopicId.value = null
+    anchor.value = null
+  }
+
+  function activate() {
+    active.value = true
+  }
+
+  function deactivate() {
+    active.value = false
+    closePanel()
+  }
+
+  function toggle() {
+    if (active.value) deactivate()
+    else activate()
+  }
+
+  return {
+    active,
+    panelTopicId,
+    anchor,
+    panelTopic,
+    openPanel,
+    closePanel,
+    activate,
+    deactivate,
+    toggle,
+  }
+})
+
+if (import.meta.hot) {
+  import.meta.hot.accept(acceptHMRUpdate(useContextualHelp, import.meta.hot))
+}

--- a/WebUI/src/assets/js/store/contextualHelp.ts
+++ b/WebUI/src/assets/js/store/contextualHelp.ts
@@ -16,8 +16,12 @@ export const useContextualHelp = defineStore('contextualHelp', () => {
   const anchor = ref<HelpPanelAnchor | null>(null)
 
   const panelTopic = computed(
-    () => panelTopicDynamic.value ?? (panelTopicId.value ? getHelpTopic(panelTopicId.value) : undefined),
+    () =>
+      panelTopicDynamic.value ??
+      (panelTopicId.value ? getHelpTopic(panelTopicId.value) : undefined),
   )
+
+  const panelOpen = computed(() => panelTopic.value !== undefined && anchor.value !== null)
 
   function setAnchorFromElement(el: HTMLElement) {
     const rect = el.getBoundingClientRect()
@@ -67,6 +71,8 @@ export const useContextualHelp = defineStore('contextualHelp', () => {
     panelTopicDynamic,
     anchor,
     panelTopic,
+    panelOpen,
+    setAnchorFromElement,
     openPanel,
     openPanelForTopic,
     closePanel,

--- a/WebUI/src/components/ContextualHelpLayer.vue
+++ b/WebUI/src/components/ContextualHelpLayer.vue
@@ -7,8 +7,8 @@
       aria-live="polite"
     >
       <div
-        v-if="!contextualHelp.panelTopic"
-        class="pointer-events-none fixed bottom-24 left-1/2 z-[40016] max-w-md -translate-x-1/2 rounded-lg border border-border bg-popover px-4 py-2 text-center text-sm text-popover-foreground shadow-lg"
+        v-if="contextualHelp.active"
+        class="pointer-events-none fixed top-14 left-1/2 z-[40016] max-w-lg -translate-x-1/2 rounded-lg border border-primary/40 bg-primary/15 px-4 py-2.5 text-center text-sm font-medium text-foreground shadow-md backdrop-blur-sm"
       >
         Help mode — click a control to learn about it. Press Esc to exit.
       </div>
@@ -23,7 +23,7 @@
         <h2 :id="headingId" class="mb-2 text-base font-semibold">
           {{ contextualHelp.panelTopic.title }}
         </h2>
-        <p class="text-sm leading-relaxed text-muted-foreground">
+        <p class="text-sm leading-relaxed text-muted-foreground whitespace-pre-line">
           {{ contextualHelp.panelTopic.body }}
         </p>
         <div class="mt-4 flex flex-wrap items-center justify-between gap-2">
@@ -50,10 +50,13 @@
 <script setup lang="ts">
 import { computed, onBeforeUnmount, watch } from 'vue'
 import { resolveHelpTarget } from '@/assets/js/help/helpTopics'
+import { helpTopicFromPreset, helpTopicFromPresetVariant } from '@/assets/js/help/presetHelp'
 import { useContextualHelp } from '@/assets/js/store/contextualHelp'
+import { usePresets } from '@/assets/js/store/presets'
 import * as toast from '@/assets/js/toast'
 
 const contextualHelp = useContextualHelp()
+const presetsStore = usePresets()
 const headingId = 'contextual-help-heading'
 
 const HIGHLIGHT_CLASS = 'aipg-help-highlight'
@@ -110,7 +113,23 @@ function onCaptureClick(event: MouseEvent) {
 
   const resolved = resolveHelpTarget(target)
   if (resolved) {
-    contextualHelp.openPanel(resolved.topicId, resolved.element)
+    if (resolved.kind === 'static') {
+      contextualHelp.openPanel(resolved.element, resolved.topicId)
+    } else if (resolved.kind === 'preset') {
+      const basePreset =
+        presetsStore.presets.find((p) => p.name === resolved.presetName) ?? null
+      contextualHelp.openPanelForTopic(
+        resolved.element,
+        helpTopicFromPreset(basePreset, resolved.presetName),
+      )
+    } else {
+      const basePreset =
+        presetsStore.presets.find((p) => p.name === resolved.presetName) ?? null
+      contextualHelp.openPanelForTopic(
+        resolved.element,
+        helpTopicFromPresetVariant(basePreset, resolved.presetName, resolved.variantName),
+      )
+    }
     setHighlight(resolved.element)
     return
   }
@@ -119,7 +138,7 @@ function onCaptureClick(event: MouseEvent) {
 }
 
 function onCaptureMouseMove(event: MouseEvent) {
-  if (!contextualHelp.active || contextualHelp.panelTopicId) return
+  if (!contextualHelp.active || contextualHelp.panelTopic) return
   const target = event.target
   if (!(target instanceof HTMLElement)) {
     setHighlight(null)
@@ -132,7 +151,7 @@ function onCaptureMouseMove(event: MouseEvent) {
 function onKeyDown(event: KeyboardEvent) {
   if (!contextualHelp.active || event.key !== 'Escape') return
   event.preventDefault()
-  if (contextualHelp.panelTopicId) contextualHelp.closePanel()
+  if (contextualHelp.panelTopic) contextualHelp.closePanel()
   else contextualHelp.deactivate()
 }
 
@@ -162,7 +181,7 @@ watch(
 watch(
   () => contextualHelp.panelTopicId,
   (id) => {
-    if (!id) clearHighlight()
+    if (!id && !contextualHelp.panelTopicDynamic) clearHighlight()
   },
 )
 
@@ -192,7 +211,10 @@ body.aipg-help-mode #advanced-settings-button,
 body.aipg-help-mode #app-settings-button,
 body.aipg-help-mode #show-history-button,
 body.aipg-help-mode #app-settings-sidebar,
-body.aipg-help-mode #advanced-settings-sidebar {
+body.aipg-help-mode #advanced-settings-sidebar,
+body.aipg-help-mode [data-aipg-preset-name],
+body.aipg-help-mode [data-aipg-variant-name],
+body.aipg-help-mode #preset-selector {
   cursor: help;
 }
 

--- a/WebUI/src/components/ContextualHelpLayer.vue
+++ b/WebUI/src/components/ContextualHelpLayer.vue
@@ -1,0 +1,204 @@
+<template>
+  <Teleport to="body">
+    <div
+      v-if="contextualHelp.active"
+      id="contextual-help-panel"
+      class="pointer-events-none fixed inset-0 z-[40015]"
+      aria-live="polite"
+    >
+      <div
+        v-if="!contextualHelp.panelTopic"
+        class="pointer-events-none fixed bottom-24 left-1/2 z-[40016] max-w-md -translate-x-1/2 rounded-lg border border-border bg-popover px-4 py-2 text-center text-sm text-popover-foreground shadow-lg"
+      >
+        Help mode — click a control to learn about it. Press Esc to exit.
+      </div>
+      <div
+        v-if="contextualHelp.panelTopic && contextualHelp.anchor"
+        class="pointer-events-auto fixed z-[40020] w-[min(22rem,calc(100vw-2rem))] rounded-lg border border-border bg-popover p-4 text-popover-foreground shadow-xl"
+        :style="panelStyle"
+        role="dialog"
+        aria-modal="true"
+        :aria-labelledby="headingId"
+      >
+        <h2 :id="headingId" class="mb-2 text-base font-semibold">
+          {{ contextualHelp.panelTopic.title }}
+        </h2>
+        <p class="text-sm leading-relaxed text-muted-foreground">
+          {{ contextualHelp.panelTopic.body }}
+        </p>
+        <div class="mt-4 flex flex-wrap items-center justify-between gap-2">
+          <button
+            type="button"
+            class="rounded-md bg-primary px-3 py-1.5 text-sm font-medium text-primary-foreground hover:bg-primary/90"
+            @click="contextualHelp.closePanel()"
+          >
+            Got it
+          </button>
+          <button
+            type="button"
+            class="text-xs text-muted-foreground underline-offset-2 hover:underline"
+            @click="contextualHelp.deactivate()"
+          >
+            Exit help mode
+          </button>
+        </div>
+      </div>
+    </div>
+  </Teleport>
+</template>
+
+<script setup lang="ts">
+import { computed, onBeforeUnmount, watch } from 'vue'
+import { resolveHelpTarget } from '@/assets/js/help/helpTopics'
+import { useContextualHelp } from '@/assets/js/store/contextualHelp'
+import * as toast from '@/assets/js/toast'
+
+const contextualHelp = useContextualHelp()
+const headingId = 'contextual-help-heading'
+
+const HIGHLIGHT_CLASS = 'aipg-help-highlight'
+let highlightedEl: HTMLElement | null = null
+
+const panelStyle = computed(() => {
+  const a = contextualHelp.anchor
+  if (!a) return {}
+  const margin = 8
+  const panelW = Math.min(352, window.innerWidth - 32)
+  let top = a.top - margin
+  let left = a.left + a.width / 2 - panelW / 2
+  left = Math.max(16, Math.min(left, window.innerWidth - panelW - 16))
+  const estimatedHeight = 160
+  if (top - estimatedHeight < 16) {
+    top = a.top + a.height + margin
+  } else {
+    top = a.top - estimatedHeight - margin
+  }
+  return {
+    top: `${Math.max(16, top)}px`,
+    left: `${left}px`,
+  }
+})
+
+function clearHighlight() {
+  if (highlightedEl) {
+    highlightedEl.classList.remove(HIGHLIGHT_CLASS)
+    highlightedEl = null
+  }
+}
+
+function setHighlight(el: HTMLElement | null) {
+  if (highlightedEl === el) return
+  clearHighlight()
+  if (el) {
+    el.classList.add(HIGHLIGHT_CLASS)
+    highlightedEl = el
+  }
+}
+
+function onCaptureClick(event: MouseEvent) {
+  if (!contextualHelp.active) return
+  const target = event.target
+  if (target instanceof HTMLElement && target.closest('#contextual-help-panel')) {
+    return
+  }
+  if (target instanceof HTMLElement && target.closest('#contextual-help-toggle')) {
+    return
+  }
+
+  event.preventDefault()
+  event.stopPropagation()
+
+  const resolved = resolveHelpTarget(target)
+  if (resolved) {
+    contextualHelp.openPanel(resolved.topicId, resolved.element)
+    setHighlight(resolved.element)
+    return
+  }
+
+  toast.show('No help topic here — try the prompt bar, mode buttons, or settings icons.')
+}
+
+function onCaptureMouseMove(event: MouseEvent) {
+  if (!contextualHelp.active || contextualHelp.panelTopicId) return
+  const target = event.target
+  if (!(target instanceof HTMLElement)) {
+    setHighlight(null)
+    return
+  }
+  const resolved = resolveHelpTarget(target)
+  setHighlight(resolved?.element ?? null)
+}
+
+function onKeyDown(event: KeyboardEvent) {
+  if (!contextualHelp.active || event.key !== 'Escape') return
+  event.preventDefault()
+  if (contextualHelp.panelTopicId) contextualHelp.closePanel()
+  else contextualHelp.deactivate()
+}
+
+function bindListeners() {
+  document.body.classList.add('aipg-help-mode')
+  document.addEventListener('click', onCaptureClick, true)
+  document.addEventListener('mousemove', onCaptureMouseMove, true)
+  document.addEventListener('keydown', onKeyDown, true)
+}
+
+function unbindListeners() {
+  document.body.classList.remove('aipg-help-mode')
+  document.removeEventListener('click', onCaptureClick, true)
+  document.removeEventListener('mousemove', onCaptureMouseMove, true)
+  document.removeEventListener('keydown', onKeyDown, true)
+  clearHighlight()
+}
+
+watch(
+  () => contextualHelp.active,
+  (on) => {
+    if (on) bindListeners()
+    else unbindListeners()
+  },
+)
+
+watch(
+  () => contextualHelp.panelTopicId,
+  (id) => {
+    if (!id) clearHighlight()
+  },
+)
+
+onBeforeUnmount(() => {
+  if (contextualHelp.active) contextualHelp.deactivate()
+  else unbindListeners()
+})
+</script>
+
+<style>
+body.aipg-help-mode {
+  cursor: help;
+}
+
+body.aipg-help-mode button:not(#contextual-help-toggle),
+body.aipg-help-mode a,
+body.aipg-help-mode textarea,
+body.aipg-help-mode [data-aipg-help],
+body.aipg-help-mode #prompt-input,
+body.aipg-help-mode #plus-icon,
+body.aipg-help-mode #mode-buttons,
+body.aipg-help-mode [id^='mode-button-'],
+body.aipg-help-mode #send-button,
+body.aipg-help-mode #camera-button,
+body.aipg-help-mode #microphone-button,
+body.aipg-help-mode #advanced-settings-button,
+body.aipg-help-mode #app-settings-button,
+body.aipg-help-mode #show-history-button,
+body.aipg-help-mode #app-settings-sidebar,
+body.aipg-help-mode #advanced-settings-sidebar {
+  cursor: help;
+}
+
+.aipg-help-highlight {
+  outline: 2px solid hsl(var(--primary));
+  outline-offset: 2px;
+  border-radius: 4px;
+}
+</style>

--- a/WebUI/src/components/ContextualHelpLayer.vue
+++ b/WebUI/src/components/ContextualHelpLayer.vue
@@ -2,23 +2,23 @@
   <Teleport to="body">
     <div
       v-if="contextualHelp.active"
-      id="contextual-help-panel"
+      :id="HELP_PANEL_ID"
       class="pointer-events-none fixed inset-0 z-[40015]"
-      aria-live="polite"
     >
       <div
-        v-if="contextualHelp.active"
+        role="status"
         class="pointer-events-none fixed top-14 left-1/2 z-[40016] max-w-lg -translate-x-1/2 rounded-lg border border-primary/40 bg-primary/15 px-4 py-2.5 text-center text-sm font-medium text-foreground shadow-md backdrop-blur-sm"
       >
         Help mode — click a control to learn about it. Press Esc to exit.
       </div>
       <div
-        v-if="contextualHelp.panelTopic && contextualHelp.anchor"
+        v-if="contextualHelp.panelOpen && contextualHelp.panelTopic"
+        ref="panelRef"
         class="pointer-events-auto fixed z-[40020] w-[min(22rem,calc(100vw-2rem))] rounded-lg border border-border bg-popover p-4 text-popover-foreground shadow-xl"
         :style="panelStyle"
         role="dialog"
-        aria-modal="true"
         :aria-labelledby="headingId"
+        tabindex="-1"
       >
         <h2 :id="headingId" class="mb-2 text-base font-semibold">
           {{ contextualHelp.panelTopic.title }}
@@ -30,14 +30,14 @@
           <button
             type="button"
             class="rounded-md bg-primary px-3 py-1.5 text-sm font-medium text-primary-foreground hover:bg-primary/90"
-            @click="contextualHelp.closePanel()"
+            @click="dismissPanel"
           >
             Got it
           </button>
           <button
             type="button"
             class="text-xs text-muted-foreground underline-offset-2 hover:underline"
-            @click="contextualHelp.deactivate()"
+            @click="exitHelpMode"
           >
             Exit help mode
           </button>
@@ -48,34 +48,58 @@
 </template>
 
 <script setup lang="ts">
-import { computed, onBeforeUnmount, watch } from 'vue'
-import { resolveHelpTarget } from '@/assets/js/help/helpTopics'
-import { helpTopicFromPreset, helpTopicFromPresetVariant } from '@/assets/js/help/presetHelp'
+import { computed, nextTick, onBeforeUnmount, ref, useTemplateRef, watch } from 'vue'
+import {
+  HELP_PANEL_ID,
+  HELP_TOGGLE_ID,
+  resolveHelpTarget,
+  type HelpResolveResult,
+} from '@/assets/js/help/helpTopics'
+import {
+  findPresetByName,
+  helpTopicFromPreset,
+  helpTopicFromPresetVariant,
+} from '@/assets/js/help/presetHelp'
 import { useContextualHelp } from '@/assets/js/store/contextualHelp'
 import { usePresets } from '@/assets/js/store/presets'
+import { usePromptStore } from '@/assets/js/store/promptArea'
 import * as toast from '@/assets/js/toast'
 
 const contextualHelp = useContextualHelp()
 const presetsStore = usePresets()
+const promptStore = usePromptStore()
+
 const headingId = 'contextual-help-heading'
+const panelRef = useTemplateRef<HTMLElement>('panelRef')
 
 const HIGHLIGHT_CLASS = 'aipg-help-highlight'
+const FALLBACK_PANEL_HEIGHT = 160
+
+// The element the panel points at. Kept out of the store so no DOM node ends up in
+// Pinia state; the layer is a singleton, so module scope is enough.
 let highlightedEl: HTMLElement | null = null
+let anchorEl: HTMLElement | null = null
+let hoverFrame = 0
+let repositionFrame = 0
+
+const panelHeight = ref(FALLBACK_PANEL_HEIGHT)
 
 const panelStyle = computed(() => {
   const a = contextualHelp.anchor
   if (!a) return {}
   const margin = 8
   const panelW = Math.min(352, window.innerWidth - 32)
-  let top = a.top - margin
-  let left = a.left + a.width / 2 - panelW / 2
-  left = Math.max(16, Math.min(left, window.innerWidth - panelW - 16))
-  const estimatedHeight = 160
-  if (top - estimatedHeight < 16) {
-    top = a.top + a.height + margin
-  } else {
-    top = a.top - estimatedHeight - margin
-  }
+  const left = Math.max(
+    16,
+    Math.min(a.left + a.width / 2 - panelW / 2, window.innerWidth - panelW - 16),
+  )
+  // Prefer above the anchor; flip below when there isn't room, and clamp so a tall
+  // panel next to a bottom-edge control can't run off screen.
+  const above = a.top - panelHeight.value - margin
+  const top =
+    above < 16
+      ? Math.min(a.top + a.height + margin, window.innerHeight - panelHeight.value - 16)
+      : above
   return {
     top: `${Math.max(16, top)}px`,
     left: `${left}px`,
@@ -83,10 +107,8 @@ const panelStyle = computed(() => {
 })
 
 function clearHighlight() {
-  if (highlightedEl) {
-    highlightedEl.classList.remove(HIGHLIGHT_CLASS)
-    highlightedEl = null
-  }
+  highlightedEl?.classList.remove(HIGHLIGHT_CLASS)
+  highlightedEl = null
 }
 
 function setHighlight(el: HTMLElement | null) {
@@ -98,75 +120,132 @@ function setHighlight(el: HTMLElement | null) {
   }
 }
 
+function topicFor(resolved: HelpResolveResult) {
+  if (resolved.kind === 'static') return null
+  const preferredType = promptStore.getCurrentMode() === 'chat' ? 'chat' : 'comfy'
+  const preset = findPresetByName(presetsStore.presets, resolved.presetName, preferredType)
+  return resolved.kind === 'preset'
+    ? helpTopicFromPreset(preset, resolved.presetName)
+    : helpTopicFromPresetVariant(preset, resolved.presetName, resolved.variantName)
+}
+
+function openHelpFor(resolved: HelpResolveResult) {
+  anchorEl = resolved.element
+  const topic = topicFor(resolved)
+  if (topic) contextualHelp.openPanelForTopic(resolved.element, topic)
+  else if (resolved.kind === 'static') contextualHelp.openPanel(resolved.element, resolved.topicId)
+  setHighlight(resolved.element)
+}
+
+/** True when the event originated in help mode's own chrome, which must keep working. */
+function isOwnChrome(target: EventTarget | null): boolean {
+  return (
+    target instanceof HTMLElement &&
+    target.closest(`#${HELP_PANEL_ID}, #${HELP_TOGGLE_ID}`) !== null
+  )
+}
+
 function onCaptureClick(event: MouseEvent) {
-  if (!contextualHelp.active) return
-  const target = event.target
-  if (target instanceof HTMLElement && target.closest('#contextual-help-panel')) {
-    return
-  }
-  if (target instanceof HTMLElement && target.closest('#contextual-help-toggle')) {
-    return
-  }
+  if (!contextualHelp.active || isOwnChrome(event.target)) return
 
   event.preventDefault()
   event.stopPropagation()
 
-  const resolved = resolveHelpTarget(target)
-  if (resolved) {
-    if (resolved.kind === 'static') {
-      contextualHelp.openPanel(resolved.element, resolved.topicId)
-    } else if (resolved.kind === 'preset') {
-      const basePreset =
-        presetsStore.presets.find((p) => p.name === resolved.presetName) ?? null
-      contextualHelp.openPanelForTopic(
-        resolved.element,
-        helpTopicFromPreset(basePreset, resolved.presetName),
-      )
-    } else {
-      const basePreset =
-        presetsStore.presets.find((p) => p.name === resolved.presetName) ?? null
-      contextualHelp.openPanelForTopic(
-        resolved.element,
-        helpTopicFromPresetVariant(basePreset, resolved.presetName, resolved.variantName),
-      )
-    }
-    setHighlight(resolved.element)
+  const resolved = resolveHelpTarget(event.target)
+  if (!resolved) {
+    toast.show('No help topic here — try the prompt bar, mode buttons, or settings icons.')
     return
   }
+  openHelpFor(resolved)
+}
 
-  toast.show('No help topic here — try the prompt bar, mode buttons, or settings icons.')
+/**
+ * Swallow the pointer events that controls actually act on. Blocking `click` alone
+ * is not enough: radix-vue opens selects on `pointerdown` and sliders drag from it,
+ * so those would still fire while help mode is meant to be inert. `click` is still
+ * delivered afterwards, which is what opens the help panel.
+ */
+function onCapturePointerDown(event: Event) {
+  if (!contextualHelp.active || isOwnChrome(event.target)) return
+  event.preventDefault()
+  event.stopPropagation()
 }
 
 function onCaptureMouseMove(event: MouseEvent) {
-  if (!contextualHelp.active || contextualHelp.panelTopic) return
-  const target = event.target
-  if (!(target instanceof HTMLElement)) {
-    setHighlight(null)
-    return
-  }
-  const resolved = resolveHelpTarget(target)
-  setHighlight(resolved?.element ?? null)
+  if (!contextualHelp.active || contextualHelp.panelOpen) return
+  const { target } = event
+  // Hover resolution walks ancestors, so coalesce the stream into one pass per frame.
+  if (hoverFrame) return
+  hoverFrame = requestAnimationFrame(() => {
+    hoverFrame = 0
+    setHighlight(resolveHelpTarget(target)?.element ?? null)
+  })
 }
 
 function onKeyDown(event: KeyboardEvent) {
   if (!contextualHelp.active || event.key !== 'Escape') return
   event.preventDefault()
-  if (contextualHelp.panelTopic) contextualHelp.closePanel()
-  else contextualHelp.deactivate()
+  event.stopPropagation()
+  if (contextualHelp.panelOpen) dismissPanel()
+  else exitHelpMode()
+}
+
+/** Keep the panel glued to its anchor while the page scrolls or the window resizes. */
+function onViewportChange() {
+  if (!contextualHelp.panelOpen || !anchorEl) return
+  if (repositionFrame) return
+  repositionFrame = requestAnimationFrame(() => {
+    repositionFrame = 0
+    if (!anchorEl) return
+    // The anchor can disappear while the panel is open (mode switch, popover close).
+    if (!anchorEl.isConnected) {
+      dismissPanel()
+      return
+    }
+    contextualHelp.setAnchorFromElement(anchorEl)
+  })
+}
+
+function focusToggle() {
+  document.getElementById(HELP_TOGGLE_ID)?.focus()
+}
+
+function dismissPanel() {
+  contextualHelp.closePanel()
+  focusToggle()
+}
+
+function exitHelpMode() {
+  contextualHelp.deactivate()
+  focusToggle()
 }
 
 function bindListeners() {
   document.body.classList.add('aipg-help-mode')
   document.addEventListener('click', onCaptureClick, true)
+  document.addEventListener('pointerdown', onCapturePointerDown, true)
+  document.addEventListener('mousedown', onCapturePointerDown, true)
   document.addEventListener('mousemove', onCaptureMouseMove, true)
   document.addEventListener('keydown', onKeyDown, true)
+  // Capture so nested scroll containers (settings sidebars) are covered too.
+  document.addEventListener('scroll', onViewportChange, true)
+  window.addEventListener('resize', onViewportChange)
 }
 
 function unbindListeners() {
   document.body.classList.remove('aipg-help-mode')
   document.removeEventListener('click', onCaptureClick, true)
+  document.removeEventListener('pointerdown', onCapturePointerDown, true)
+  document.removeEventListener('mousedown', onCapturePointerDown, true)
   document.removeEventListener('mousemove', onCaptureMouseMove, true)
   document.removeEventListener('keydown', onKeyDown, true)
+  document.removeEventListener('scroll', onViewportChange, true)
+  window.removeEventListener('resize', onViewportChange)
+  if (hoverFrame) cancelAnimationFrame(hoverFrame)
+  if (repositionFrame) cancelAnimationFrame(repositionFrame)
+  hoverFrame = 0
+  repositionFrame = 0
+  anchorEl = null
   clearHighlight()
 }
 
@@ -178,16 +257,27 @@ watch(
   },
 )
 
+// Keyed on the resolved topic rather than `panelTopicId`: the latter stays null for
+// preset topics, so closing one was a null -> null transition that never fired.
 watch(
-  () => contextualHelp.panelTopicId,
-  (id) => {
-    if (!id && !contextualHelp.panelTopicDynamic) clearHighlight()
+  () => contextualHelp.panelOpen,
+  async (open) => {
+    if (!open) {
+      anchorEl = null
+      clearHighlight()
+      panelHeight.value = FALLBACK_PANEL_HEIGHT
+      return
+    }
+    await nextTick()
+    // Measure the rendered panel so the above/below flip uses the real height.
+    if (panelRef.value) panelHeight.value = panelRef.value.offsetHeight
+    panelRef.value?.focus()
   },
 )
 
 onBeforeUnmount(() => {
   if (contextualHelp.active) contextualHelp.deactivate()
-  else unbindListeners()
+  unbindListeners()
 })
 </script>
 
@@ -196,10 +286,20 @@ body.aipg-help-mode {
   cursor: help;
 }
 
-body.aipg-help-mode button:not(#contextual-help-toggle),
+/* Controls are inert while help mode is on, so don't keep promising `pointer`. */
+body.aipg-help-mode button,
 body.aipg-help-mode a,
+body.aipg-help-mode input,
 body.aipg-help-mode textarea,
+body.aipg-help-mode [role='button'] {
+  cursor: not-allowed;
+}
+
+/* Only elements that actually have help copy advertise it, so the cursor doesn't
+   promise a topic that resolves to the "no help here" toast. Mirrors the anchors
+   understood by resolveHelpTarget(). */
 body.aipg-help-mode [data-aipg-help],
+body.aipg-help-mode [data-aipg-preset-name],
 body.aipg-help-mode #prompt-input,
 body.aipg-help-mode #plus-icon,
 body.aipg-help-mode #mode-buttons,
@@ -211,11 +311,14 @@ body.aipg-help-mode #advanced-settings-button,
 body.aipg-help-mode #app-settings-button,
 body.aipg-help-mode #show-history-button,
 body.aipg-help-mode #app-settings-sidebar,
-body.aipg-help-mode #advanced-settings-sidebar,
-body.aipg-help-mode [data-aipg-preset-name],
-body.aipg-help-mode [data-aipg-variant-name],
-body.aipg-help-mode #preset-selector {
+body.aipg-help-mode #advanced-settings-sidebar {
   cursor: help;
+}
+
+/* Help mode's own chrome stays interactive. */
+body.aipg-help-mode #contextual-help-toggle,
+body.aipg-help-mode #contextual-help-panel button {
+  cursor: pointer;
 }
 
 .aipg-help-highlight {

--- a/WebUI/src/components/DemoModeOverlayDriverJs.vue
+++ b/WebUI/src/components/DemoModeOverlayDriverJs.vue
@@ -6,6 +6,7 @@
 import { driver, type DriveStep } from 'driver.js'
 import 'driver.js/dist/driver.css'
 import { useDemoMode, type DemoButtonId } from '@/assets/js/store/demoMode'
+import { TOUR_STEPS, TOUR_STEPS_ALTERNATIVE, type TourStep } from '@/assets/js/help/tourSteps'
 import { computed } from 'vue'
 
 const demoMode = useDemoMode()
@@ -15,15 +16,6 @@ onMounted(() => {
     triggerFirstTimeHelp: (buttonId: DemoButtonId) => triggerFirstTimeHelp(buttonId),
   })
 })
-
-type Step = {
-  id: string
-  title: string
-  descr: string
-  align?: 'start' | 'center' | 'end'
-}
-
-type StepList = Step[]
 
 const SELECTOR_TO_MODE: Record<string, ModeType> = {
   '#mode-button-chat': 'chat',
@@ -36,105 +28,13 @@ const enabledModes = computed(
   () => demoMode.profile?.enabledModes ?? ['chat', 'imageGen', 'imageEdit', 'video'],
 )
 
-function isStepEnabled(step: Step): boolean {
+function isStepEnabled(step: TourStep): boolean {
   const mode = SELECTOR_TO_MODE[step.id]
   return !mode || enabledModes.value.includes(mode)
 }
 
-const steps: StepList = [
-  {
-    id: '#demo-buttons-group',
-    title: 'Welcome to Intel AI-Playground!',
-    descr:
-      'Intel AI-Playground is a generative AI app that provides local-powered chat, image, and video capabilities. You can get context-specific help with the "Need Help" button. Click "Next" or press "Right" to start the tour.',
-  },
-  {
-    id: '#mode-buttons',
-    title: 'Pick your Mode',
-    descr:
-      'Here are multiple mode buttons, that define the type of content you are generating. Select any one of these modes later to explore each. Little dots generally indicate additional help is available when clicking the first time.',
-  },
-  {
-    id: '#prompt-input',
-    title: 'Unified Prompt',
-    descr:
-      'This is your Prompt field. This is the core experience of AI Playground, across all features of the app. This is where you write a prompt, add images or documents to guide your content, and select modes for the type of content you want to generate.',
-  },
-  {
-    id: '#send-button',
-    title: 'Ready to start?',
-    descr:
-      'This is the magic button that will start a generation. Select a mode like Chat, enter a question and click this button to get your first response.',
-    align: 'end',
-  },
-]
-
-const stepsAlternative: StepList = [
-  {
-    id: '#plus-icon',
-    title: 'Add Images or Documents',
-    descr:
-      "The PLUS icon allows you to load content like documents or images to the prompt. Alternatively you can also drag and drop content here. When added this content is part of your generation. In Chat mode you can ask questions about a document or an image. For Image Edit you can add images you want to edit. Note: If you're not able to load a certain type of document, check Prompt Settings as you might need to select a preset like Vision to support images, or RAG to support text documents",
-  },
-  {
-    id: '#mode-button-chat',
-    title: 'Chat Mode',
-    descr:
-      'Chat works like a typical AI chat. You can type questions to get information on almost any topic you can imagine. In the settings you can select from a variety of chat options where you can do document search, work with Reasoning or Vision models, and more. Click the prompt input to see a sample prompt!',
-  },
-  {
-    id: '#mode-button-imageGen',
-    title: 'Image Mode',
-    descr:
-      "The Image Gen mode allows you to generate images from text you enter. Describe a scene or character and style (photographic, watercolor, etc), you wish to generate, and have watching your ideas come to life. When in this mode, you'll find ready to go presets in the Prompt Settings that allow you to create images using generative models to achieve different levels of realism and generation times. Click the prompt input to see a sample prompt!",
-  },
-  {
-    id: '#mode-button-imageEdit',
-    title: 'Image Edit Mode',
-    descr:
-      'The Image Edit mode allows you to edit existing images or photos, often by describing what to change. Simply drag in a photo, select an editing Preset in Prompt Settings where you can upscale images, edit images with precision, generate 3D models from images, and more. An input image is already pre-selected for you. Click the prompt input to see a sample prompt!',
-  },
-  {
-    id: '#mode-button-video',
-    title: 'Video Mode',
-    descr:
-      'Video generation allows you to create short video clips from your imagination either from prompt or guided by images and video.',
-  },
-  {
-    id: '#microphone-button',
-    title: 'Mic Button',
-    descr:
-      "The Mic button is only active after you've selected and turned on Speech Mode in app settings.When done you simply click this icon, start talking in a language you're comfortable speaking, then click again. You'll see your speech written out as text in the prompt field.",
-  },
-  {
-    id: '#camera-button',
-    title: 'Camera Button',
-    descr:
-      'Click this button to capture an image from your camera. The captured image will be added to your prompt for vision-capable models to analyze.',
-  },
-  {
-    id: '#advanced-settings-button',
-    title: 'Prompt Settings',
-    descr:
-      'Each mode has prompt settings specific to the mode of content you are generating. Here you will find ready to go preset to do targeted tasks. Each preset is already dialed in to go, but you choose to adjust options and own values from Max Tokens in Chat, to Aspect Ratio settings for Image Gen. Prompt settings is at the heart of getting AI Playground to do what you want it to do. Select a Mode and explore what our Prompt Settings have to offer.',
-    align: 'end',
-  },
-  {
-    id: '#app-settings-button',
-    title: 'Application Settings',
-    descr:
-      "Select this gear icon to see a list of application-level settings, from to language options, installation manager, and speech mode. You'll find important application settings here. Click here and select the Theme menu to give AI Playground different looks.",
-  },
-  {
-    id: '#show-history-button',
-    title: 'History Panel',
-    descr:
-      "The History Panel keeps track of all that you've generated. History will show you the latest content from each mode you used. Use this to scroll back through and revisit previous discussion and content generated from AI Playground.",
-  },
-]
-
 function startTour() {
-  const filteredSteps = steps.filter(isStepEnabled)
+  const filteredSteps = TOUR_STEPS.filter(isStepEnabled)
   const driverObj = driver({
     showProgress: true,
     showButtons: ['next', 'previous', 'close'],
@@ -229,7 +129,7 @@ const firstTimeHelpConfig: Record<DemoButtonId, { stepId: string; highlightEleme
 
 function resolveDriverStep(target: ContextHelpTarget): DriveStep | null {
   const config = contextHelpConfig[target]
-  const step = stepsAlternative.find((s) => s.id === config.stepId)
+  const step = TOUR_STEPS_ALTERNATIVE.find((s) => s.id === config.stepId)
   if (!step) {
     console.warn(`triggerContextHelp: No step definition found for "${target}"`)
     return null
@@ -272,7 +172,7 @@ function triggerFirstTimeHelp(buttonId: DemoButtonId) {
     return
   }
 
-  const step = stepsAlternative.find((s) => s.id === config.stepId)
+  const step = TOUR_STEPS_ALTERNATIVE.find((s) => s.id === config.stepId)
   if (!step) {
     console.warn(`triggerFirstTimeHelp: No step definition found for "${buttonId}"`)
     return

--- a/WebUI/src/components/DemoModeOverlayDriverJs.vue
+++ b/WebUI/src/components/DemoModeOverlayDriverJs.vue
@@ -77,20 +77,6 @@ function startMiniTour(driverSteps: DriveStep[]) {
   miniDriver.drive()
 }
 
-type ContextHelpTarget = ModeType | 'app-settings' | 'advanced-settings'
-
-const contextHelpConfig: Record<ContextHelpTarget, { stepId: string; highlightElement: string }> = {
-  chat: { stepId: '#mode-button-chat', highlightElement: '#prompt-input' },
-  imageGen: { stepId: '#mode-button-imageGen', highlightElement: '#prompt-input' },
-  imageEdit: { stepId: '#mode-button-imageEdit', highlightElement: '#prompt-input' },
-  video: { stepId: '#mode-button-video', highlightElement: '#prompt-input' },
-  'app-settings': { stepId: '#app-settings-button', highlightElement: '#app-settings-sidebar' },
-  'advanced-settings': {
-    stepId: '#advanced-settings-button',
-    highlightElement: '#advanced-settings-sidebar',
-  },
-}
-
 const firstTimeHelpConfig: Record<DemoButtonId, { stepId: string; highlightElement: string }> = {
   'plus-icon': { stepId: '#plus-icon', highlightElement: '#plus-icon' },
   'app-settings-button': {
@@ -125,44 +111,6 @@ const firstTimeHelpConfig: Record<DemoButtonId, { stepId: string; highlightEleme
     stepId: '#microphone-button',
     highlightElement: '#microphone-button',
   },
-}
-
-function resolveDriverStep(target: ContextHelpTarget): DriveStep | null {
-  const config = contextHelpConfig[target]
-  const step = TOUR_STEPS_ALTERNATIVE.find((s) => s.id === config.stepId)
-  if (!step) {
-    console.warn(`triggerContextHelp: No step definition found for "${target}"`)
-    return null
-  }
-  if (!isStepEnabled(step)) return null
-  if (!document.querySelector(config.highlightElement)) {
-    console.warn(`triggerContextHelp: DOM element "${config.highlightElement}" not found`)
-    return null
-  }
-  return {
-    element: config.highlightElement,
-    popover: {
-      title: step.title,
-      description: step.descr,
-      side: 'top',
-      align: step.align,
-    },
-  }
-}
-
-function triggerContextHelp(
-  mode: ModeType,
-  appSettingsOpen: boolean,
-  advancedSettingsOpen: boolean,
-) {
-  const targets: ContextHelpTarget[] = []
-  if (appSettingsOpen) targets.push('app-settings')
-  if (advancedSettingsOpen) targets.push('advanced-settings')
-  targets.push(mode)
-
-  const driverSteps = targets.map((target) => resolveDriverStep(target)).filter((s) => s !== null)
-
-  startMiniTour(driverSteps)
 }
 
 function triggerFirstTimeHelp(buttonId: DemoButtonId) {
@@ -200,7 +148,6 @@ function triggerFirstTimeHelp(buttonId: DemoButtonId) {
 
 defineExpose({
   startTour,
-  triggerContextHelp,
   triggerFirstTimeHelp,
 })
 </script>

--- a/WebUI/src/components/PresetSelector.vue
+++ b/WebUI/src/components/PresetSelector.vue
@@ -4,10 +4,8 @@
          right padding keeps the sidebar's floating close arrow (rendered by
          SideModalBase with hide-header) off the card content. -->
     <section
-      id="preset-selector"
       role="group"
       :aria-label="`${selectedPreset.name} preset information`"
-      data-aipg-help="preset-selector"
       :data-aipg-preset-name="selectedPreset.name"
       class="flex flex-col gap-3 rounded-lg border border-border bg-muted/40 p-3 pr-8"
     >

--- a/WebUI/src/components/PresetSelector.vue
+++ b/WebUI/src/components/PresetSelector.vue
@@ -4,8 +4,11 @@
          right padding keeps the sidebar's floating close arrow (rendered by
          SideModalBase with hide-header) off the card content. -->
     <section
+      id="preset-selector"
       role="group"
       :aria-label="`${selectedPreset.name} preset information`"
+      data-aipg-help="preset-selector"
+      :data-aipg-preset-name="selectedPreset.name"
       class="flex flex-col gap-3 rounded-lg border border-border bg-muted/40 p-3 pr-8"
     >
       <div class="flex flex-row items-start gap-3">
@@ -68,6 +71,7 @@
 import { computed, watch, onMounted } from 'vue'
 import { usePresets } from '@/assets/js/store/presets'
 import { useBackendServices } from '@/assets/js/store/backendServices'
+import { extendedDescriptionText } from '@/assets/js/help/presetHelp'
 import { Label } from '@/components/ui/label'
 import VariantSelector, { type VariantOption } from '@/components/VariantSelector.vue'
 interface Props {
@@ -128,10 +132,12 @@ const availableVariants = computed(() => {
 })
 
 const variantSelectorOptions = computed<VariantOption[]>(() => {
+  const presetName = selectedPreset.value?.name ?? ''
   return availableVariants.value.map((variant, index) => ({
     id: `variant-${index}`,
     name: variant.displayName ?? variant.name,
     value: variant.name,
+    presetName,
   }))
 })
 
@@ -171,16 +177,9 @@ watch(
   { immediate: true },
 )
 
-const extendedDescription = computed(() => {
-  const preset = selectedPreset.value
-  const raw = preset?.extendedDescription
-  if (raw == null) return undefined
-  if (typeof raw === 'string') return raw
-  const variant = activeVariantName.value
-  if (variant && variant in raw) return raw[variant]
-  const first = Object.values(raw)[0]
-  return typeof first === 'string' ? first : undefined
-})
+const extendedDescription = computed(() =>
+  extendedDescriptionText(selectedPreset.value, activeVariantName.value),
+)
 
 // The "info" description shown beside the preset icon: the extended how-to text
 // (same content the info box used to show), falling back to the preset's base

--- a/WebUI/src/components/VariantSelector.vue
+++ b/WebUI/src/components/VariantSelector.vue
@@ -8,6 +8,8 @@ export interface VariantOption {
   name: string
   value: string
   icon?: string
+  /** Parent preset name — used by contextual help mode */
+  presetName?: string
 }
 
 interface Props {
@@ -53,6 +55,8 @@ const gridClass = computed(() => {
       <Label
         :for="option.id"
         :title="option.name"
+        :data-aipg-preset-name="option.presetName ?? undefined"
+        :data-aipg-variant-name="option.presetName ? option.value : undefined"
         class="flex flex-col items-center justify-between rounded-md border-2 border-muted bg-popover px-2 py-1.5 text-sm min-w-0 hover:bg-accent hover:text-accent-foreground peer-data-[state=checked]:border-primary [&:has([data-state=checked])]:border-primary"
       >
         <span class="truncate max-w-full">{{ option.name }}</span>

--- a/WebUI/src/views/PromptArea.vue
+++ b/WebUI/src/views/PromptArea.vue
@@ -169,6 +169,7 @@
                           :aria-label="preset.name"
                           :aria-pressed="presetsStore.activePresetName === preset.name"
                           :aria-disabled="!presetGate(preset).enabled"
+                          :data-aipg-preset-name="preset.name"
                           class="relative flex-none w-16 h-16 rounded-md overflow-hidden border-2 transition-all duration-150"
                           :class="[
                             presetsStore.activePresetName === preset.name

--- a/WebUI/src/views/PromptArea.vue
+++ b/WebUI/src/views/PromptArea.vue
@@ -157,6 +157,7 @@
                 <!-- Hover handlers live on this inner div rather than <PopoverContent>:
                      that wrapper's root is a Teleport (PopoverPortal), which drops attrs. -->
                 <div
+                  data-aipg-help="preset-selector"
                   class="flex gap-2 overflow-x-auto max-w-[76vw] pb-1"
                   @pointerenter="cancelPickerClose"
                   @pointerleave="schedulePickerClose"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
**Description:**

Ports the contextual help mode POC from `qiacheng/AI-Playground@feat/help-mode` onto `dev-leslie`, fixes the bugs found reviewing it, gets the new files through `prettier --check`, and retires the demo-mode "Need Help" button that help mode replaces.

Help mode is a `?` toggle in the title bar. While it's on, clicking any annotated control shows a short "what is this" panel anchored to that control instead of activating it. Hovering outlines whatever would be explained, and `Esc` closes the panel or exits the mode.

The original two commits are preserved with their original authorship. `dev-leslie` had reworked `PresetSelector.vue` (it is now an info card for the selected preset) and moved the preset grid into a hover picker in `PromptArea.vue`, so the preset/variant annotations were re-targeted at the new structure during the rebase.

[Help mode active with the Unified Prompt topic open](https://cursor.com/agents/bc-a9a3b673-0754-4f07-8e09-612eb9211f34/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fhelp_mode_prompt_topic.png)

**Related Issue:**

None.

**Changes Made:**

Bug fixes on top of the POC:

- **Pointer events were not intercepted.** Help mode only swallowed `click`, but `radix-vue` opens its select on `pointerdown` and sliders drag from it, so dropdowns in Prompt Settings still opened while help mode was meant to be inert. Pointer events are captured too now; `click` still arrives and is what opens the panel.
- **Variant help was keyed by the display label.** `VariantSelector` published `option.name` (`variant.displayName ?? variant.name`) while lookups key on the internal `name`, so a variant with a `displayName` lost its title and, because `extendedDescription` falls back to its first entry, quietly described a *different* variant. It now publishes `option.value`.
- **The panel never re-anchored.** It captured one `getBoundingClientRect()` and is `position: fixed`, so scrolling a settings sidebar left it pointing at nothing. It re-anchors on scroll and resize and closes if the anchor leaves the DOM.
- **The highlight ring stuck after closing a preset panel.** The cleanup watcher keyed on `panelTopicId`, which stays `null` for dynamic topics, so closing one was a `null → null` transition that never fired. It keys on the resolved topic now.
- **Panel height was a hardcoded 160px estimate** for the above/below flip; the panel is measured after render and clamped inside the viewport.
- **Dead code.** Two unreachable mode-button branches in `resolveHelpTarget` (the preceding id lookup already matched them) and an unused `isHelpAnnotatedElement` export. `resolveHelpTarget` is now a single ancestor walk instead of re-running `closest()` at every level, and `getHelpTopic` no longer resolves inherited `Object` properties such as `constructor` as topics.
- **Preset lookup was not mode-scoped**, so a chat preset sharing a name with a comfy one could win. It prefers the type matching the active mode.
- **`cursor: help` was applied to every button**, promising a topic even where the answer is the "no help topic here" toast. It is scoped to annotated elements; other controls read `not-allowed`, since they are inert.
- **Accessibility.** Dropped the inaccurate `aria-modal` (nothing was trapped and the app stayed reachable), moved focus into the panel on open and back to the toggle on close, replaced `aria-live` on the wrapper with `role="status"` on the banner, and gave the toggle `aria-label` plus `aria-pressed`.
- **Prettier.** All three new files failed `format:ci` on the original branch, which would have turned the `eslint-prettier` job red.

Duplication removed:

- `HELP_TOPICS` was a second set of per-control copy keyed off the same DOM ids the demo tour already anchors to. The tour's copy moves **verbatim** into `assets/js/help/tourSteps.ts` beside the click-to-learn topics, and `TourStep.id` is typed as `` `#${HelpTopicId}` `` plus an explicit tour-only anchor list, so renaming an anchor in one surface fails type-check in the other. The two keep their own wording deliberately — the tour narrates a walkthrough, help mode answers "what is this".
- `extendedDescriptionText` is one shared helper instead of being duplicated between `presetHelp.ts` and `PresetSelector.vue`.

Demo-mode "Need Help" button removed:

Help mode answers "what is this control" for any annotated element, which is what the demo-mode "Need Help" button did for a fixed set of three targets (current mode, plus whichever settings sidebar was open). Two help affordances sitting next to each other in the title bar is worse than one.

[Demo mode title bar before and after removing the Need Help button](https://cursor.com/agents/bc-a9a3b673-0754-4f07-8e09-612eb9211f34/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdemo_titlebar_need_help_removed.png)

Removing the button makes its whole path unreachable, so that goes too: `triggerHelpForCurrentMode`, `triggerContextHelp`, `resolveDriverStep`, `contextHelpConfig` and the `ContextHelpTarget` type. The auto-started demo tour and the per-button first-time popovers (`triggerFirstTimeHelp`, driven by the notification dots) are **untouched** — they are separate entry points.

The tour's welcome step was anchored to the removed button's wrapper and its copy told people to use it, so it now anchors to the `?` toggle and points there instead. `TOUR_ONLY_ANCHORS` is an exported constant that both the `TourStep` id type and the parity test derive from, with a new test asserting a tour-only anchor is never also a click-to-learn topic — the help toggle must not be a topic, or help mode would try to explain itself.

`DEMO_NEED_HELP` is left in the locale files: `demoMode.ts` documents the other `DEMO_*` keys as legacy leftovers that are kept, so removing just this one across 13 files would be inconsistent churn.

**Testing Done:**

**1. Automated checks**, run against a clean `npm ci --legacy-peer-deps` to match the CI job:

| Check | `dev-leslie` | This branch |
|---|---|---|
| `npm test` | 145 passed (20 files) | **173 passed (22 files)** |
| `npx vue-tsc --noEmit` | 0 errors | 0 errors |
| `npm run lint:ci` | clean | clean |
| `npm run format:ci` | clean | clean (was **failing** on the source branch) |

28 new tests cover the pure logic: `resolveHelpTarget` precedence and the ancestor walk, the guard that stops help mode explaining its own toggle/panel, variant resolution by internal name (with an explicit regression test for the display-label bug), and parity between tour anchors and help topics in both directions.

Each new guard was mutation-tested — reverting a fix in place makes a specific test fail:

| Reverted fix | Failing test |
|---|---|
| preset annotation precedence | `prefers the preset annotation when one element carries both` |
| prototype lookup guard | `does not resolve inherited Object properties as topics` |
| own-chrome guard | `never explains help mode itself` |
| variant keyed by display label | `describes the wrong variant when handed a display label` |
| help toggle given a help topic | `keeps tour-only anchors out of the click-to-learn topics` |

The demo tour copy was verified to have moved byte-for-byte: all 14 `descr` blocks and all 14 anchor ids are identical to `dev-leslie`, so the tour narration is unchanged.

**2. Manual verification in the running app** (`npm run dev` on Linux, `ai-backend` + `llamacpp-backend` installed to reach `loadingState === 'running'`).

The headline fix, measured on the real `radix-vue` model dropdown in Chat Settings:

| | trigger `data-state` | open `[role=menu]` count | help panel |
|---|---|---|---|
| help mode **off** (baseline) | `open` | 1 | — |
| help mode **on** | `closed` | 0 | opens, focus moves into it |
| after exiting help mode | `open` | 1 | — |

Also confirmed live:

- Clicking the **Image Gen** mode button in help mode showed the `Image Gen mode` topic and left the app in Chat mode (settings button still read "Chat").
- **Re-anchoring**: scrolling the settings sidebar moved the anchor by `-100px` and the panel followed by exactly `-100px` (it previously stayed put).
- **Highlight clearing** on a preset (dynamic) topic: outline count went `1 → 0` on "Got it", help mode stayed on, and focus returned to the toggle.
- **Preset lookup on the new `dev-leslie` layout**: clicking the preset info card resolved to the `Assistant` preset's own description, not the generic blurb.
- `Esc` twice cleared the panel then the mode, leaving `aipg-help-mode` off, no overlay, 0 highlights, and `aria-pressed="false"`.

Demo of the interception and of normal behaviour resuming afterwards:

[help_mode_blocks_dropdown_then_restores.mp4](https://cursor.com/agents/bc-a9a3b673-0754-4f07-8e09-612eb9211f34/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fhelp_mode_blocks_dropdown_then_restores.mp4)

Note in the video that the panel anchors to the whole settings sidebar rather than the dropdown itself. That is expected: nothing inside the sidebar carries per-control help copy yet, so it falls through to the sidebar topic. See the follow-ups below.

**3. Verified in demo mode** (`isDemoModeEnabled: true`), which is the only place the removed button ever rendered:

- `#demo-need-help-button` and `#demo-buttons-group` are both absent; `#contextual-help-toggle` is present. Confirmed both in the DOM and visually (before/after image above, captured by swapping only `App.vue` over HMR).
- Demo mode was genuinely active for the check: minimize/fullscreen hidden, "Demo mode active." badge shown, 8 notification dots rendered.
- The kept first-time-help path still fires: clicking **Image Gen** produced the driver.js `Image Mode` popover with its unchanged copy.

**Pre-existing issue found while testing (not caused by this PR):** in demo mode the renderer crashes intermittently in this headless Linux VM — `render-process-gone: reason=crashed exitCode=133`, which `dmesg` shows as `electron: Compositor: potentially unexpected fatal signal 5` (a Chromium CHECK in the compositor thread under software rendering, since `disable-gpu` is set on Linux). It reproduces on **`dev-leslie` with none of these changes applied**, with an identical exit code and signature, once its backends are present so it reaches the running state. It also fires with the auto-tour disabled, so it is not specific to the tour. Reported here only so it is not mistaken for a regression from this PR; it needs a separate look, ideally on real hardware.

**Screenshots:**

See the images and video above.

**Checklist:**

- [x] I have tested the changes locally.
- [x] I have self-reviewed the code changes.
- [ ] I have updated the documentation, if necessary.

**Known follow-ups (not addressed here):**

- **i18n.** All help copy is hardcoded English and no keys were added to the 13 files in `src/assets/i18n/`. The source marks it as POC copy and the comment is kept; this needs doing before it ships.
- Controls inside the settings sidebars have no per-control copy, so help there falls through to one whole-sidebar topic and outlines the entire panel (visible in the video).
- The renderer compositor crash in demo mode described above.


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a9a3b673-0754-4f07-8e09-612eb9211f34?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a9a3b673-0754-4f07-8e09-612eb9211f34&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

