### PR TITLE
Fix custom TTS voice labeled as leftover preset speaker

### DIFF
--- a/WebUI/e2e/appDriver.ts
+++ b/WebUI/e2e/appDriver.ts
@@ -256,6 +256,13 @@ export class AppDriver {
    * it — asserting a *second*, distinct audio result appears (TTS answers with an audio
    * bubble, never a text reply). The Text-to-Speech flow must always run to completion:
    * an unavailable preset or a gated model is a failure, never a skip.
+   *
+   * Also covers the regressions reported against this flow:
+   *  - creating a voice pulls the voice-design weights at save time, so no download
+   *    dialog ambushes the first synthesis with it;
+   *  - Regenerate re-synthesizes instead of loading a chat model into a TTS thread;
+   *  - a saved voice is reproducible — the same text comes back as the same audio,
+   *    until the user deliberately re-rolls the voice.
    */
   async runTtsPreset(opts: {
     text: string
@@ -265,7 +272,18 @@ export class AppDriver {
       this.selectModeAndPreset('Chat', 'Text to Speech'))
     expect(available, 'Preset "Text to Speech" must be available in this product mode').toBe(true)
 
-    await this.settings.close('Chat')
+    await test.step('Start from a known voice selection', async () => {
+      // The app's TTS settings persist across runs (saved voices and the active
+      // voice selection live in the store's persisted state), so a second run would
+      // otherwise open with the custom voice a previous run created still selected —
+      // making "the default voice" a designed voice, skipping the preset-speaker path
+      // entirely, and turning "create a voice" into "re-save the same voice". Pin a
+      // built-in speaker and drop the leftover voice so both paths are exercised.
+      await this.settings.open('Chat')
+      await this.settings.deleteTtsVoiceIfPresent(opts.newVoice.name)
+      await this.settings.selectTtsVoice(/^Ryan\b/)
+      await this.settings.close('Chat')
+    })
 
     await test.step('Synthesize speech with the default voice', async () => {
       await this.main.sendPrompt(opts.text)
@@ -280,17 +298,72 @@ export class AppDriver {
         name: opts.newVoice.name,
         description: opts.newVoice.description,
       })
+      // Created voices need the voice-design weights, which are different from the
+      // preset speakers'. Saving the voice is what offers that download, so the
+      // dialog (when the model isn't on disk yet) belongs to THIS step.
+      await this.resolveDownloadsOrFail('the custom-voice Text-to-Speech model')
       await this.settings.close('Chat')
 
       await this.main.sendPrompt(opts.newVoice.text)
-      // A designed voice uses different model weights than the presets, so this turn
-      // may pull its own model via the same download dialog.
-      await this.resolveDownloadsOrFail('the custom-voice Text-to-Speech model')
+      // …and therefore the first synthesis with the new voice must not need one:
+      // `resolve()` returns 'none' when no dialog shows within its window.
+      expect(
+        await this.downloads.resolve(),
+        'the custom-voice model should already be installed by "Save voice" — synthesis must not prompt for a download',
+      ).toBe('none')
       await this.main.waitForTtsAudioCount(2)
       await expect(
         this.main.assistantResponses.last(),
         'the custom-voice result should name the saved voice, not a leftover preset speaker',
       ).toContainText(opts.newVoice.name)
+    })
+
+    const beforeRegenerate = await this.main.ttsAudioFingerprint()
+
+    await test.step('Regenerate re-synthesizes instead of loading a chat model', async () => {
+      await this.main.regenerateLastTurn()
+      // A TTS thread has no chat model; regenerating must never reach for one.
+      expect(
+        await this.downloads.resolve(),
+        'regenerating a Text-to-Speech turn must not pull a chat model',
+      ).toBe('none')
+      // The audio turn is replaced, not appended to — still two results, the last
+      // of which is audio (a text reply here would mean the LLM path ran).
+      await this.main.waitForTtsAudioCount(2)
+      await expect(
+        this.main.ttsAudioPlayer,
+        'the regenerated turn should be an audio result, not a text reply',
+      ).toBeVisible({ timeout: 15_000 })
+      await expect(this.main.assistantResponses.last()).toContainText(opts.newVoice.name)
+      // Same voice, same text, pinned seed → the same audio back.
+      expect(
+        await this.main.ttsAudioFingerprint(),
+        'regenerating the same text with the same saved voice should reproduce the same audio',
+      ).toBe(beforeRegenerate)
+    })
+
+    await test.step('The saved voice still sounds the same on a later turn', async () => {
+      await this.main.sendPrompt(opts.newVoice.text)
+      expect(await this.downloads.resolve()).toBe('none')
+      await this.main.waitForTtsAudioCount(3)
+      expect(
+        await this.main.ttsAudioFingerprint(),
+        'coming back to a saved voice and synthesizing the same text again should give the same voice',
+      ).toBe(beforeRegenerate)
+    })
+
+    await test.step('Re-rolling the voice draws a different speaker', async () => {
+      await this.settings.open('Chat')
+      await this.settings.rerollTtsVoice(opts.newVoice.name)
+      await this.settings.close('Chat')
+
+      await this.main.sendPrompt(opts.newVoice.text)
+      expect(await this.downloads.resolve()).toBe('none')
+      await this.main.waitForTtsAudioCount(4)
+      expect(
+        await this.main.ttsAudioFingerprint(),
+        're-rolling a saved voice should change how it sounds (otherwise the seed never reaches synthesis)',
+      ).not.toBe(beforeRegenerate)
     })
   }
 

--- a/WebUI/e2e/appDriver.ts
+++ b/WebUI/e2e/appDriver.ts
@@ -287,6 +287,10 @@ export class AppDriver {
       // may pull its own model via the same download dialog.
       await this.resolveDownloadsOrFail('the custom-voice Text-to-Speech model')
       await this.main.waitForTtsAudioCount(2)
+      await expect(
+        this.main.assistantResponses.last(),
+        'the custom-voice result should name the saved voice, not a leftover preset speaker',
+      ).toContainText(opts.newVoice.name)
     })
   }
 

