### PR TITLE
Run the vendored Qwen3-TTS engine on transformers 5 (clears the last 3 advisories)

### DIFF
--- a/docs/qwen-tts-dependency-evaluation.md
+++ b/docs/qwen-tts-dependency-evaluation.md
@@ -19,9 +19,12 @@ replaced with [`vllm-omni`](https://github.com/vllm-project/vllm-omni), motivate
 >   unpinning: `qwen-tts` 0.1.1 does not run on transformers 5.x. Verified — see
 >   [§5.1](#51-tested-unpin-transformers-fails).
 >
-> **Status:** the vendoring half ([§5.4](#54-scoping-the-vendor-and-port-option) Step A) has
-> landed — `qwen3-tts/vendor/qwen_tts/`, 145 → 99 locked packages, output verified bit-exact
-> against the upstream package. The transformers port (Step B) has not been attempted.
+> **Status: both halves have landed.** The 12 Hz subset is vendored
+> ([§5.4](#54-scoping-the-vendor-and-port-option) Step A) and ported to `transformers` 5.14.1
+> (Step B, [§5.5](#55-the-transformers-5-port-as-landed)). The lock went 145 → 110 packages
+> and the advisory count **18 → 2**, the remainder being a deliberate `torch` ceiling and an
+> unreachable `setuptools` sdist issue. Audio is bit-identical to the upstream package
+> throughout.
 
 ---
 
@@ -66,13 +69,20 @@ the GitHub Advisory Database. 18 matches, and they cluster sharply:
 | `setuptools` | 81.0.0 | 1 (medium) | `torch` | No — see below |
 | `torch` | 2.12.1 | 1 (low) | ours | No — we ceiling `torch<2.13` deliberately |
 
-Re-running the same audit after the vendoring ([§5.4](#54-scoping-the-vendor-and-port-option))
-gives **5 matches over 95 packages**: the 13 `pillow` ones are gone with `gradio`, and what
-remains is the three `transformers` advisories plus two deliberate residuals. `torch` is held
-below 2.13 on purpose. `setuptools` is an unbounded requirement of `torch` that resolves to
-81.0.0 and does not move on `uv lock --upgrade-package setuptools`; the advisory is an sdist
-`MANIFEST.in` bypass on macOS filesystems, which is unreachable for a service that never builds
-an sdist, so it is not worth adding a floor on a transitive build tool to silence.
+Re-running the same audit after each step:
+
+| Lock | Packages | Advisories |
+|---|---|---|
+| original, `qwen-tts` dependency | 137 | 18 |
+| after vendoring ([§5.4](#54-scoping-the-vendor-and-port-option)) | 95 | 5 |
+| after the `transformers` 5 port ([§5.5](#55-the-transformers-5-port-as-landed)) | 106 | **2** |
+
+Vendoring removed the 13 `pillow` advisories along with `gradio`; the port removed the three
+`transformers` ones. The two that remain are deliberate. `torch` is held below 2.13 on purpose.
+`setuptools` is an unbounded requirement of `torch` that resolves to 81.0.0 and does not move on
+`uv lock --upgrade-package setuptools`; the advisory is an sdist `MANIFEST.in` bypass on macOS
+filesystems, which is unreachable for a service that never builds an sdist, so it is not worth
+adding a floor on a transitive build tool to silence.
 
 Two things follow:
 
@@ -140,11 +150,12 @@ launch `vllm serve` instead of `web_api.py`, and `synthesizeTextToSpeech` would 
 
 ## 5. Alternatives, and what we measured
 
-### 5.1 Tested: unpin `transformers` (fails)
+### 5.1 Tested: unpin `transformers` without touching the code (fails)
 
-The attractive cheap fix is to override `qwen-tts`'s pin and move to transformers 5.x,
-fixing all three advisories. It does not work. Against transformers 5.14.1, `qwen-tts`
-0.1.1 fails progressively, and each fix reveals the next breakage:
+The attractive cheap fix is to override `qwen-tts`'s pin and move to transformers 5.x, fixing
+all three advisories with no code changes. That does not work — the code has to be ported,
+which is what [§5.5](#55-the-transformers-5-port-as-landed) did. Against transformers 5.14.1,
+`qwen-tts` 0.1.1 fails progressively, and each mechanical fix reveals the next breakage:
 
 | # | Failure | API change |
 |---|---|---|
@@ -155,14 +166,15 @@ fixing all three advisories. It does not work. Against transformers 5.14.1, `qwe
 | 5 | `create_causal_mask() got an unexpected keyword argument 'cache_position'` | replaced by `position_ids` |
 | 6 | `RuntimeError: probability tensor contains either inf, nan or element < 0` | **numerical**, not an API error |
 
-Failure 6 is the important one. After five mechanical shims the model loads and runs, then
-produces NaN logits — a shim changed attention/mask semantics silently. Re-basing this code
-onto transformers 5.x is not dependency hygiene, it is porting model internals (masking,
-RoPE, cache) with no reference output to validate against beyond listening to the audio.
+Failure 6 is the important one, and it is what made this a port rather than a version bump:
+after five mechanical shims the model loads and runs, and then produces NaN logits. Guessing
+does not close that gap — [§5.5](#55-the-transformers-5-port-as-landed) records what actually
+caused it.
 
-So the `transformers==4.57.3` pin is load-bearing. Fixing those three advisories requires
-either vendoring and *properly* porting the modeling code — a fork we would then own, scoped
-in [§5.4](#54-scoping-the-vendor-and-port-option) — or replacing the runner entirely.
+So the `transformers==4.57.3` pin is load-bearing *for the unmodified package*. Fixing those
+three advisories requires either vendoring and properly porting the modelling code — scoped in
+[§5.4](#54-scoping-the-vendor-and-port-option), landed in
+[§5.5](#55-the-transformers-5-port-as-landed) — or replacing the runner entirely.
 
 Note this also rules out a tempting simpler idea: **`trust_remote_code` is not an option**
 either. The `Qwen3-TTS-12Hz-*` repos ship no modeling `.py` and no `auto_map`, and upstream
@@ -324,10 +336,77 @@ whose imports we deliberately removed — the tool stubs those modules in the up
 rather than reinstalling them (with real `__spec__`s, or `torch._dynamo`'s module scan raises
 `ValueError: onnxruntime.__spec__ is None`).
 
-**What Step B would add to what we own:** a port of ~5.4k lines that includes a subclass of an
-upstream transformers model, plus a config-translation shim, re-validated on every
-`transformers` bump. Step A on its own carries none of that — the code is upstream's, byte for
-byte, apart from deletions — which is why it landed first and separately.
+**What Step B adds to what we own:** a compatibility layer over model code that uses internal
+transformers APIs, re-validated on every `transformers` bump. Step A on its own carries none of
+that — the code is upstream's, byte for byte, apart from deletions — which is why it landed
+first and separately.
+
+### 5.5 The `transformers` 5 port, as landed
+
+Cheaper than [§5.4](#54-scoping-the-vendor-and-port-option) feared, but only because the two
+non-obvious failures were found by instrumenting rather than guessing. The work lives in
+`vendor/qwen_tts/_compat.py`, which bridges both versions rather than rewriting against 5.x —
+that matters because the upstream package only runs on 4.57.3, so keeping 4.x working is what
+keeps `tests/vendor_parity.py` able to compare against upstream at all.
+
+Three of the six failures from [§5.1](#51-tested-unpin-transformers-without-touching-the-code-fails)
+were signature bridging (the `check_model_inputs` decorator form, the `"default"` RoPE entry,
+the mask builders' renamed/dropped arguments). Two were narrower than they looked:
+`config.pad_token_id` resolves to `None` on 4.57.3 for these checkpoints, so reading it through
+`getattr` is the same value rather than a new default; and `rope_config_validation` only
+validates, so it is skipped where 5.x expects the `rope_parameters` schema these configs do not
+use. Several things that looked like they would need work did not: `Cache.update()` still
+absorbs the old `cache_kwargs` positionally, `ALL_ATTENTION_FUNCTIONS[...]` still supports
+indexing, and the `PretrainedConfig` rename is aliased.
+
+The two real problems, both silent:
+
+**Uninitialized `inv_freq` — the NaN.** `inv_freq` is a *non-persistent* buffer, computed in
+`__init__` and never stored in a checkpoint. transformers 5 builds the module tree on the meta
+device and then restores such buffers only for rotary modules that its own
+`PreTrainedModel._init_weights` recognizes, which it decides by looking for `"RotaryEmbedding"`
+in the class name plus an `original_inv_freq` attribute. None of the three rotary classes here
+qualify: the talker's two define `original_inv_freq` but this model overrides `_init_weights`
+without delegating to `super()`, and the codec decoder's class is spelled
+`Qwen3TTSTokenizerV2Decoder**Rotatory**Embedding` upstream, so the name test fails outright.
+The result was `inv_freq` holding uninitialized memory (`1.6e-31, 0.0, 0.0, …` with a NaN),
+which is why the first forward pass produced NaN logits. `reset_rotary_buffers()` recomputes it
+after each `from_pretrained`; recomputation is deterministic and idempotent, so it is a no-op
+on 4.57.3. Diagnosing this took one dump of the loaded buffers — the model's *inputs* were
+identical across versions, so the difference had to be in state, not in the forward path.
+
+**Accumulated `position_ids` — the shape mismatch.** 4.x's `prepare_inputs_for_generation`
+handed the model only the current step's positions; 5.x's
+`_update_model_kwargs_for_generation` instead *concatenates* the next positions onto the
+running tensor. So on the first decode step the model received `position_ids` of length 20
+alongside an `inputs_embeds` of length 1, computed cos/sin for the whole sequence, and failed
+in `o_proj` with `mat1 and mat2 shapes cannot be multiplied (1x40960 and 2048x1024)`.
+`align_position_ids()` trims to the query length at the three forwards that accept
+`position_ids`, which is again a no-op on 4.57.3.
+
+**Verification.** The chain from [§5.4](#54-scoping-the-vendor-and-port-option) closed exactly
+as designed, on one torch build (`2.12.1+cpu`) so that `transformers` is the only variable:
+
+| Comparison | Result |
+|---|---|
+| upstream `qwen-tts` @ 4.57.3 vs vendored @ 4.57.3 | codes equal, waveforms bit-exact (4/4 cases) |
+| vendored @ 4.57.3 vs vendored @ 5.14.1 | codes equal, waveforms bit-exact (4/4 cases) |
+| all 144 shared model buffers after load, 4.57.3 vs 5.14.1 | identical |
+
+The waveform hashes are also unchanged from the pre-port Step A run, so the port did not move
+the output at all. Both product modes then ran through the sidecar API on 5.14.1
+(`custom_voice` on the 0.6B model, `voice_design` on the 1.7B one). The buffer comparison was
+worth doing separately: uninitialized memory does not have to contain NaN, so a second
+mis-restored buffer could have shifted output subtly instead of failing loudly.
+
+**Cost.** `transformers` 5 pulls `typer` (it grew a CLI) and with it `rich`, `markdown-it-py`,
+`mdurl`, `pygments` and `shellingham`, and `huggingface-hub` moves to 1.x: 99 → 110 packages.
+That is the price of closing two high-severity RCEs, one of which was reachable from
+`tts_engine._load_model()`.
+
+**Constraint.** `transformers>=5.14.0,<6` — floor is the version verification ran on, not the
+oldest version that merely clears the advisories (5.5.0), since the two failures above were
+version-specific behaviours and there is no reason to claim untested ground.
 
 ## 6. Reproducing the evidence
 

--- a/qwen3-tts/pyproject.toml
+++ b/qwen3-tts/pyproject.toml
@@ -10,9 +10,11 @@ dependencies = [
   # Direct deps of the vendored Qwen3-TTS modelling code (vendor/README.md). These were
   # previously inherited from the `qwen-tts` package, which pinned transformers/accelerate by
   # equality and pulled gradio for a demo CLI we never import.
-  # transformers is capped below 5: the modelling code uses internal APIs that 5.x reworked
-  # (masking_utils, modeling_rope_utils, config-owned generation attrs) and does not run there.
-  "transformers>=4.57.3,<5",
+  # transformers 5 is required, not just tolerated: 4.x carries three advisories fixed only in
+  # 5.x (the reachable one is CVE-2026-4372, RCE from a crafted config.json). The vendored code
+  # bridges both via vendor/qwen_tts/_compat.py and produces bit-identical audio on either, but
+  # the floor is the version that verification actually ran on.
+  "transformers>=5.14.0,<6",
   "accelerate>=1.12.0",
   "librosa",
   "huggingface_hub",

--- a/qwen3-tts/tests/test_compat.py
+++ b/qwen3-tts/tests/test_compat.py
@@ -1,0 +1,190 @@
+"""Tests for the transformers 4.x/5.x compatibility layer of the vendored tree.
+
+Fast and dependency-light: no model weights, no network. They cover the two behaviours that
+actually broke when the vendored code first ran on transformers 5, because both failures were
+silent-ish and expensive to diagnose:
+
+- `inv_freq` came back as uninitialized memory after loading, so the first forward pass
+  produced NaN logits.
+- `position_ids` accumulated across decoding steps, so the rotary embedding was computed for
+  the whole sequence while only one token was being decoded.
+
+End-to-end proof that the port is behaviour-preserving is `tests/vendor_parity.py`, which
+compares generated audio bit-for-bit; these tests just make sure the mechanisms it relies on
+cannot quietly disappear.
+
+Run: python -m unittest discover -s tests
+"""
+
+import ast
+import sys
+import unittest
+from pathlib import Path
+from typing import ClassVar
+
+SERVICE_DIR = Path(__file__).resolve().parent.parent
+VENDOR_DIR = SERVICE_DIR / "vendor" / "qwen_tts"
+sys.path.insert(0, str(SERVICE_DIR))
+
+import torch  # noqa: E402
+import transformers  # noqa: E402
+from vendor.qwen_tts import _compat  # noqa: E402
+
+
+class _FakeRopeConfig:
+    """The attributes `_compute_default_rope_parameters` reads off a config."""
+
+    rope_theta = 1000000
+    hidden_size = 1024
+    num_attention_heads = 16
+    head_dim = 128
+
+
+class _FakeRotary(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.config = _FakeRopeConfig()
+        self.rope_type = "default"
+        inv_freq, self.attention_scaling = _compat._compute_default_rope_parameters(
+            self.config
+        )
+        self.register_buffer("inv_freq", inv_freq, persistent=False)
+        self.original_inv_freq = self.inv_freq
+
+
+class TestAlignPositionIds(unittest.TestCase):
+    def test_trims_accumulated_positions_to_the_query(self):
+        # transformers 5 hands the model every position seen so far while `inputs_embeds`
+        # holds only the token being decoded.
+        position_ids = torch.arange(20).view(1, 1, -1).expand(3, 1, -1)
+        aligned = _compat.align_position_ids(position_ids, 1)
+        self.assertEqual(tuple(aligned.shape), (3, 1, 1))
+        self.assertEqual(
+            aligned[0, 0, 0].item(), 19, "must keep the newest position, not the oldest"
+        )
+
+    def test_is_a_noop_when_lengths_already_agree(self):
+        position_ids = torch.arange(19).view(1, -1)
+        self.assertIs(_compat.align_position_ids(position_ids, 19), position_ids)
+
+    def test_tolerates_none(self):
+        self.assertIsNone(_compat.align_position_ids(None, 5))
+
+    def test_never_pads_a_shorter_tensor(self):
+        position_ids = torch.arange(3).view(1, -1)
+        self.assertIs(_compat.align_position_ids(position_ids, 10), position_ids)
+
+
+class TestResetRotaryBuffers(unittest.TestCase):
+    def test_recomputes_uninitialized_inv_freq(self):
+        module = _FakeRotary()
+        expected = module.inv_freq.clone()
+        # Simulate what transformers 5 leaves behind for a non-persistent buffer it does not
+        # recognize: whatever was in memory.
+        module.inv_freq.copy_(torch.full_like(module.inv_freq, float("nan")))
+        self.assertTrue(torch.isnan(module.inv_freq).all())
+
+        _compat.reset_rotary_buffers(module)
+
+        self.assertFalse(torch.isnan(module.inv_freq).any())
+        torch.testing.assert_close(module.inv_freq, expected, rtol=0, atol=0)
+        torch.testing.assert_close(module.original_inv_freq, expected, rtol=0, atol=0)
+
+    def test_is_idempotent(self):
+        module = _FakeRotary()
+        before = module.inv_freq.clone()
+        _compat.reset_rotary_buffers(module)
+        _compat.reset_rotary_buffers(module)
+        torch.testing.assert_close(module.inv_freq, before, rtol=0, atol=0)
+
+    def test_ignores_modules_without_a_rope_buffer(self):
+        plain = torch.nn.Linear(4, 4)
+        _compat.reset_rotary_buffers(plain)  # must not raise
+
+    def test_matches_the_frequencies_transformers_4_computed(self):
+        """The shim replaces `ROPE_INIT_FUNCTIONS["default"]`, dropped in transformers 5."""
+        from transformers.modeling_rope_utils import ROPE_INIT_FUNCTIONS
+
+        if "default" not in ROPE_INIT_FUNCTIONS:
+            self.skipTest(
+                f"transformers {transformers.__version__} has no default rope entry"
+            )
+        expected, expected_scaling = ROPE_INIT_FUNCTIONS["default"](_FakeRopeConfig())
+        actual, actual_scaling = _compat._compute_default_rope_parameters(
+            _FakeRopeConfig()
+        )
+        torch.testing.assert_close(actual, expected, rtol=0, atol=0)
+        self.assertEqual(actual_scaling, expected_scaling)
+
+
+class TestVendoredCodeUsesTheShims(unittest.TestCase):
+    """Direct use of the reworked transformers internals must go through `_compat`.
+
+    Re-vendoring from a new upstream wheel re-introduces the 4.x call sites, and on
+    transformers 5 they fail in ways that are tedious to trace back (NaN logits, a shape
+    mismatch deep in attention). Failing here instead names the file and the symbol.
+    """
+
+    FORBIDDEN: ClassVar[dict[str, str]] = {
+        "ROPE_INIT_FUNCTIONS": "use _compat.rope_init_fn()",
+        "check_model_inputs": "use _compat.check_model_inputs (bare decorator)",
+        "rope_config_validation": "use _compat.rope_config_validation()",
+    }
+
+    def _modelling_files(self):
+        return [
+            p
+            for p in VENDOR_DIR.rglob("*.py")
+            if "__pycache__" not in p.parts and p.name != "_compat.py"
+        ]
+
+    def test_no_direct_imports_of_reworked_internals(self):
+        offenders = []
+        for path in self._modelling_files():
+            tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+            for node in ast.walk(tree):
+                if not isinstance(node, ast.ImportFrom) or node.level:
+                    continue
+                if not (node.module or "").startswith("transformers"):
+                    continue
+                for alias in node.names:
+                    if alias.name in self.FORBIDDEN:
+                        offenders.append(
+                            f"{path.relative_to(VENDOR_DIR)} imports {alias.name} from "
+                            f"{node.module} — {self.FORBIDDEN[alias.name]}"
+                        )
+                    if alias.name in (
+                        "create_causal_mask",
+                        "create_sliding_window_causal_mask",
+                    ):
+                        offenders.append(
+                            f"{path.relative_to(VENDOR_DIR)} imports {alias.name} from "
+                            f"{node.module} — use the _compat wrapper (signature changed in 5.x)"
+                        )
+        self.assertEqual(offenders, [])
+
+    def test_generation_token_ids_are_read_defensively(self):
+        # transformers 5 raises instead of returning None for a config that does not define
+        # them, so bare `config.pad_token_id` reintroduces a load failure.
+        offenders = [
+            str(p.relative_to(VENDOR_DIR))
+            for p in self._modelling_files()
+            if "config.pad_token_id" in p.read_text(encoding="utf-8")
+        ]
+        self.assertEqual(offenders, [], "read via getattr(config, ..., None) instead")
+
+    def test_both_load_paths_reset_the_rope_buffers(self):
+        wired = {
+            path.name
+            for path in self._modelling_files()
+            if "reset_rotary_buffers(" in path.read_text(encoding="utf-8")
+        }
+        self.assertEqual(
+            wired,
+            {"modeling_qwen3_tts.py", "qwen3_tts_tokenizer.py"},
+            "every from_pretrained path must reset inv_freq, or the first forward NaNs on 5.x",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/qwen3-tts/tests/test_vendor.py
+++ b/qwen3-tts/tests/test_vendor.py
@@ -68,7 +68,11 @@ STDLIB_PREFIXES = {
     "warnings",
 }
 
-EXPECTED_FILES = {
+# Files in the vendored tree that are ours rather than upstream's, and so are exempt from the
+# "upstream notice preserved" check.
+OUR_FILES = {"_compat.py"}
+
+EXPECTED_FILES = OUR_FILES | {
     "__init__.py",
     "core/__init__.py",
     "core/models/__init__.py",
@@ -185,7 +189,8 @@ class TestVendoredTree(unittest.TestCase):
         missing = [
             str(p.relative_to(VENDOR_DIR))
             for p in _python_files()
-            if not any(
+            if str(p.relative_to(VENDOR_DIR)).replace("\\", "/") not in OUR_FILES
+            and not any(
                 notice in p.read_text(encoding="utf-8")[:1200]
                 for notice in (
                     "SPDX-License-Identifier: Apache-2.0",

--- a/qwen3-tts/uv.lock
+++ b/qwen3-tts/uv.lock
@@ -91,10 +91,32 @@ requires-dist = [
     { name = "torch", marker = "sys_platform != 'darwin' and extra == 'cuda'", specifier = ">=2.12.0", index = "https://download.pytorch.org/whl/cu130", conflict = { package = "aipg-qwen3-tts", extra = "cuda" } },
     { name = "torch", marker = "sys_platform != 'darwin' and extra == 'xpu'", specifier = ">=2.12.0", index = "https://download.pytorch.org/whl/xpu", conflict = { package = "aipg-qwen3-tts", extra = "xpu" } },
     { name = "torch", marker = "extra == 'cpu'", specifier = ">=2.12.0", index = "https://download.pytorch.org/whl/cpu", conflict = { package = "aipg-qwen3-tts", extra = "cpu" } },
-    { name = "transformers", specifier = ">=4.57.3,<5" },
+    { name = "transformers", specifier = ">=5.14.0,<6" },
     { name = "triton-xpu", marker = "(sys_platform == 'linux' and extra == 'xpu') or (sys_platform == 'win32' and extra == 'xpu')", specifier = ">=3.6.0", index = "https://download.pytorch.org/whl/xpu", conflict = { package = "aipg-qwen3-tts", extra = "xpu" } },
 ]
 provides-extras = ["xpu", "cuda", "cpu"]
+
+[[package]]
+name = "annotated-doc"
+version = "0.0.5"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5a/8e/38aa427ed5402449e226975b649c5dc73ccadfefeb95e6aecb8f8ea4b6b6/annotated_doc-0.0.5.tar.gz", hash = "sha256:c7e58ce09192557605d8bbd92836d7e1d520ac9580096042c0bfd197efacf1bb", size = 10758, upload-time = "2026-07-28T13:50:58.129Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3e/30/e900b21425a860e195f32e37657aa1f7c7f2b1bfb26f03ca209b90933c06/annotated_doc-0.0.5-py3-none-any.whl", hash = "sha256:117bac03a25ede5df5440e855b32d556049ca169ead221505badf432fed4b101", size = 5302, upload-time = "2026-07-28T13:50:57.239Z" },
+]
+
+[[package]]
+name = "anyio"
+version = "4.14.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "idna" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/61/cc/a381afa6efea9f496eff839d4a6a1aed3bfafc7b3ab4b0d1b243a12573dd/anyio-4.14.2.tar.gz", hash = "sha256:cfa139f3ed1a23ee8f88a145ddb5ac7605b8bbfd8592baacd7ce3d8bb4313c7f", size = 260176, upload-time = "2026-07-12T20:29:07.082Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/da/35/f2287558c17e29fafc8ef3daf819bb9834061cfa43bff8014f7df7f63bdc/anyio-4.14.2-py3-none-any.whl", hash = "sha256:9f505dda5ac9f0c8309b5e8bd445a8c2bf7246f3ce950121e45ea15bc41d1494", size = 125813, upload-time = "2026-07-12T20:29:05.763Z" },
+]
 
 [[package]]
 name = "audioread"
@@ -325,6 +347,15 @@ wheels = [
 ]
 
 [[package]]
+name = "h11"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload-time = "2025-04-24T03:35:25.427Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
+]
+
+[[package]]
 name = "hf-xet"
 version = "1.5.1"
 source = { registry = "https://pypi.org/simple" }
@@ -341,22 +372,51 @@ wheels = [
 ]
 
 [[package]]
-name = "huggingface-hub"
-version = "0.36.2"
+name = "httpcore"
+version = "1.0.9"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
+    { name = "certifi" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", size = 85484, upload-time = "2025-04-24T22:06:22.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55", size = 78784, upload-time = "2025-04-24T22:06:20.566Z" },
+]
+
+[[package]]
+name = "httpx"
+version = "0.28.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "certifi" },
+    { name = "httpcore" },
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
+]
+
+[[package]]
+name = "huggingface-hub"
+version = "1.26.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
     { name = "filelock" },
     { name = "fsspec" },
-    { name = "hf-xet", marker = "platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'arm64' or platform_machine == 'x86_64' or (extra == 'extra-14-aipg-qwen3-tts-cpu' and extra == 'extra-14-aipg-qwen3-tts-cuda') or (extra == 'extra-14-aipg-qwen3-tts-cpu' and extra == 'extra-14-aipg-qwen3-tts-xpu') or (extra == 'extra-14-aipg-qwen3-tts-cuda' and extra == 'extra-14-aipg-qwen3-tts-xpu')" },
+    { name = "hf-xet", marker = "platform_machine == 'AMD64' or platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'arm64' or platform_machine == 'x86_64' or (extra == 'extra-14-aipg-qwen3-tts-cpu' and extra == 'extra-14-aipg-qwen3-tts-cuda') or (extra == 'extra-14-aipg-qwen3-tts-cpu' and extra == 'extra-14-aipg-qwen3-tts-xpu') or (extra == 'extra-14-aipg-qwen3-tts-cuda' and extra == 'extra-14-aipg-qwen3-tts-xpu')" },
+    { name = "httpx" },
     { name = "packaging" },
     { name = "pyyaml" },
-    { name = "requests" },
     { name = "tqdm" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/7c/b7/8cb61d2eece5fb05a83271da168186721c450eb74e3c31f7ef3169fa475b/huggingface_hub-0.36.2.tar.gz", hash = "sha256:1934304d2fb224f8afa3b87007d58501acfda9215b334eed53072dd5e815ff7a", size = 649782, upload-time = "2026-02-06T09:24:13.098Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/82/db/3582597f8be0d34bd6881365a26d390854f12893eabdd62dd36de9df5a47/huggingface_hub-1.26.0.tar.gz", hash = "sha256:c8cd4e2df1ba9402f77fce9b509ec1d52debb502551789473f34016acc14e361", size = 936665, upload-time = "2026-07-30T14:12:04.156Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a8/af/48ac8483240de756d2438c380746e7130d1c6f75802ef22f3c6d49982787/huggingface_hub-0.36.2-py3-none-any.whl", hash = "sha256:48f0c8eac16145dfce371e9d2d7772854a4f591bcb56c9cf548accf531d54270", size = 566395, upload-time = "2026-02-06T09:24:11.133Z" },
+    { url = "https://files.pythonhosted.org/packages/97/bb/63a644c75b545f3ff394b822e9bd1c4a9586489c618b77a4d8a44a33a23b/huggingface_hub-1.26.0-py3-none-any.whl", hash = "sha256:e8cca670caa5d8dfa7e45bf45e86b466698198cd8150c021bcdb4a86b9252364", size = 780357, upload-time = "2026-07-30T14:12:01.998Z" },
 ]
 
 [[package]]
@@ -534,6 +594,18 @@ wheels = [
 ]
 
 [[package]]
+name = "markdown-it-py"
+version = "4.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mdurl" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/ff/7841249c247aa650a76b9ee4bbaeae59370dc8bfd2f6c01f3630c35eb134/markdown_it_py-4.2.0.tar.gz", hash = "sha256:04a21681d6fbb623de53f6f364d352309d4094dd4194040a10fd51833e418d49", size = 82454, upload-time = "2026-05-07T12:08:28.36Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/81/4da04ced5a082363ecfa159c010d200ecbd959ae410c10c0264a38cac0f5/markdown_it_py-4.2.0-py3-none-any.whl", hash = "sha256:9f7ebbcd14fe59494226453aed97c1070d83f8d24b6fc3a3bcf9a38092641c4a", size = 91687, upload-time = "2026-05-07T12:08:27.182Z" },
+]
+
+[[package]]
 name = "markupsafe"
 version = "3.0.3"
 source = { registry = "https://pypi.org/simple" }
@@ -550,6 +622,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/2f/e1/78ee7a023dac597a5825441ebd17170785a9dab23de95d2c7508ade94e0e/markupsafe-3.0.3-cp312-cp312-win32.whl", hash = "sha256:d88b440e37a16e651bda4c7c2b930eb586fd15ca7406cb39e211fcff3bf3017d", size = 14540, upload-time = "2025-09-27T18:36:38.761Z" },
     { url = "https://files.pythonhosted.org/packages/aa/5b/bec5aa9bbbb2c946ca2733ef9c4ca91c91b6a24580193e891b5f7dbe8e1e/markupsafe-3.0.3-cp312-cp312-win_amd64.whl", hash = "sha256:26a5784ded40c9e318cfc2bdb30fe164bdb8665ded9cd64d500a34fb42067b1c", size = 15105, upload-time = "2025-09-27T18:36:39.701Z" },
     { url = "https://files.pythonhosted.org/packages/e5/f1/216fc1bbfd74011693a4fd837e7026152e89c4bcf3e77b6692fba9923123/markupsafe-3.0.3-cp312-cp312-win_arm64.whl", hash = "sha256:35add3b638a5d900e807944a078b51922212fb3dedb01633a8defc4b01a3c85f", size = 13906, upload-time = "2025-09-27T18:36:40.689Z" },
+]
+
+[[package]]
+name = "mdurl"
+version = "0.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729, upload-time = "2022-08-14T12:40:10.846Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779Z" },
 ]
 
 [[package]]
@@ -982,6 +1063,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pygments"
+version = "2.20.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
 name = "pyyaml"
 version = "6.0.3"
 source = { registry = "https://pypi.org/simple" }
@@ -1036,6 +1126,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/ac/c3/e2a2b89f2d3e2179abd6d00ebd70bff6273f37fb3e0cc209f48b39d00cbf/requests-2.34.2.tar.gz", hash = "sha256:f288924cae4e29463698d6d60bc6a4da69c89185ad1e0bcc4104f584e960b9ed", size = 142856, upload-time = "2026-05-14T19:25:27.735Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a0/f4/c67b0b3f1b9245e8d266f0f112c500d50e5b4e83cb6f3b71b6528104182a/requests-2.34.2-py3-none-any.whl", hash = "sha256:2a0d60c172f83ac6ab31e4554906c0f3b3588d37b5cb939b1c061f4907e278e0", size = 73075, upload-time = "2026-05-14T19:25:26.443Z" },
+]
+
+[[package]]
+name = "rich"
+version = "15.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown-it-py" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c0/8f/0722ca900cc807c13a6a0c696dacf35430f72e0ec571c4275d2371fca3e9/rich-15.0.0.tar.gz", hash = "sha256:edd07a4824c6b40189fb7ac9bc4c52536e9780fbbfbddf6f1e2502c31b068c36", size = 230680, upload-time = "2026-04-12T08:24:00.75Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/82/3b/64d4899d73f91ba49a8c18a8ff3f0ea8f1c1d75481760df8c68ef5235bf5/rich-15.0.0-py3-none-any.whl", hash = "sha256:33bd4ef74232fb73fe9279a257718407f169c09b78a87ad3d296f548e27de0bb", size = 310654, upload-time = "2026-04-12T08:24:02.83Z" },
 ]
 
 [[package]]
@@ -1111,6 +1214,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/0d/1c/73e719955c59b8e424d015ab450f51c0af856ae46ea2da83eba51cc88de1/setuptools-81.0.0.tar.gz", hash = "sha256:487b53915f52501f0a79ccfd0c02c165ffe06631443a886740b91af4b7a5845a", size = 1198299, upload-time = "2026-02-06T21:10:39.601Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e1/e3/c164c88b2e5ce7b24d667b9bd83589cf4f3520d97cad01534cd3c4f55fdb/setuptools-81.0.0-py3-none-any.whl", hash = "sha256:fdd925d5c5d9f62e4b74b30d6dd7828ce236fd6ed998a08d81de62ce5a6310d6", size = 1062021, upload-time = "2026-02-06T21:10:37.175Z" },
+]
+
+[[package]]
+name = "shellingham"
+version = "1.5.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/58/15/8b3609fd3830ef7b27b655beb4b4e9c62313a4e8da8c676e142cc210d58e/shellingham-1.5.4.tar.gz", hash = "sha256:8dbca0739d487e5bd35ab3ca4b36e11c4078f3a234bfce294b0a0291363404de", size = 10310, upload-time = "2023-10-24T04:13:40.426Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e0/f9/0595336914c5619e5f28a1fb793285925a8cd4b432c9da0a987836c7f822/shellingham-1.5.4-py2.py3-none-any.whl", hash = "sha256:7ecfff8f2fd72616f7481040475a65b2bf8af90a56c89140852d1120324e8686", size = 9755, upload-time = "2023-10-24T04:13:38.866Z" },
 ]
 
 [[package]]
@@ -1384,23 +1496,22 @@ wheels = [
 
 [[package]]
 name = "transformers"
-version = "4.57.3"
+version = "5.14.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "filelock" },
     { name = "huggingface-hub" },
     { name = "numpy" },
     { name = "packaging" },
     { name = "pyyaml" },
     { name = "regex" },
-    { name = "requests" },
     { name = "safetensors" },
     { name = "tokenizers" },
     { name = "tqdm" },
+    { name = "typer" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/dd/70/d42a739e8dfde3d92bb2fff5819cbf331fe9657323221e79415cd5eb65ee/transformers-4.57.3.tar.gz", hash = "sha256:df4945029aaddd7c09eec5cad851f30662f8bd1746721b34cc031d70c65afebc", size = 10139680, upload-time = "2025-11-25T15:51:30.139Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5a/fb/2a2ba88f325e68a921d8b69ff63b477830b2e73ade9a3c8c8cab2f06d741/transformers-5.14.1.tar.gz", hash = "sha256:60d196c27781eacf8637e2b533f517582907ad6f9ae142046d6b69431a5b2173", size = 9295927, upload-time = "2026-07-16T09:41:57.773Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6a/6b/2f416568b3c4c91c96e5a365d164f8a4a4a88030aa8ab4644181fdadce97/transformers-4.57.3-py3-none-any.whl", hash = "sha256:c77d353a4851b1880191603d36acb313411d3577f6e2897814f333841f7003f4", size = 11993463, upload-time = "2025-11-25T15:51:26.493Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/67/8d85ca2323233ae3c0365a659c4e52ee1f587b440e4bc577e7d8e4416d0f/transformers-5.14.1-py3-none-any.whl", hash = "sha256:9db974c4079ede2d1a3ea7ca5a240df33f2cc26fc2b36ba64c5f2a4f43b6e725", size = 11625234, upload-time = "2026-07-16T09:41:54.143Z" },
 ]
 
 [[package]]
@@ -1422,6 +1533,21 @@ dependencies = [
 wheels = [
     { url = "https://download-r2.pytorch.org/whl/triton_xpu-3.7.1-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a31c058c5c2e78ebe490a2e69f2f50caec6b1307ac096e944f116fdc06819d9a", upload-time = "2026-06-17T16:52:20Z" },
     { url = "https://download-r2.pytorch.org/whl/triton_xpu-3.7.1-cp312-cp312-win_amd64.whl", hash = "sha256:6589ece3adc2b1ab88d90ff1267afc25df5c7b868f0b633e732cac70df36cbde", upload-time = "2026-06-17T16:53:02Z" },
+]
+
+[[package]]
+name = "typer"
+version = "0.27.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-doc" },
+    { name = "colorama", marker = "sys_platform == 'win32' or (extra == 'extra-14-aipg-qwen3-tts-cpu' and extra == 'extra-14-aipg-qwen3-tts-cuda') or (extra == 'extra-14-aipg-qwen3-tts-cpu' and extra == 'extra-14-aipg-qwen3-tts-xpu') or (extra == 'extra-14-aipg-qwen3-tts-cuda' and extra == 'extra-14-aipg-qwen3-tts-xpu')" },
+    { name = "rich" },
+    { name = "shellingham" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ae/40/4a3db7990d1f62a53182aa96eaef57aeb2886a27f90a195bc66713565d31/typer-0.27.1.tar.gz", hash = "sha256:a79bef8469a79c45498e7b814ecf8d603cc7644e9acbd9e19cac0334240b18df", size = 203994, upload-time = "2026-08-03T14:41:03.438Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/43/89/9518bc0c3929bee36b3a4a8e3daddd6e03f92f9961c66d4983b837160543/typer-0.27.1-py3-none-any.whl", hash = "sha256:53150287edd11baeb4e4722c8e394fcdf8181c0ae89485cba8d25c778d5edd56", size = 122874, upload-time = "2026-08-03T14:41:04.391Z" },
 ]
 
 [[package]]

--- a/qwen3-tts/vendor/README.md
+++ b/qwen3-tts/vendor/README.md
@@ -28,31 +28,78 @@ Full analysis and measurements: [`docs/qwen-tts-dependency-evaluation.md`](../..
 
 ## Local modifications
 
-Deletions — the 25 Hz tokenizer and the demo CLI. AI Playground only loads the 12 Hz
-checkpoints (`Qwen3-TTS-12Hz-*`), and the 25 Hz path is the only importer of `sox`,
-`onnxruntime`, `torchaudio` and `einops`:
+### 1. Deletions — the 25 Hz tokenizer and the demo CLI
+
+AI Playground only loads the 12 Hz checkpoints (`Qwen3-TTS-12Hz-*`), and the 25 Hz path is the
+only importer of `sox`, `onnxruntime`, `torchaudio` and `einops`:
 
 - removed `qwen_tts/core/tokenizer_25hz/` (5 files)
 - removed `qwen_tts/cli/` and `qwen_tts/__main__.py` (the `gradio` importers)
 
-Edits, all mechanical consequences of those deletions:
+Consequential edits:
 
 - `qwen_tts/core/__init__.py` — dropped the `Qwen3TTSTokenizerV1{Config,Model}` re-exports.
 - `qwen_tts/inference/qwen3_tts_tokenizer.py` — dropped the V1 imports and their
   `AutoConfig`/`AutoModel` registrations, and the 25 Hz branch of `decode()` (an unsupported
   tokenizer type now raises). Docstrings referring to the 25 Hz variant trimmed.
 
-Everything else is byte-identical to the wheel. To verify:
+### 2. `transformers` 5 support
+
+Upstream is written against `transformers` 4.57.3 internals and pins that version by equality.
+4.x carries three advisories fixed only in 5.x, so the affected call sites now route through
+**`qwen_tts/_compat.py`** (our file, not upstream's), which keeps the tree working on both
+versions. Five things needed bridging:
+
+| What | Why |
+|---|---|
+| `@check_model_inputs()` → `@check_model_inputs` | decorator factory became a plain decorator |
+| `ROPE_INIT_FUNCTIONS["default"]` | removed in 5.x; the shim reproduces 4.57.3's computation |
+| `rope_config_validation` | 5.x validates the new `rope_parameters` schema these configs don't use |
+| `create_causal_mask` / `create_sliding_window_causal_mask` | `input_embeds` → `inputs_embeds`, and `cache_position` dropped (the cache supplies the query offset now) |
+| `config.pad_token_id` | 5.x raises instead of returning `None` for a config that doesn't define it (it is `None` here on 4.57.3, so the `getattr` is the same value) |
+
+Two changes are more than signature bridging, and both were silent failures worth knowing
+about:
+
+- **`reset_rotary_buffers()` after every `from_pretrained`.** `inv_freq` is a non-persistent
+  buffer, so it is never in a checkpoint. transformers 5 builds modules on the meta device and
+  only restores such buffers for rotary classes its own `_init_weights` recognizes (name
+  contains `RotaryEmbedding` *and* an `original_inv_freq` attribute). None of these three
+  qualify — this model overrides `_init_weights` without delegating, and the codec decoder's
+  class is spelled `...RotatoryEmbedding` upstream. Without the reset, `inv_freq` keeps
+  uninitialized memory and the first forward pass produces NaN logits.
+- **`align_position_ids()` in the three forwards that take `position_ids`.** 4.x passed only
+  the current step's positions; 5.x accumulates them (`_update_model_kwargs_for_generation`
+  concatenates), so while decoding one token the model receives the whole sequence and
+  attention output stops matching the query length.
+
+## Verifying
+
+Everything outside `_compat.py` and the five bridged call sites is byte-identical to the
+wheel:
 
 ```bash
 pip download --no-deps qwen-tts==0.1.1 -d /tmp/qtts && unzip -q /tmp/qtts/*.whl -d /tmp/qtts/src
 diff -r /tmp/qtts/src/qwen_tts qwen3-tts/vendor/qwen_tts
 ```
 
+Behaviour is checked two ways:
+
+- `python -m unittest discover -s tests` — fast structural guards plus unit tests for the
+  compat layer. No model download; runs in well under a second.
+- `python tests/vendor_parity.py` — generates a fixed case list with both this tree and the
+  upstream package and compares codec token sequences and waveforms bit-for-bit. Needs the
+  model weights and a temporary upstream install (`uv pip install --no-deps qwen-tts==0.1.1`).
+  Because upstream only runs on `transformers` 4.57.3, comparing against it means installing
+  that version too — the tree still supports it, which is the reason the compat layer bridges
+  rather than replaces.
+
+The chain that justifies the vendoring is: upstream @ 4.57.3 == this tree @ 4.57.3 == this
+tree @ 5.14.1, bit-for-bit, verified on the same torch build.
+
 ## Updating
 
-Re-copy from the new wheel, re-apply the deletions and edits above, then re-run the parity
-check in `qwen3-tts/tests/test_vendor_parity.py`, which asserts that generation is bit-exact
-against a stored reference. A `transformers` bump needs the same check — the modelling code
-uses internal APIs (`masking_utils`, `cache_utils`, `modeling_rope_utils`) and is known not to
-work on `transformers` 5.x.
+Re-copy from the new wheel, re-apply the modifications above, then run both checks. A
+`transformers` bump needs the parity check too: this is model code written against internal
+APIs (`masking_utils`, `cache_utils`, `modeling_rope_utils`), and the failure modes are NaN
+output and shape mismatches rather than import errors.

--- a/qwen3-tts/vendor/qwen_tts/_compat.py
+++ b/qwen3-tts/vendor/qwen_tts/_compat.py
@@ -1,0 +1,164 @@
+"""Transformers 4.x / 5.x compatibility shims for the vendored Qwen3-TTS code.
+
+Not upstream. The vendored modelling code is written against `transformers` 4.57.3 internals
+(`masking_utils`, `modeling_rope_utils`, `utils.generic`), several of which were reworked in
+5.0. Rather than rewrite the model files against one version, the handful of affected call
+sites import from here, which keeps the tree runnable on **both**:
+
+- 5.x is what the service installs, because 4.57.3 has three published advisories that are
+  only fixed in 5.x (see docs/qwen-tts-dependency-evaluation.md).
+- 4.57.3 still matters for verification: it is the only version the upstream `qwen-tts`
+  package runs on, so `tests/vendor_parity.py` can only compare against upstream there.
+
+Each shim below mirrors what 4.57.3 did, so behaviour is unchanged; where 5.x moved a
+responsibility elsewhere (mask offsets now come from the cache), the shim drops the argument
+rather than re-deriving it. `tests/vendor_parity.py` and
+`tests/test_transformers5_equivalence.py` are what make that claim checkable.
+"""
+
+from __future__ import annotations
+
+import torch
+from transformers import __version__ as _transformers_version
+from transformers import masking_utils as _masking_utils
+from transformers.modeling_rope_utils import ROPE_INIT_FUNCTIONS as _ROPE_INIT_FUNCTIONS
+from transformers.utils.generic import check_model_inputs as _check_model_inputs
+
+# Parsed by hand rather than with `packaging`, which is only ever an indirect dependency here.
+IS_TRANSFORMERS_V5 = int(_transformers_version.split(".", 1)[0]) >= 5
+
+
+def check_model_inputs(func):
+    """`@check_model_inputs` as a plain decorator on both versions.
+
+    4.57.3 exposes a decorator *factory* (`@check_model_inputs()`); 5.x replaced it with a
+    plain decorator that forwards to `merge_with_config_defaults`. Using the bare form
+    everywhere and adapting here keeps the call sites version-agnostic.
+    """
+    if IS_TRANSFORMERS_V5:
+        return _check_model_inputs(func)
+    return _check_model_inputs()(func)
+
+
+def _compute_default_rope_parameters(config, device=None, **_ignored):
+    """The "default" RoPE init, which 5.x removed from `ROPE_INIT_FUNCTIONS`.
+
+    Byte-for-byte the same computation as 4.57.3's `_compute_default_rope_parameters`, reading
+    `rope_theta` from wherever the config keeps it (5.x moved transformers' own configs to a
+    `rope_parameters` dict, though the vendored config classes still use a plain attribute).
+    """
+    base = getattr(config, "rope_theta", None)
+    if base is None:
+        base = config.rope_parameters["rope_theta"]
+    partial_rotary_factor = getattr(config, "partial_rotary_factor", 1.0)
+    head_dim = getattr(config, "head_dim", None) or config.hidden_size // config.num_attention_heads
+    dim = int(head_dim * partial_rotary_factor)
+
+    attention_factor = 1.0  # Unused in this type of RoPE
+
+    inv_freq = 1.0 / (
+        base ** (torch.arange(0, dim, 2, dtype=torch.int64).to(device=device, dtype=torch.float) / dim)
+    )
+    return inv_freq, attention_factor
+
+
+def rope_init_fn(rope_type):
+    """Resolve a RoPE init function by type across versions."""
+    if rope_type == "default":
+        # 5.x dropped the "default" entry and inlined the computation into each model's
+        # rotary embedding class as a static method.
+        return _ROPE_INIT_FUNCTIONS.get("default", _compute_default_rope_parameters)
+    return _ROPE_INIT_FUNCTIONS[rope_type]
+
+
+def rope_config_validation(config):
+    """Validate `rope_scaling`, when the installed transformers still understands that schema.
+
+    5.x rewrote the validator around `config.rope_parameters` (`RotaryEmbeddingConfigMixin`),
+    which the vendored config classes do not implement — they keep 4.x's `rope_theta` /
+    `rope_scaling` attributes. Validation has no effect on numerics, so it is skipped there
+    rather than adapted.
+    """
+    if IS_TRANSFORMERS_V5:
+        return
+    from transformers.modeling_rope_utils import rope_config_validation as _validate
+
+    _validate(config)
+
+
+def _adapt_mask_kwargs(kwargs):
+    """Translate 4.57.3 mask-builder kwargs to the installed signature.
+
+    5.x renamed `input_embeds` to `inputs_embeds` and dropped `cache_position`: the query
+    offset now comes from the cache (`Cache.get_query_offset()`) and the kv sizes from the
+    query length, so there is nothing to re-derive. `position_ids` keeps the same meaning in
+    both versions (packed-sequence detection only).
+    """
+    embeds = kwargs.pop("inputs_embeds", None)
+    if embeds is None:
+        embeds = kwargs.pop("input_embeds", None)
+    else:
+        kwargs.pop("input_embeds", None)
+
+    if IS_TRANSFORMERS_V5:
+        kwargs.pop("cache_position", None)
+        kwargs["inputs_embeds"] = embeds
+    else:
+        kwargs["input_embeds"] = embeds
+    return kwargs
+
+
+def create_causal_mask(**kwargs):
+    return _masking_utils.create_causal_mask(**_adapt_mask_kwargs(kwargs))
+
+
+def create_sliding_window_causal_mask(**kwargs):
+    return _masking_utils.create_sliding_window_causal_mask(**_adapt_mask_kwargs(kwargs))
+
+
+def align_position_ids(position_ids, query_length):
+    """Trim `position_ids` to the tokens actually being processed in this forward pass.
+
+    4.57.3's `prepare_inputs_for_generation` handed the model only the current step's
+    positions. 5.x instead *accumulates* them — `_update_model_kwargs_for_generation`
+    concatenates the next positions onto the running tensor — so during decoding a model that
+    takes `position_ids` receives the whole sequence while `inputs_embeds` holds just the new
+    token. Feeding that straight to the rotary embedding yields cos/sin for the full sequence
+    and the attention output no longer matches the query length (it fails in `o_proj` with a
+    shape mismatch).
+
+    Positions are aligned to the *end* of the sequence, which is where the current query
+    tokens live. A no-op on 4.57.3, where the lengths already agree.
+    """
+    if position_ids is not None and position_ids.shape[-1] > query_length:
+        return position_ids[..., -query_length:]
+    return position_ids
+
+
+def reset_rotary_buffers(model):
+    """Recompute every rotary embedding's `inv_freq` after weights have been loaded.
+
+    `inv_freq` is a *non-persistent* buffer: it is computed in the module's `__init__` and never
+    stored in a checkpoint. transformers 5 builds the module tree on the meta device and then
+    only restores such buffers for modules its own `PreTrainedModel._init_weights` recognizes,
+    which it decides by looking for `"RotaryEmbedding"` in the class name plus an
+    `original_inv_freq` attribute. None of the three rotary classes here qualify — the
+    talker's two define `original_inv_freq` but this model overrides `_init_weights` without
+    delegating, and the codec decoder's class is spelled `...RotatoryEmbedding` upstream — so
+    without this, `inv_freq` keeps uninitialized memory and the first forward pass produces
+    NaN logits.
+
+    Recomputing from the config is deterministic and idempotent, so this is a no-op on 4.57.3,
+    where the constructor's value survives loading.
+    """
+    for module in model.modules():
+        if not (hasattr(module, "rope_type") and hasattr(module, "inv_freq")):
+            continue
+        inv_freq, attention_scaling = rope_init_fn(module.rope_type)(module.config)
+        with torch.no_grad():
+            for name in ("inv_freq", "original_inv_freq"):
+                buffer = getattr(module, name, None)
+                if isinstance(buffer, torch.Tensor) and not buffer.is_meta:
+                    buffer.copy_(inv_freq.to(dtype=buffer.dtype, device=buffer.device))
+        module.attention_scaling = attention_scaling
+    return model

--- a/qwen3-tts/vendor/qwen_tts/core/models/configuration_qwen3_tts.py
+++ b/qwen3-tts/vendor/qwen_tts/core/models/configuration_qwen3_tts.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from transformers.configuration_utils import PretrainedConfig, layer_type_validation
-from transformers.modeling_rope_utils import rope_config_validation
+from ..._compat import rope_config_validation
 from transformers.utils import logging
 
 logger = logging.get_logger(__name__)

--- a/qwen3-tts/vendor/qwen_tts/core/models/modeling_qwen3_tts.py
+++ b/qwen3-tts/vendor/qwen_tts/core/models/modeling_qwen3_tts.py
@@ -29,20 +29,20 @@ from transformers.activations import ACT2FN
 from transformers.cache_utils import Cache, DynamicCache
 from transformers.generation import GenerationMixin
 from transformers.integrations import use_kernel_forward_from_hub
-from transformers.masking_utils import (create_causal_mask,
-                                        create_sliding_window_causal_mask)
 from transformers.modeling_flash_attention_utils import FlashAttentionKwargs
 from transformers.modeling_layers import GradientCheckpointingLayer
 from transformers.modeling_outputs import (BaseModelOutputWithPast,
                                            CausalLMOutputWithPast, ModelOutput)
-from transformers.modeling_rope_utils import (ROPE_INIT_FUNCTIONS,
-                                              dynamic_rope_update)
+from transformers.modeling_rope_utils import dynamic_rope_update
 from transformers.modeling_utils import (ALL_ATTENTION_FUNCTIONS,
                                          PreTrainedModel)
 from transformers.processing_utils import Unpack
 from transformers.utils import can_return_tuple, logging
 from transformers.utils.hub import cached_file
 
+from ..._compat import (align_position_ids, create_causal_mask,
+                        create_sliding_window_causal_mask,
+                        reset_rotary_buffers, rope_init_fn)
 from ...inference.qwen3_tts_tokenizer import Qwen3TTSTokenizer
 from .configuration_qwen3_tts import (Qwen3TTSConfig,
                                       Qwen3TTSSpeakerEncoderConfig,
@@ -535,7 +535,7 @@ class Qwen3TTSTalkerRotaryEmbedding(nn.Module):
         self.original_max_seq_len = config.max_position_embeddings
 
         self.config = config
-        self.rope_init_fn = ROPE_INIT_FUNCTIONS[self.rope_type]
+        self.rope_init_fn = rope_init_fn(self.rope_type)
 
         inv_freq, self.attention_scaling = self.rope_init_fn(self.config, device)
         self.register_buffer("inv_freq", inv_freq, persistent=False)
@@ -570,7 +570,7 @@ class Qwen3TTSRotaryEmbedding(nn.Module):
         self.original_max_seq_len = config.max_position_embeddings
 
         self.config = config
-        self.rope_init_fn = ROPE_INIT_FUNCTIONS[self.rope_type]
+        self.rope_init_fn = rope_init_fn(self.rope_type)
 
         inv_freq, self.attention_scaling = self.rope_init_fn(self.config, device)
         self.register_buffer("inv_freq", inv_freq, persistent=False)
@@ -1018,7 +1018,11 @@ class Qwen3TTSTalkerCodePredictorModel(Qwen3TTSPreTrainedModel):
 
     def __init__(self, config: Qwen3TTSTalkerCodePredictorConfig, embedding_dim: int):
         super().__init__(config)
-        self.padding_idx = config.pad_token_id
+        # transformers 5 removed the generation token ids from PreTrainedConfig, so a config
+        # that does not define one raises instead of returning None. Both Qwen3-TTS talker
+        # configs fall in that case (verified: `pad_token_id` is None on 4.57.3), so this is
+        # the same value, not a new default.
+        self.padding_idx = getattr(config, "pad_token_id", None)
         self.vocab_size = config.vocab_size
         self.layers = nn.ModuleList(
             [Qwen3TTSDecoderLayer(config, layer_idx) for layer_idx in range(config.num_hidden_layers)]
@@ -1090,6 +1094,9 @@ class Qwen3TTSTalkerCodePredictorModel(Qwen3TTSPreTrainedModel):
 
         if position_ids is None:
             position_ids = cache_position.unsqueeze(0)
+        # transformers 5 accumulates position_ids across decoding steps; keep only the
+        # positions of the tokens in this forward pass. See _compat.align_position_ids.
+        position_ids = align_position_ids(position_ids, inputs_embeds.shape[1])
 
         # It may already have been prepared by e.g. `generate`
         if not isinstance(causal_mask_mapping := attention_mask, dict):
@@ -1430,7 +1437,11 @@ class Qwen3TTSTalkerModel(Qwen3TTSTalkerTextPreTrainedModel):
 
     def __init__(self, config):
         super().__init__(config)
-        self.padding_idx = config.pad_token_id
+        # transformers 5 removed the generation token ids from PreTrainedConfig, so a config
+        # that does not define one raises instead of returning None. Both Qwen3-TTS talker
+        # configs fall in that case (verified: `pad_token_id` is None on 4.57.3), so this is
+        # the same value, not a new default.
+        self.padding_idx = getattr(config, "pad_token_id", None)
         self.vocab_size = config.vocab_size
         self.layers = nn.ModuleList(
             [Qwen3TTSTalkerDecoderLayer(config, layer_idx) for layer_idx in range(config.num_hidden_layers)]
@@ -1494,6 +1505,10 @@ class Qwen3TTSTalkerModel(Qwen3TTSTalkerTextPreTrainedModel):
             cache_position = torch.arange(
                 past_seen_tokens, past_seen_tokens + inputs_embeds.shape[1], device=inputs_embeds.device
             )
+
+        # transformers 5 accumulates position_ids across decoding steps; keep only the
+        # positions of the tokens in this forward pass. See _compat.align_position_ids.
+        position_ids = align_position_ids(position_ids, inputs_embeds.shape[1])
 
         # the hard coded `3` is for temporal, height and width.
         if position_ids is None:
@@ -1888,6 +1903,9 @@ class Qwen3TTSForConditionalGeneration(Qwen3TTSPreTrainedModel, GenerationMixin)
             attn_implementation=requested_attn_implementation,
             **kwargs,
         )
+        # inv_freq is a non-persistent buffer, so it is not part of the checkpoint and
+        # transformers 5 leaves it uninitialized for these classes. See _compat.
+        reset_rotary_buffers(model)
         if not local_files_only and not os.path.isdir(pretrained_model_name_or_path):
             download_cache_dir = kwargs.get("cache_dir", cache_dir)
             download_revision = kwargs.get("revision", revision)

--- a/qwen3-tts/vendor/qwen_tts/core/tokenizer_12hz/modeling_qwen3_tts_tokenizer_v2.py
+++ b/qwen3-tts/vendor/qwen_tts/core/tokenizer_12hz/modeling_qwen3_tts_tokenizer_v2.py
@@ -27,20 +27,18 @@ from transformers import MimiConfig, MimiModel
 from transformers.activations import ACT2FN
 from transformers.cache_utils import Cache, DynamicCache
 from transformers.integrations import use_kernel_forward_from_hub
-from transformers.masking_utils import (
-    create_causal_mask,
-    create_sliding_window_causal_mask,
-)
 from transformers.modeling_flash_attention_utils import FlashAttentionKwargs
 from transformers.modeling_layers import GradientCheckpointingLayer
 from transformers.modeling_outputs import BaseModelOutputWithPast
-from transformers.modeling_rope_utils import ROPE_INIT_FUNCTIONS, dynamic_rope_update
+from transformers.modeling_rope_utils import dynamic_rope_update
 from transformers.modeling_utils import ALL_ATTENTION_FUNCTIONS, PreTrainedModel
 from transformers.processing_utils import Unpack
 from transformers.utils import ModelOutput, auto_docstring, logging
 from transformers.utils.deprecation import deprecate_kwarg
-from transformers.utils.generic import check_model_inputs
 
+from ..._compat import (align_position_ids, check_model_inputs,
+                        create_causal_mask,
+                        create_sliding_window_causal_mask, rope_init_fn)
 from .configuration_qwen3_tts_tokenizer_v2 import (
     Qwen3TTSTokenizerV2Config,
     Qwen3TTSTokenizerV2DecoderConfig,
@@ -257,7 +255,7 @@ class Qwen3TTSTokenizerV2DecoderRotatoryEmbedding(nn.Module):
         self.original_max_seq_len = config.max_position_embeddings
 
         self.config = config
-        self.rope_init_fn = ROPE_INIT_FUNCTIONS[self.rope_type]
+        self.rope_init_fn = rope_init_fn(self.rope_type)
 
         inv_freq, self.attention_scaling = self.rope_init_fn(self.config, device)
         self.register_buffer("inv_freq", inv_freq, persistent=False)
@@ -496,7 +494,7 @@ class Qwen3TTSTokenizerV2DecoderTransformerModel(Qwen3TTSTokenizerV2DecoderPreTr
         # Initialize weights and apply final processing
         self.post_init()
 
-    @check_model_inputs()
+    @check_model_inputs
     @auto_docstring
     def forward(
         self,
@@ -530,6 +528,9 @@ class Qwen3TTSTokenizerV2DecoderTransformerModel(Qwen3TTSTokenizerV2DecoderPreTr
 
         if position_ids is None:
             position_ids = cache_position.unsqueeze(0)
+        # transformers 5 accumulates position_ids across decoding steps; keep only the
+        # positions of the tokens in this forward pass. See _compat.align_position_ids.
+        position_ids = align_position_ids(position_ids, inputs_embeds.shape[1])
 
         # It may already have been prepared by e.g. `generate`
         if not isinstance(causal_mask_mapping := attention_mask, dict):

--- a/qwen3-tts/vendor/qwen_tts/inference/qwen3_tts_tokenizer.py
+++ b/qwen3-tts/vendor/qwen_tts/inference/qwen3_tts_tokenizer.py
@@ -26,6 +26,7 @@ import torch
 from torch.nn.utils.rnn import pad_sequence
 from transformers import AutoConfig, AutoFeatureExtractor, AutoModel
 
+from .._compat import reset_rotary_buffers
 from ..core import (
     Qwen3TTSTokenizerV2Config,
     Qwen3TTSTokenizerV2Model,
@@ -81,6 +82,9 @@ class Qwen3TTSTokenizer:
 
         inst.feature_extractor = AutoFeatureExtractor.from_pretrained(pretrained_model_name_or_path)
         inst.model = AutoModel.from_pretrained(pretrained_model_name_or_path, **kwargs)
+        # inv_freq is a non-persistent buffer, so it is not part of the checkpoint and
+        # transformers 5 leaves it uninitialized for these classes. See _compat.
+        reset_rotary_buffers(inst.model)
         inst.config = inst.model.config
 
         inst.device = getattr(inst.model, "device", None)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
**Description:**

Step B of the plan in `docs/qwen-tts-dependency-evaluation.md`, stacked on the vendoring PR ([#258](https://github.com/TNG/AI-Playground/pull/258)) — review that one first.

Vendoring cleared 13 of the 18 advisories in the TTS lock, but left three on `transformers` 4.57.3, and the reachable one is serious: [CVE-2026-4372](https://github.com/advisories/GHSA-29pf-2h5f-8g72) lets a crafted `config.json` point `_attn_implementation_internal` at an attacker's Hub repo, which `from_pretrained()` then downloads and executes — **bypassing `trust_remote_code`**. `tts_engine._load_model()` is exactly that call. This PR ports the vendored code to `transformers` 5.14.1, taking the lock from 5 advisories to **2**.

The port bridges both versions via `vendor/qwen_tts/_compat.py` rather than rewriting against 5.x. That is deliberate: the upstream `qwen-tts` package only runs on 4.57.3, so keeping 4.x working is what keeps `tests/vendor_parity.py` able to compare against upstream at all.

Of the six failures recorded in the evaluation, four were signature bridging (the `check_model_inputs` decorator form, the removed `"default"` RoPE entry, the mask builders' renamed/dropped arguments, `rope_config_validation`'s new schema). `config.pad_token_id` turned out narrower than it looked — it is `None` on 4.57.3 for these checkpoints, so reading it through `getattr` is the same value, not a new default. Several things that looked like work were not: `Cache.update()` still absorbs the old `cache_kwargs` positionally, `ALL_ATTENTION_FUNCTIONS[...]` still supports indexing, and the `PretrainedConfig` rename is aliased.

**The two real problems were both silent, and both were found by instrumenting rather than guessing.**

*NaN logits.* `inv_freq` is a non-persistent buffer, so it is in no checkpoint. transformers 5 builds modules on the meta device and restores such buffers only for rotary classes its own `PreTrainedModel._init_weights` recognizes — by class name containing `RotaryEmbedding` plus an `original_inv_freq` attribute. None of the three rotary classes here qualify: the talker's two have `original_inv_freq` but this model overrides `_init_weights` without delegating to `super()`, and the codec decoder's class is spelled `Qwen3TTSTokenizerV2Decoder**Rotatory**Embedding` upstream, so the name test fails outright. `inv_freq` was therefore uninitialized memory (`1.6e-31, 0.0, 0.0, …` with a NaN). Dumping the loaded buffers found it in one run — the model's *inputs* were identical across versions, so the difference had to be in state. `reset_rotary_buffers()` recomputes it after each `from_pretrained`; it is deterministic and idempotent, so a no-op on 4.57.3.

*Shape mismatch (`mat1 and mat2 shapes cannot be multiplied (1x40960 and 2048x1024)`).* 4.x's `prepare_inputs_for_generation` passed only the current step's `position_ids`; 5.x's `_update_model_kwargs_for_generation` *concatenates* them instead. So on the first decode step the model received 20 positions alongside a 1-token `inputs_embeds` and computed cos/sin for the whole sequence — 40960 = 20 × 2048. `align_position_ids()` trims to the query length at the three forwards that accept `position_ids`.

**Related Issue:**

None.

**Changes Made:**

- `qwen3-tts/vendor/qwen_tts/_compat.py` (new) — the 4.x/5.x bridge: `check_model_inputs`, `rope_init_fn`, `rope_config_validation`, the mask-builder wrappers, `reset_rotary_buffers()` and `align_position_ids()`, each documenting what moved and why the shim is faithful.
- Five call sites in three vendored files now route through it; `from_pretrained` in both load paths resets the rope buffers. The upstream diff stays small — 4 of 10 upstream files are still byte-identical, and the touched ones are 2, 2, 17 and 33 changed lines.
- `qwen3-tts/pyproject.toml` / `uv.lock` — `transformers>=5.14.0,<6` (floor is what verification ran on, not the oldest version that merely clears the advisories).
- `qwen3-tts/tests/test_compat.py` (new) — unit tests for both mechanisms plus guards against a re-vendor silently reintroducing the 4.x call sites.
- `qwen3-tts/vendor/README.md`, `docs/qwen-tts-dependency-evaluation.md` — what the port took, how each failure was found, and the verification chain.

**Testing Done:**

Everything ran on one torch build (`2.12.1+cpu`) so that `transformers` is the only variable.

- **Output does not move.** `upstream@4.57.3` == `vendored@4.57.3` == `vendored@5.14.1`: codec token sequences equal and waveforms bit-exact across all four fixed-seed cases (including German and a greedy decode). The waveform hashes are unchanged from the pre-port Step A run.
- **All 144 shared model buffers identical** after loading on both versions. Worth checking separately: uninitialized memory need not contain NaN, so a second mis-restored buffer could have shifted output subtly instead of failing loudly. (The buffer *count* differs, 152 vs 146, only because transformers' own Mimi moved rope from per-layer to model-level.)
- **Sidecar end-to-end on 5.14.1** from a fresh `uv sync --extra cpu`: `/healthy` ok, `/api/config` ok, `/api/synthesize` returning 4.32 s for `custom_voice` (0.6B) and 2.40 s for `voice_design` (1.7B, the second model-cache slot), both bfloat16 as the Electron service runs it.
- **17 tests pass on both** 4.57.3 and 5.14.1 (one skip on 5.x, the 4.x-only rope comparison), in ~0.1 s with no model or network. Negative-tested: deleting one `reset_rotary_buffers()` call fails `test_both_load_paths_reset_the_rope_buffers`.
- **Advisory re-audit** of the new lock: 2 matches over 106 packages, down from 5. Both remaining are deliberate — the `torch<2.13` ceiling, and a `setuptools` sdist issue pulled in by `torch` that a service which never builds an sdist cannot reach.
- **Ruff** `check` and `format --check` clean, with the vendored tree confirmed untouched by the formatter.

Cost, stated plainly: 99 → 110 packages, because `transformers` 5 grew a CLI and pulls `typer`/`rich`, and `huggingface-hub` moves to 1.x.

**Screenshots:**

Same seed, same torch build, only `transformers` differs — the difference trace is exactly zero:

[Waveforms from transformers 4.57.3 and 5.14.1 with a zero difference trace](https://cursor.com/agents/bc-26cacd45-1158-48da-ac87-aa02de5fc5f5/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ftts_transformers5_bitexact.png)

The sidecar serving audio on 5.14.1:

[Waveform of audio produced through the sidecar API on transformers 5.14.1](https://cursor.com/agents/bc-26cacd45-1158-48da-ac87-aa02de5fc5f5/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ftts_transformers5_sidecar_output.png)

Full verification transcript (root-cause evidence, all four comparisons, sidecar responses, diff stats) is attached to the agent run as `tts_transformers5_port_verification.txt`, along with the generated WAVs for both modes.

**Checklist:**

- [x] I have tested the changes locally.
- [x] I have self-reviewed the code changes.
- [x] I have updated the documentation, if necessary.


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-26cacd45-1158-48da-ac87-aa02de5fc5f5?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-26cacd45-1158-48da-ac87-aa02de5fc5f5&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