--- a/WebUI/e2e/pages/MainPage.ts
+++ b/WebUI/e2e/pages/MainPage.ts
@@ -81,6 +81,50 @@ export class MainPage {
   }
 
   /**
+   * The "Regenerate" control on the last assistant turn (Chat.vue renders it only
+   * for the final message). Re-runs that turn: another LLM answer for a chat
+   * thread, another synthesis for a Text-to-Speech thread.
+   */
+  get regenerateButton(): Locator {
+    return this.page.getByRole('button', { name: 'Regenerate' }).last()
+  }
+
+  /** Re-run the last assistant turn and wait for it to start. */
+  async regenerateLastTurn(): Promise<void> {
+    await expect(this.regenerateButton).toBeVisible({ timeout: 15_000 })
+    await this.regenerateButton.click()
+    await this.expectTurnStarted()
+  }
+
+  /**
+   * Fingerprint of a rendered TTS result's audio — the player's `src` is a data URI
+   * holding the whole WAV, so equal fingerprints mean byte-identical audio.
+   * `index` counts from the end when negative (-1 = the most recent result).
+   *
+   * Used to prove a saved voice is reproducible: the same text spoken by the same
+   * saved voice must come back identical, because the voice's seed is pinned
+   * (`ttsVoiceSeed.ts` → `/api/synthesize` `seed` → `torch.manual_seed`). Hashed
+   * in-page (djb2 over the data URI, prefixed with its length) so multi-MB WAVs
+   * aren't shipped across the CDP bridge.
+   */
+  async ttsAudioFingerprint(index: number = -1): Promise<string> {
+    const players = this.ttsAudioPlayers
+    const count = await players.count()
+    const target = players.nth(index < 0 ? count + index : index)
+    await expect(target, 'expected a rendered TTS audio player to fingerprint').toBeVisible({
+      timeout: 15_000,
+    })
+    return target.evaluate((el) => {
+      const src = (el as HTMLAudioElement).getAttribute('src') ?? ''
+      let hash = 5381
+      for (let i = 0; i < src.length; i++) {
+        hash = ((hash * 33) ^ src.charCodeAt(i)) >>> 0
+      }
+      return `${src.length}:${hash.toString(16)}`
+    })
+  }
+
+  /**
    * The prompt-area attachment file input (the "+" control). Present only when the
    * active preset allows an attachment: a vision chat model (image) or a RAG preset
    * (document). Used for chat-mode attachments; ComfyUI reference images are set in

--- a/WebUI/e2e/pages/SpecificSettingsPage.ts
+++ b/WebUI/e2e/pages/SpecificSettingsPage.ts
@@ -194,6 +194,57 @@ export class SpecificSettingsPage {
     ).toBeVisible({ timeout: 5_000 })
   }
 
+  /**
+   * The "Voice" picker row in the Text-to-Speech settings (SettingsTts.vue). Anchored
+   * on a label whose text is exactly "Voice", so it can't drift onto the neighbouring
+   * "Your voices" list or the two "Language" rows.
+   */
+  private ttsVoiceTrigger(mode: ChatMode): Locator {
+    return this.panel(mode)
+      .locator('div.grid')
+      .filter({ has: this.page.getByText('Voice', { exact: true }) })
+      .getByRole('button')
+  }
+
+  /**
+   * Select an entry from the "Voice" picker — a built-in speaker (listed as
+   * "Ryan — English") or a saved one ("Tammy (your voice)"). Pass a regex to match a
+   * prefix. Requires the settings sidebar open with the "Text to Speech" preset active.
+   */
+  async selectTtsVoice(label: string | RegExp, mode: ChatMode = 'Chat'): Promise<void> {
+    const trigger = this.ttsVoiceTrigger(mode)
+    await trigger.click()
+    const menu = this.page.getByRole('menu')
+    await menu.getByRole('menuitem', { name: label }).first().click()
+    await menu.waitFor({ state: 'hidden', timeout: 5_000 }).catch(() => {})
+    await expect(trigger).toContainText(label, { timeout: 15_000 })
+  }
+
+  /**
+   * Remove a saved TTS voice if it is listed, so a run that shares persisted app state
+   * with an earlier one still *creates* the voice rather than re-saving it. No-op when
+   * the voice isn't there.
+   */
+  async deleteTtsVoiceIfPresent(name: string, mode: ChatMode = 'Chat'): Promise<void> {
+    const row = this.panel(mode).locator('li').filter({ hasText: name })
+    if ((await row.count()) === 0) return
+    await row.first().getByRole('button', { name: 'Remove' }).click()
+    await expect(row, `saved voice "${name}" should be gone after Remove`).toHaveCount(0)
+  }
+
+  /**
+   * Re-roll a saved TTS voice: draw a different speaker for the same description by
+   * giving the voice a new seed (SettingsTts.vue → `rerollVoiceSeed`). The counterpart
+   * of the pinned seed — proof that the seed is what fixes the voice, since audio
+   * synthesized after a re-roll must differ from audio synthesized before it.
+   * Requires the settings sidebar open with the "Text to Speech" preset active.
+   */
+  async rerollTtsVoice(name: string, mode: ChatMode = 'Chat'): Promise<void> {
+    const row = this.panel(mode).locator('li').filter({ hasText: name })
+    await expect(row, `saved voice "${name}" should be listed under "Your voices"`).toHaveCount(1)
+    await row.getByRole('button', { name: 'Re-roll' }).click()
+  }
+
   /** Close the sidebar via its (responsive) Close button, scoped to the sidebar
    *  region so it can't match the header's window-close (X) button. */
   async close(mode: ChatMode = 'Chat'): Promise<void> {

--- a/WebUI/e2e/preset-chat.spec.ts
+++ b/WebUI/e2e/preset-chat.spec.ts
@@ -4,8 +4,10 @@ import { test, expect } from './fixtures'
 // (plain text, reasoning, vision, RAG) plus the separate Text-to-Speech preset:
 // install backends, select the preset, (optionally attach a fixture), send a prompt
 // and assert the expected result — a non-empty, well-formed text reply, or (for the
-// Text-to-Speech preset) two playable audio results: one from the default voice and a
-// second from a custom voice created mid-test. Excludes "aiDAPTIV™" (Phison) and
+// Text-to-Speech preset) a series of playable audio results: the default voice, then a
+// custom voice created mid-test, plus its regressions — the voice model is fetched when
+// the voice is saved, Regenerate re-synthesizes instead of loading a chat model, and a
+// saved voice reproduces the same audio until it is re-rolled. Excludes "aiDAPTIV™" (Phison) and
 // "Home Agent" per request; the Assistant agentic/tool flow has its own richer
 // coverage in assistant-media-flow.spec.ts. A preset not offered in the running product
 // mode skips itself.
@@ -64,7 +66,10 @@ test.describe('Chat presets', () => {
     const action = kind === 'tts' ? 'synthesizes audio from text' : 'replies to a prompt'
     const title = label ? `"${preset}" preset ${action} (${label})` : `"${preset}" preset ${action}`
     test(title, async ({ app }) => {
-      test.setTimeout(40 * 60_000)
+      // The TTS case runs five synthesis turns (default voice, custom voice,
+      // regenerate, repeat, re-roll) on top of two model downloads, so it gets more
+      // room than a single-turn chat case.
+      test.setTimeout(kind === 'tts' ? 55 * 60_000 : 40 * 60_000)
       await app.installAllBackends()
 
       if (kind === 'tts') {

--- a/WebUI/src/assets/js/qwen3TtsConstants.ts
+++ b/WebUI/src/assets/js/qwen3TtsConstants.ts
@@ -45,6 +45,13 @@ export type Qwen3TtsSavedVoice = {
   name: string
   instruct: string
   language?: Qwen3TtsLanguage
+  /**
+   * Sampling seed pinned to this voice. Voice-design synthesis is sampled, so the
+   * same description otherwise yields a different-sounding person on every call.
+   * Persisting a seed makes a saved voice reproducible across generations; the
+   * user can re-roll it from settings when they dislike the result.
+   */
+  seed?: number
 }
 
 export const QWEN3_TTS_SPEAKERS: Array<{

--- a/WebUI/src/assets/js/store/backendServices.ts
+++ b/WebUI/src/assets/js/store/backendServices.ts
@@ -2,6 +2,7 @@ import { defineStore } from 'pinia'
 import { ref, computed, watch } from 'vue'
 import z from 'zod'
 import { demoAwareStorage } from '../demoAwareStorage'
+import { invalidateBackendAuthToken } from '@/lib/loopbackAuth'
 
 const backends = [
   'ai-backend',
@@ -471,6 +472,12 @@ export const useBackendServices = defineStore(
           ovmsKvCachePrecision: effectiveOvmsKvCachePrecision.value,
         })
       }
+      // A spawn regenerates the service's loopback token, so anything the renderer
+      // cached for it is now stale. Drop it here — the per-fetch 401 retry recovers
+      // either way, but only after the first call to the restarted service has been
+      // rejected (e.g. TTS: restart after a model download → `POST /api/load` 401,
+      // refresh, retry). Invalidating up front removes that wasted round-trip.
+      invalidateBackendAuthToken(serviceName)
       return window.electronAPI.startService(serviceName)
     }
 

--- a/WebUI/src/assets/js/store/openAiCompatibleChat.ts
+++ b/WebUI/src/assets/js/store/openAiCompatibleChat.ts
@@ -1305,7 +1305,12 @@ export const useOpenAiCompatibleChat = defineStore(
     async function synthesizeDirect(
       question: string,
       targetKey: string,
-      opts: { clearInputs: boolean; sideChannel: boolean },
+      opts: {
+        clearInputs: boolean
+        sideChannel: boolean
+        /** Regenerate: the user's message is already in the thread — don't duplicate it. */
+        keepExistingUserMessage?: boolean
+      },
     ): Promise<void> {
       const qwen3 = useQwen3TextToSpeech()
       const chat = getOrCreateChat(targetKey)
@@ -1313,14 +1318,16 @@ export const useOpenAiCompatibleChat = defineStore(
       // Show the user's message right away so the turn isn't blank while we
       // synthesize — this path has no streaming LLM to fill the bubble, and the
       // audio can take a while to generate.
-      const userMessage = {
-        id: crypto.randomUUID(),
-        role: 'user',
-        parts: [{ type: 'text', text: question }],
-        metadata: { timestamp: Date.now() },
-      } as unknown as AipgUiMessage
-      chat.messages.push(userMessage)
-      conversations.updateConversation(chat.messages, targetKey)
+      if (!opts.keepExistingUserMessage) {
+        const userMessage = {
+          id: crypto.randomUUID(),
+          role: 'user',
+          parts: [{ type: 'text', text: question }],
+          metadata: { timestamp: Date.now() },
+        } as unknown as AipgUiMessage
+        chat.messages.push(userMessage)
+        conversations.updateConversation(chat.messages, targetKey)
+      }
       if (opts.clearInputs) {
         messageInput.value = ''
         fileInput.value = []
@@ -1405,6 +1412,45 @@ export const useOpenAiCompatibleChat = defineStore(
       } as unknown as AipgUiMessage
       chat.messages.push(assistantMessage)
       conversations.updateConversation(chat.messages, targetKey)
+    }
+
+    /**
+     * Regenerate an audio turn in a TTS thread: drop the audio message (and
+     * anything after it) and synthesize the same prompt again, keeping the user's
+     * message in place. No LLM is involved — a TTS thread has no chat model.
+     */
+    async function regenerateSynthesis(messageId: string, targetKey: string): Promise<void> {
+      const chat = getOrCreateChat(targetKey)
+      const targetIdx = chat.messages.findIndex((m) => m.id === messageId)
+      if (targetIdx < 0) return
+      const priorUserMessage = [...chat.messages.slice(0, targetIdx)]
+        .reverse()
+        .find((m) => m.role === 'user')
+      const question =
+        priorUserMessage?.parts
+          ?.filter((p): p is { type: 'text'; text: string } => p.type === 'text')
+          .map((p) => p.text)
+          .join('\n\n')
+          .trim() ?? ''
+      if (!question) return
+
+      // A previous Stop leaves `manuallyStopped` set, which would keep `processing`
+      // false for this turn and let the UI accept a second submission mid-synthesis.
+      manuallyStopped.value = false
+      markGenerating(targetKey)
+      try {
+        // Drop the old audio turn first so the retry replaces it rather than
+        // appending a second player under the same prompt.
+        chat.messages.splice(targetIdx, chat.messages.length - targetIdx)
+        conversations.updateConversation(chat.messages, targetKey)
+        await synthesizeDirect(question, targetKey, {
+          clearInputs: false,
+          sideChannel: false,
+          keepExistingUserMessage: true,
+        })
+      } finally {
+        unmarkGenerating(targetKey)
+      }
     }
 
     async function generate(question: string, options?: GenerateOptions) {
@@ -1549,6 +1595,14 @@ export const useOpenAiCompatibleChat = defineStore(
       // so the new turn matches the thread's current profile (matches `generate`).
       textInference.ensureGlobalsMatchConversation(targetKey)
       textInference.stampMetaForConversation(targetKey)
+
+      // TTS preset: re-synthesize the prompt instead of running the LLM. Without
+      // this the regenerate button falls through to `ensureReadyForInference()`
+      // and loads a chat model into a thread that never uses one.
+      if (textInference.activePreset?.ttsPreset) {
+        await regenerateSynthesis(messageId, targetKey)
+        return
+      }
 
       try {
         await textInference.ensureReadyForInference()

--- a/WebUI/src/assets/js/store/qwen3TextToSpeech.ts
+++ b/WebUI/src/assets/js/store/qwen3TextToSpeech.ts
@@ -8,6 +8,7 @@ import { useDialogStore } from './dialogs'
 import * as toast from '@/assets/js/toast'
 import { createAppError } from '../errors/appError'
 import { qwen3TtsFetch } from '@/lib/loopbackAuth'
+import { resolveTtsSpeakerLabel } from '@/lib/ttsSpeakerLabel'
 import { QWEN3_TTS_MODEL_REPOS } from '@/assets/js/qwen3TtsConstants'
 import type {
   Qwen3TtsApiResponse,
@@ -31,6 +32,9 @@ export const useQwen3TextToSpeech = defineStore(
     /** Free-form voice description used when `mode === 'voice_design'` and no per-call
      *  `instruct` is supplied (e.g. the direct-synthesis TTS preset). */
     const defaultInstruct = ref<string>('')
+    /** Name of the saved voice currently selected in settings. Empty when a preset
+     *  speaker is active. Independent of `defaultSpeaker`, which is only a preset id. */
+    const defaultVoiceName = ref<string>('')
 
     /** User-created named voice directions, reusable from settings, chat, and the agent. */
     const savedVoices = ref<Qwen3TtsSavedVoice[]>([])
@@ -186,7 +190,6 @@ export const useQwen3TextToSpeech = defineStore(
       let mode = args.mode ?? defaultMode.value
       let language = args.language ?? defaultLanguage.value
       let instruct = args.instruct
-      const speaker = args.speaker ?? defaultSpeaker.value
       // A named voice is a saved voice_design description; it wins over mode/instruct.
       if (args.voiceName) {
         const saved = resolveVoice(args.voiceName)
@@ -197,6 +200,20 @@ export const useQwen3TextToSpeech = defineStore(
         instruct = saved.instruct
         if (saved.language) language = saved.language
       }
+      // For voice_design fall back to the saved description when the caller omits one.
+      const resolvedInstruct =
+        instruct ?? (mode === 'voice_design' ? defaultInstruct.value : undefined)
+      // Voice-design ignores the preset speaker id; label with the saved voice name
+      // instead of the leftover custom_voice default.
+      const speaker = resolveTtsSpeakerLabel({
+        mode,
+        voiceName:
+          args.voiceName?.trim() || (mode === 'voice_design' ? defaultVoiceName.value.trim() : ''),
+        instruct: resolvedInstruct,
+        savedVoices: savedVoices.value,
+        speaker: args.speaker,
+        defaultSpeaker: defaultSpeaker.value,
+      })
       // Only the model for the resolved mode is required.
       await ensureModelInstalled(mode)
       const baseUrl = await ensureBackendRunning()
@@ -204,8 +221,7 @@ export const useQwen3TextToSpeech = defineStore(
         text: args.text,
         language,
         speaker,
-        // For voice_design fall back to the saved description when the caller omits one.
-        instruct: instruct ?? (mode === 'voice_design' ? defaultInstruct.value : undefined),
+        instruct: resolvedInstruct,
         mode,
       }
       const response = await qwen3TtsFetch(`${baseUrl}/api/synthesize`, {
@@ -217,7 +233,8 @@ export const useQwen3TextToSpeech = defineStore(
       if (!response.ok || payload.code !== 0 || !payload.data) {
         throw new Error(payload.message ?? `Text To Speech synthesis failed (${response.status})`)
       }
-      return payload.data
+      // Sidecar echoes `speaker`; keep the resolved label if it ever diverges.
+      return { ...payload.data, speaker }
     }
 
     /** Persist WAV bytes under Documents/AI-Playground/audio and return the absolute path. */
@@ -243,7 +260,26 @@ export const useQwen3TextToSpeech = defineStore(
       if (args.speaker) defaultSpeaker.value = args.speaker
       if (args.language) defaultLanguage.value = args.language
       if (args.mode) defaultMode.value = args.mode
+      if (args.mode === 'custom_voice') defaultVoiceName.value = ''
       toast.success('Updated default Text To Speech voice settings for this session')
+    }
+
+    /** Select a saved voice as the active voice_design default. */
+    function applySavedVoice(name: string): boolean {
+      const voice = resolveVoice(name)
+      if (!voice) return false
+      defaultMode.value = 'voice_design'
+      defaultInstruct.value = voice.instruct
+      defaultVoiceName.value = voice.name
+      if (voice.language) defaultLanguage.value = voice.language
+      return true
+    }
+
+    /** Select a built-in preset speaker (custom_voice mode). */
+    function applyPresetSpeaker(speaker: Qwen3TtsSpeakerId): void {
+      defaultMode.value = 'custom_voice'
+      defaultSpeaker.value = speaker
+      defaultVoiceName.value = ''
     }
 
     /** Create or update a named voice direction (matched case-insensitively by name). */
@@ -258,9 +294,9 @@ export const useQwen3TextToSpeech = defineStore(
     }
 
     function deleteVoice(name: string): void {
-      savedVoices.value = savedVoices.value.filter(
-        (v) => v.name.toLowerCase() !== name.trim().toLowerCase(),
-      )
+      const n = name.trim().toLowerCase()
+      savedVoices.value = savedVoices.value.filter((v) => v.name.toLowerCase() !== n)
+      if (defaultVoiceName.value.toLowerCase() === n) defaultVoiceName.value = ''
     }
 
     function resolveVoice(name: string): Qwen3TtsSavedVoice | undefined {
@@ -287,6 +323,7 @@ export const useQwen3TextToSpeech = defineStore(
       defaultLanguage,
       defaultMode,
       defaultInstruct,
+      defaultVoiceName,
       savedVoices,
       isFeatureEnabled,
       synthesize,
@@ -298,6 +335,8 @@ export const useQwen3TextToSpeech = defineStore(
       isModelInstalled,
       isBackendSetUp,
       applyUserVoicePreference,
+      applySavedVoice,
+      applyPresetSpeaker,
       saveVoice,
       deleteVoice,
       resolveVoice,
@@ -306,7 +345,14 @@ export const useQwen3TextToSpeech = defineStore(
   {
     persist: {
       storage: demoAwareStorage,
-      pick: ['defaultSpeaker', 'defaultLanguage', 'defaultMode', 'defaultInstruct', 'savedVoices'],
+      pick: [
+        'defaultSpeaker',
+        'defaultLanguage',
+        'defaultMode',
+        'defaultInstruct',
+        'defaultVoiceName',
+        'savedVoices',
+      ],
     },
   },
 )

--- a/WebUI/src/assets/js/store/qwen3TextToSpeech.ts
+++ b/WebUI/src/assets/js/store/qwen3TextToSpeech.ts
@@ -9,6 +9,7 @@ import * as toast from '@/assets/js/toast'
 import { createAppError } from '../errors/appError'
 import { qwen3TtsFetch } from '@/lib/loopbackAuth'
 import { resolveTtsSpeakerLabel } from '@/lib/ttsSpeakerLabel'
+import { randomVoiceSeed, seedForVoice, stableVoiceSeed } from '@/lib/ttsVoiceSeed'
 import { QWEN3_TTS_MODEL_REPOS } from '@/assets/js/qwen3TtsConstants'
 import type {
   Qwen3TtsApiResponse,
@@ -191,14 +192,18 @@ export const useQwen3TextToSpeech = defineStore(
       let language = args.language ?? defaultLanguage.value
       let instruct = args.instruct
       // A named voice is a saved voice_design description; it wins over mode/instruct.
+      let saved = args.voiceName ? resolveVoice(args.voiceName) : undefined
       if (args.voiceName) {
-        const saved = resolveVoice(args.voiceName)
         if (!saved) {
           throw new Error(`No saved Text To Speech voice named "${args.voiceName}"`)
         }
         mode = 'voice_design'
         instruct = saved.instruct
         if (saved.language) language = saved.language
+      } else if (mode === 'voice_design' && defaultVoiceName.value) {
+        // Settings-driven path (TTS preset / "Speak"): the active voice is the one
+        // selected in settings, so it supplies the seed that keeps it recognisable.
+        saved = resolveVoice(defaultVoiceName.value)
       }
       // For voice_design fall back to the saved description when the caller omits one.
       const resolvedInstruct =
@@ -214,6 +219,17 @@ export const useQwen3TextToSpeech = defineStore(
         speaker: args.speaker,
         defaultSpeaker: defaultSpeaker.value,
       })
+      // Voice design samples a speaker from the description, so an unseeded run
+      // invents a new person every time. Pin the saved voice's seed (falling back
+      // to one derived from its description) so a saved voice stays itself across
+      // separate generations. Preset speakers already have a fixed timbre, so they
+      // keep their natural prosody variation.
+      const seed =
+        mode === 'voice_design' && saved
+          ? seedForVoice(saved)
+          : mode === 'voice_design' && resolvedInstruct
+            ? stableVoiceSeed('', resolvedInstruct)
+            : undefined
       // Only the model for the resolved mode is required.
       await ensureModelInstalled(mode)
       const baseUrl = await ensureBackendRunning()
@@ -223,6 +239,7 @@ export const useQwen3TextToSpeech = defineStore(
         speaker,
         instruct: resolvedInstruct,
         mode,
+        seed,
       }
       const response = await qwen3TtsFetch(`${baseUrl}/api/synthesize`, {
         method: 'POST',
@@ -287,10 +304,38 @@ export const useQwen3TextToSpeech = defineStore(
       const name = voice.name.trim()
       const instruct = voice.instruct.trim()
       if (!name || !instruct) return
-      const entry: Qwen3TtsSavedVoice = { name, instruct, language: voice.language }
       const idx = savedVoices.value.findIndex((v) => v.name.toLowerCase() === name.toLowerCase())
+      const existing = idx >= 0 ? savedVoices.value[idx] : undefined
+      // Pin a seed so the voice sounds the same every time it is used. Keep the
+      // existing one when only re-saving the same description; a rewritten
+      // description is a different voice, so it gets a fresh seed.
+      const seed =
+        voice.seed ??
+        (existing && existing.instruct.trim() === instruct
+          ? seedForVoice(existing)
+          : stableVoiceSeed(name, instruct))
+      const entry: Qwen3TtsSavedVoice = { name, instruct, language: voice.language, seed }
       if (idx >= 0) savedVoices.value.splice(idx, 1, entry)
       else savedVoices.value.push(entry)
+      // Keep an active selection of this voice in sync with the edited description.
+      if (defaultVoiceName.value.toLowerCase() === name.toLowerCase()) {
+        defaultInstruct.value = instruct
+      }
+    }
+
+    /**
+     * Give a saved voice a new random seed — i.e. draw a different speaker for the
+     * same description. The escape hatch when the pinned voice sounds wrong (too
+     * slow, wrong gender, odd prosody) instead of it silently changing on its own.
+     */
+    function rerollVoiceSeed(name: string): number | undefined {
+      const idx = savedVoices.value.findIndex(
+        (v) => v.name.toLowerCase() === name.trim().toLowerCase(),
+      )
+      if (idx < 0) return undefined
+      const seed = randomVoiceSeed()
+      savedVoices.value.splice(idx, 1, { ...savedVoices.value[idx], seed })
+      return seed
     }
 
     function deleteVoice(name: string): void {
@@ -338,6 +383,7 @@ export const useQwen3TextToSpeech = defineStore(
       applySavedVoice,
       applyPresetSpeaker,
       saveVoice,
+      rerollVoiceSeed,
       deleteVoice,
       resolveVoice,
     }

--- a/WebUI/src/components/SettingsTts.vue
+++ b/WebUI/src/components/SettingsTts.vue
@@ -15,7 +15,15 @@
       v-else-if="!ttsModelDownloaded"
       class="flex items-center justify-between gap-3 rounded-md border border-amber-500/40 bg-amber-500/10 px-3 py-2 text-xs text-amber-600 dark:text-amber-300"
     >
-      <span>The model for the selected voice isn't installed yet.</span>
+      <span>
+        {{
+          qwen3Tts.defaultMode === 'voice_design'
+            ? "The model for created voices isn't installed yet."
+            : "The model for the built-in voices isn't installed yet."
+        }}
+        Built-in voices and voices you create use different models, so each is downloaded once,
+        separately.
+      </span>
       <Button size="sm" :disabled="installing" @click="installModel">
         {{ installing ? 'Installing…' : 'Install model' }}
       </Button>
@@ -70,8 +78,10 @@
       <div>
         <h3 class="text-sm font-medium text-foreground">Create a custom voice</h3>
         <p class="text-xs text-muted-foreground">
-          Describe a voice in words — timbre, age, accent, tone (e.g. “Authoritative American female
-          voice”). Save it to add it to your Voice list and use it in chat by name.
+          Describe a voice in words — timbre, age, accent, tone, and pace (e.g. “Authoritative
+          American female voice speaking at a natural, brisk pace”). Save it to add it to your Voice
+          list and use it in chat by name. A saved voice keeps its sound across sessions; use
+          Re-roll below to draw a different speaker for the same description.
         </p>
       </div>
 
@@ -108,7 +118,9 @@
       <div class="grid grid-cols-[120px_1fr] items-center gap-4">
         <span></span>
         <div>
-          <Button size="sm" :disabled="!canSaveVoice" @click="saveCurrentVoice">Save voice</Button>
+          <Button size="sm" :disabled="!canSaveVoice || savingVoice" @click="saveCurrentVoice">
+            {{ savingVoice ? 'Preparing…' : 'Save voice' }}
+          </Button>
         </div>
       </div>
 
@@ -128,12 +140,24 @@
               <div class="text-sm text-foreground">{{ voice.name }}</div>
               <div class="truncate text-xs text-muted-foreground">{{ voice.instruct }}</div>
             </div>
-            <button
-              class="shrink-0 text-xs text-muted-foreground hover:text-destructive"
-              @click="qwen3Tts.deleteVoice(voice.name)"
-            >
-              Remove
-            </button>
+            <div class="flex shrink-0 items-center gap-3">
+              <!-- A saved voice keeps the same seed so it sounds the same every
+                   time. Re-roll draws a different speaker for the same description
+                   (useful when the current one sounds off — e.g. too slow). -->
+              <button
+                class="text-xs text-muted-foreground hover:text-foreground"
+                title="Draw a different speaker for this description"
+                @click="qwen3Tts.rerollVoiceSeed(voice.name)"
+              >
+                Re-roll
+              </button>
+              <button
+                class="text-xs text-muted-foreground hover:text-destructive"
+                @click="qwen3Tts.deleteVoice(voice.name)"
+              >
+                Remove
+              </button>
+            </div>
           </li>
         </ul>
       </div>
@@ -253,8 +277,10 @@ const canSaveVoice = computed(
   () => newVoiceName.value.trim().length > 0 && newVoiceInstruct.value.trim().length > 0,
 )
 
-function saveCurrentVoice() {
-  if (!canSaveVoice.value) return
+const savingVoice = ref(false)
+
+async function saveCurrentVoice() {
+  if (!canSaveVoice.value || savingVoice.value) return
   const name = newVoiceName.value.trim()
   qwen3Tts.saveVoice({
     name,
@@ -266,5 +292,19 @@ function saveCurrentVoice() {
   newVoiceName.value = ''
   newVoiceInstruct.value = ''
   newVoiceLanguage.value = 'Auto'
+
+  // Created voices need the voice-design weights, which are a different model
+  // from the preset speakers'. Offer the download here — at the moment the user
+  // creates the voice — instead of ambushing them mid-chat on first use. The
+  // voice stays saved either way if they cancel.
+  savingVoice.value = true
+  try {
+    await qwen3Tts.ensureModelInstalled('voice_design')
+  } catch {
+    // Cancellation / failure is surfaced by the download dialog itself.
+  } finally {
+    savingVoice.value = false
+    await refreshModelInstalled()
+  }
 }
 </script>

--- a/WebUI/src/components/SettingsTts.vue
+++ b/WebUI/src/components/SettingsTts.vue
@@ -220,10 +220,16 @@ const voiceItems = computed(() => {
   return [...presets, ...saved]
 })
 
-// Which voice is active: a preset speaker, or a created voice matched by its
-// description. Falls back to empty when a designed voice has no saved match.
+// Which voice is active: a saved voice by name (preferred) or by matching
+// description (older persisted sessions), else a preset speaker.
 const selectedVoiceValue = computed(() => {
   if (qwen3Tts.defaultMode === 'voice_design') {
+    const byName = qwen3Tts.defaultVoiceName
+      ? qwen3Tts.savedVoices.find(
+          (v) => v.name.toLowerCase() === qwen3Tts.defaultVoiceName.toLowerCase(),
+        )
+      : undefined
+    if (byName) return `saved:${byName.name}`
     const match = qwen3Tts.savedVoices.find((v) => v.instruct === qwen3Tts.defaultInstruct)
     return match ? `saved:${match.name}` : ''
   }
@@ -232,20 +238,10 @@ const selectedVoiceValue = computed(() => {
 
 function onSelectVoice(value: string) {
   if (value.startsWith('saved:')) {
-    applySavedVoice(value.slice('saved:'.length))
+    qwen3Tts.applySavedVoice(value.slice('saved:'.length))
   } else {
-    qwen3Tts.defaultMode = 'custom_voice'
-    qwen3Tts.defaultSpeaker = value.replace(/^preset:/, '') as Qwen3TtsSpeakerId
+    qwen3Tts.applyPresetSpeaker(value.replace(/^preset:/, '') as Qwen3TtsSpeakerId)
   }
-}
-
-// A created voice is a voice_design description; apply it as the active voice.
-function applySavedVoice(name: string) {
-  const voice = qwen3Tts.resolveVoice(name)
-  if (!voice) return
-  qwen3Tts.defaultMode = 'voice_design'
-  qwen3Tts.defaultInstruct = voice.instruct
-  if (voice.language) qwen3Tts.defaultLanguage = voice.language
 }
 
 // --- Create-a-voice form (kept separate from the active selection) ---
@@ -266,7 +262,7 @@ function saveCurrentVoice() {
     language: newVoiceLanguage.value,
   })
   // Make the freshly created voice the active one, and reset the form.
-  applySavedVoice(name)
+  qwen3Tts.applySavedVoice(name)
   newVoiceName.value = ''
   newVoiceInstruct.value = ''
   newVoiceLanguage.value = 'Auto'

--- a/WebUI/src/lib/loopbackAuth.ts
+++ b/WebUI/src/lib/loopbackAuth.ts
@@ -26,6 +26,16 @@ function invalidate(serviceName: BackendServiceName) {
 }
 
 /**
+ * Drop the cached token for a service. Every spawn regenerates the service's
+ * `AIPG_LOOPBACK_TOKEN`, so whoever (re)starts a service should call this: the
+ * per-fetch 401 retry below would recover anyway, but only after burning a
+ * guaranteed-rejected request on the first call after the restart.
+ */
+export function invalidateBackendAuthToken(serviceName: BackendServiceName): void {
+  invalidate(serviceName)
+}
+
+/**
  * Wraps `fetch` for the ai-backend (Flask) service, attaching the loopback
  * auth token via the `X-AIPG-Auth` request header.
  *

--- a/WebUI/src/lib/ttsSpeakerLabel.test.ts
+++ b/WebUI/src/lib/ttsSpeakerLabel.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from 'vitest'
+import { resolveTtsSpeakerLabel } from './ttsSpeakerLabel'
+
+const hans = {
+  name: 'Hans',
+  instruct: 'Authoritative and commanding – Delivered with strict, formal authority.',
+}
+
+describe('resolveTtsSpeakerLabel', () => {
+  it('uses a saved voice name in voice_design even when a leftover preset speaker is set', () => {
+    expect(
+      resolveTtsSpeakerLabel({
+        mode: 'voice_design',
+        voiceName: 'Hans',
+        instruct: hans.instruct,
+        savedVoices: [hans],
+        speaker: 'Vivian',
+        defaultSpeaker: 'Ryan',
+      }),
+    ).toBe('Hans')
+  })
+
+  it('matches a saved voice by instruct when no name is stored (persisted selection)', () => {
+    expect(
+      resolveTtsSpeakerLabel({
+        mode: 'voice_design',
+        instruct: hans.instruct,
+        savedVoices: [hans],
+        speaker: 'Ryan',
+        defaultSpeaker: 'Ryan',
+      }),
+    ).toBe('Hans')
+  })
+
+  it('is case-insensitive for saved voice names', () => {
+    expect(
+      resolveTtsSpeakerLabel({
+        mode: 'voice_design',
+        voiceName: 'hans',
+        savedVoices: [hans],
+        defaultSpeaker: 'Ryan',
+      }),
+    ).toBe('Hans')
+  })
+
+  it('labels unnamed voice_design as custom instead of a preset speaker', () => {
+    expect(
+      resolveTtsSpeakerLabel({
+        mode: 'voice_design',
+        instruct: 'A gravelly pirate voice',
+        savedVoices: [hans],
+        speaker: 'Vivian',
+        defaultSpeaker: 'Ryan',
+      }),
+    ).toBe('custom')
+  })
+
+  it('uses the preset speaker in custom_voice mode', () => {
+    expect(
+      resolveTtsSpeakerLabel({
+        mode: 'custom_voice',
+        speaker: 'Vivian',
+        savedVoices: [hans],
+        defaultSpeaker: 'Ryan',
+      }),
+    ).toBe('Vivian')
+  })
+
+  it('falls back to the default preset speaker in custom_voice mode', () => {
+    expect(
+      resolveTtsSpeakerLabel({
+        mode: 'custom_voice',
+        savedVoices: [],
+        defaultSpeaker: 'Ryan',
+      }),
+    ).toBe('Ryan')
+  })
+})

--- a/WebUI/src/lib/ttsSpeakerLabel.ts
+++ b/WebUI/src/lib/ttsSpeakerLabel.ts
@@ -1,0 +1,38 @@
+import type { Qwen3TtsSavedVoice, Qwen3TtsSynthesisMode } from '@/assets/js/qwen3TtsConstants'
+
+/**
+ * Speaker name shown in "Synthesized … speech (language, NAME)" and echoed by the
+ * sidecar. Voice-design uses a saved voice's name (or "custom"); leftover preset
+ * speakers like Ryan/Vivian must not leak through just because they are the last
+ * custom_voice default.
+ */
+export function resolveTtsSpeakerLabel(opts: {
+  mode: Qwen3TtsSynthesisMode
+  /** Explicit saved-voice name (tool `voiceName` or the settings selection). */
+  voiceName?: string
+  instruct?: string
+  savedVoices: ReadonlyArray<Pick<Qwen3TtsSavedVoice, 'name' | 'instruct'>>
+  speaker?: string
+  defaultSpeaker: string
+}): string {
+  const findByName = (name: string) => {
+    const n = name.trim().toLowerCase()
+    if (!n) return undefined
+    return opts.savedVoices.find((v) => v.name.toLowerCase() === n)
+  }
+
+  const named = opts.voiceName?.trim()
+  if (named) {
+    return findByName(named)?.name ?? named
+  }
+
+  if (opts.mode === 'voice_design') {
+    if (opts.instruct) {
+      const match = opts.savedVoices.find((v) => v.instruct === opts.instruct)
+      if (match) return match.name
+    }
+    return 'custom'
+  }
+
+  return opts.speaker || opts.defaultSpeaker
+}

--- a/qwen3-tts/tts_engine.py
+++ b/qwen3-tts/tts_engine.py
@@ -218,6 +218,24 @@ def _load_model(model_id: str) -> Any:
             raise
 
 
+def _seed_everything(seed: int) -> None:
+    """Pin the sampler so the same request reproduces the same voice.
+
+    Voice design draws a speaker from the description, so without a seed the same
+    saved voice sounds like a different person on every generation. Called with
+    the inference lock held, right before generate().
+    """
+    import torch
+
+    torch.manual_seed(seed)
+    with contextlib.suppress(AttributeError, RuntimeError, OSError):
+        if torch.cuda.is_available():
+            torch.cuda.manual_seed_all(seed)
+    with contextlib.suppress(AttributeError, RuntimeError, OSError):
+        if hasattr(torch, "xpu") and torch.xpu.is_available():
+            torch.xpu.manual_seed_all(seed)
+
+
 def synthesize_wav(
     *,
     text: str,
@@ -225,6 +243,7 @@ def synthesize_wav(
     speaker: str,
     instruct: str | None,
     mode: SynthesisMode,
+    seed: int | None = None,
 ) -> tuple[bytes, int]:
     import numpy as np
     import soundfile as sf
@@ -248,6 +267,8 @@ def synthesize_wav(
     # Serialize inference: the cached models share one accelerator and the
     # generate paths are not thread-safe, so only one synthesis runs at a time.
     with _infer_lock:
+        if seed is not None:
+            _seed_everything(seed)
         if mode == "voice_design":
             wavs, sr = model.generate_voice_design(
                 text=trimmed,

--- a/qwen3-tts/web_api.py
+++ b/qwen3-tts/web_api.py
@@ -106,6 +106,14 @@ def synthesize():
     mode = body.get("mode", "custom_voice")
     if mode not in ("custom_voice", "voice_design"):
         return jsonify({"code": -1, "message": f"unsupported mode: {mode}"}), 400
+    # Optional sampler seed: the client pins one per saved voice so the voice is
+    # reproducible across generations. Clamped to a torch-safe non-negative int;
+    # anything unparsable just means "unseeded".
+    seed_raw = body.get("seed")
+    try:
+        seed = abs(int(seed_raw)) % (2**31) if seed_raw is not None else None
+    except (TypeError, ValueError):
+        seed = None
     try:
         wav_bytes, sample_rate = synthesize_wav(
             text=str(text),
@@ -113,6 +121,7 @@ def synthesize():
             speaker=str(speaker),
             instruct=str(instruct) if instruct is not None else None,
             mode=mode,
+            seed=seed,
         )
         encoded = base64.b64encode(wav_bytes).decode("ascii")
         return jsonify(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
**Description:**

Selecting a saved custom voice (e.g. "Hans (your voice)") correctly sent the voice-design `instruct` to the sidecar, but the chat result still named a leftover preset speaker (`Ryan`, `Vivian`, …). The preset id was never cleared when switching to a designed voice, and `synthesize()` always echoed `defaultSpeaker`.

**Related Issue:**

N/A — reported from a TTS playground session where a custom voice was selected but the status line showed a different name.

**Changes Made:**

- Track the selected saved voice name (`defaultVoiceName`) separately from the last preset speaker id.
- Resolve the displayed/API `speaker` for `voice_design` from that name (or by matching `instruct` for older persisted sessions), never from the leftover preset.
- Selecting a preset speaker clears the saved-voice name; deleting the active saved voice does too.
- E2E TTS flow asserts the second (custom-voice) result names the saved voice.

**Testing Done:**

- Unit tests for `resolveTtsSpeakerLabel` (saved name wins, instruct fallback, unnamed design → `custom`, preset path unchanged).
- Full Vitest suite: 199 passed.
- `vue-tsc --noEmit` and ESLint on the touched files.
- `npx playwright test --config playwright-e2e.config.ts --list` (34 tests listed).

**Screenshots:**

N/A — label-only fix; synthesis still uses the custom instruct as before.

**Checklist:**

- [x] I have tested the changes locally.
- [x] I have self-reviewed the code changes.
- [x] I have updated the documentation, if necessary.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6ac1dca6-f802-4d58-872f-eddbd52232c4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6ac1dca6-f802-4d58-872f-eddbd52232c4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

