### PR TITLE
Fix ComfyUI ENOENT after upgrading AI Playground

### DIFF
--- a/WebUI/electron/subprocesses/aiBackendService.ts
+++ b/WebUI/electron/subprocesses/aiBackendService.ts
@@ -143,11 +143,7 @@ export class AiBackendService extends LongLivedPythonApiService {
       AIPG_LOOPBACK_TOKEN: this.loopbackAuthToken,
     }
 
-    const pythonBinary = path.join(
-      this.pythonEnvDir,
-      process.platform === 'win32' ? 'Scripts' : 'bin',
-      process.platform === 'win32' ? 'python.exe' : 'python',
-    )
+    const pythonBinary = this.getPythonBinaryPath()
     const apiProcess = spawn(pythonBinary, ['web_api.py', '--port', this.port.toString()], {
       cwd: this.serviceDir,
       windowsHide: true,

--- a/WebUI/electron/subprocesses/comfyUIBackendService.ts
+++ b/WebUI/electron/subprocesses/comfyUIBackendService.ts
@@ -21,7 +21,7 @@ import {
   installExtraWheels,
   pipInstallRequirementsFromFile,
 } from './uvBasedBackends/uv.ts'
-import { isUsableVenv, venvInterpreterPath } from './uvBasedBackends/venvState.ts'
+import { isUsableVenv } from './uvBasedBackends/venvState.ts'
 import {
   COMFYUI_DEPS_MARKER_FILENAME,
   normalizeComfyUiRef,
@@ -1441,10 +1441,6 @@ export class ComfyUiBackendService extends LongLivedPythonApiService {
       ...this.getCommonEnvVars(),
       ...this.getDeviceSelectorEnv(),
     }
-  }
-
-  getPythonBinaryPath() {
-    return venvInterpreterPath(this.pythonEnvDir)
   }
 
   async detectDevices() {

--- a/WebUI/electron/subprocesses/comfyUIBackendService.ts
+++ b/WebUI/electron/subprocesses/comfyUIBackendService.ts
@@ -21,6 +21,7 @@ import {
   installExtraWheels,
   pipInstallRequirementsFromFile,
 } from './uvBasedBackends/uv.ts'
+import { isUsableVenv, venvInterpreterPath } from './uvBasedBackends/venvState.ts'
 import {
   COMFYUI_DEPS_MARKER_FILENAME,
   normalizeComfyUiRef,
@@ -571,12 +572,13 @@ export class ComfyUiBackendService extends LongLivedPythonApiService {
         this.getEffectiveVariant(),
       )
 
-      // If venv doesn't exist, service is not set up
-      if (!checkDetails.venvExists) {
+      // Dir-only leftover .venv (no python.exe after upgrade) is not installed.
+      if (!checkDetails.venvExists || checkDetails.needsInstallation) {
         this.appLogger.info(
-          `Service ${this.name} venv does not exist, needs installation`,
+          `Service ${this.name} venv is missing or incomplete, needs installation`,
           this.name,
         )
+        this.environmentMismatchError = null
         return false
       }
 
@@ -1059,7 +1061,7 @@ export class ComfyUiBackendService extends LongLivedPythonApiService {
           existingMarker?.mode === 'flexible' &&
           markerMatches &&
           !variantChanged &&
-          filesystem.existsSync(this.pythonEnvDir)
+          isUsableVenv(this.pythonEnvDir)
         ) {
           needsInstall = false
           this.appLogger.info(
@@ -1442,11 +1444,7 @@ export class ComfyUiBackendService extends LongLivedPythonApiService {
   }
 
   getPythonBinaryPath() {
-    return path.join(
-      this.pythonEnvDir,
-      process.platform === 'win32' ? 'Scripts' : 'bin',
-      process.platform === 'win32' ? 'python.exe' : 'python',
-    )
+    return venvInterpreterPath(this.pythonEnvDir)
   }
 
   async detectDevices() {

--- a/WebUI/electron/subprocesses/homeAgentBackendService.ts
+++ b/WebUI/electron/subprocesses/homeAgentBackendService.ts
@@ -316,11 +316,7 @@ export class HomeAgentBackendService extends LongLivedPythonApiService {
       AIPG_LOOPBACK_TOKEN: this.loopbackAuthToken,
     }
 
-    const pythonBinary = path.join(
-      this.pythonEnvDir,
-      process.platform === 'win32' ? 'Scripts' : 'bin',
-      process.platform === 'win32' ? 'python.exe' : 'python',
-    )
+    const pythonBinary = this.getPythonBinaryPath()
     const apiProcess = spawn(pythonBinary, ['web_api.py', '--port', this.port.toString()], {
       cwd: this.serviceDir,
       windowsHide: true,

--- a/WebUI/electron/subprocesses/openVINOBackendService.ts
+++ b/WebUI/electron/subprocesses/openVINOBackendService.ts
@@ -10,6 +10,7 @@ import { exec } from 'child_process'
 import { LocalSettings } from '../main.ts'
 import getPort, { portNumbers } from 'get-port'
 import { ensureManagedPython, installBackend, uvPipInstallToTarget } from './uvBasedBackends/uv.ts'
+import { venvInterpreterPath } from './uvBasedBackends/venvState.ts'
 import { binary, extract, restoreTreeWritePermissions } from './tools.ts'
 import { getBundledBackendVersionSync, resolveModels } from '../remoteUpdates.ts'
 import {
@@ -955,10 +956,7 @@ export class OpenVINOBackendService implements ApiService {
    * Returns array of {id, name} objects, or null if detection fails.
    */
   private async detectDevicesWithPython(): Promise<{ id: string; name: string }[] | null> {
-    const pythonExe = path.join(
-      this.pythonEnvDir,
-      process.platform === 'win32' ? 'Scripts/python.exe' : 'bin/python',
-    )
+    const pythonExe = venvInterpreterPath(this.pythonEnvDir)
 
     // Check if Python environment and script exist
     if (!filesystem.existsSync(pythonExe) || !filesystem.existsSync(this.detectDevicesScript)) {

--- a/WebUI/electron/subprocesses/qwen3TtsBackendService.ts
+++ b/WebUI/electron/subprocesses/qwen3TtsBackendService.ts
@@ -111,11 +111,7 @@ export class Qwen3TtsBackendService extends LongLivedPythonApiService {
   }
 
   private get pythonBinary(): string {
-    return path.join(
-      this.pythonEnvDir,
-      process.platform === 'win32' ? 'Scripts' : 'bin',
-      process.platform === 'win32' ? 'python.exe' : 'python',
-    )
+    return this.getPythonBinaryPath()
   }
 
   /**

--- a/WebUI/electron/subprocesses/service.ts
+++ b/WebUI/electron/subprocesses/service.ts
@@ -15,6 +15,7 @@ import { promisify } from 'util'
 import { Arch, getArchPriority, getDeviceArch } from './deviceArch.ts'
 import { z } from 'zod'
 import { LocalSettings } from '../main.ts'
+import { isUsableVenv, venvInterpreterPath } from './uvBasedBackends/venvState.ts'
 
 const exec = promisify(childProcess.exec)
 
@@ -525,6 +526,10 @@ export abstract class LongLivedPythonApiService implements ApiService {
   abstract serviceIsSetUp(): Promise<boolean>
   abstract detectDevices(): Promise<void>
 
+  getPythonBinaryPath(): string {
+    return venvInterpreterPath(this.pythonEnvDir)
+  }
+
   async selectDevice(deviceId: string): Promise<void> {
     if (!this.devices.find((d) => d.id === deviceId)) return
     this.devices = this.devices.map((d) => ({ ...d, selected: d.id === deviceId }))
@@ -791,6 +796,14 @@ export abstract class LongLivedPythonApiService implements ApiService {
    * specific message.
    */
   protected async assertReadyToStart(): Promise<void> {
+    // Dir-only leftover `.venv` after an app upgrade (no python.exe) must not
+    // reach spawn — every uv-backed backend shares this interpreter check.
+    if (!isUsableVenv(this.pythonEnvDir)) {
+      this.isSetUp = false
+      throw new Error(
+        `The ${this.name} environment is not fully installed. Reinstall this component to finish provisioning it before starting.`,
+      )
+    }
     const ready = await this.serviceIsSetUp()
     if (!ready) {
       this.isSetUp = false

--- a/WebUI/electron/subprocesses/uvBasedBackends/uv.ts
+++ b/WebUI/electron/subprocesses/uvBasedBackends/uv.ts
@@ -5,6 +5,7 @@ import path from 'path'
 import fs from 'fs'
 import { spawn } from 'child_process'
 import z from 'zod'
+import { isUsableVenv, removeBrokenVenv, venvInterpreterPath } from './venvState.ts'
 
 export const aipgBaseDir = app.isPackaged
   ? packagedResourcesRoot()
@@ -235,9 +236,24 @@ const isHashMismatchError = (errorMessage: string): boolean => {
   return /hash mismatch/i.test(errorMessage)
 }
 
+const backendVenvDir = (backend: string) => path.join(aipgBaseDir, backend, '.venv')
+
+const removeBrokenBackendVenv = async (
+  backend: string,
+  logger: ReturnType<typeof loggerFor>,
+): Promise<void> => {
+  const venvDir = backendVenvDir(backend)
+  if (await removeBrokenVenv(venvDir)) {
+    logger.warn(
+      `Removed broken venv at ${venvDir} (python interpreter missing); it will be recreated`,
+    )
+  }
+}
+
 export const ensureBackendVenv = async (backend: string, extraEnv?: Record<string, string>) => {
   const logger = loggerFor(`uv.venv.${backend}`)
   await assertUv(logger)
+  await removeBrokenBackendVenv(backend, logger)
   const uvVenvCommand = [
     'venv',
     '--directory',
@@ -293,6 +309,7 @@ export const installBackend = async (
 ) => {
   const logger = loggerFor(`uv.sync.${backend}`)
   await assertUv(logger)
+  await removeBrokenBackendVenv(backend, logger)
   const uvVenvCommand = [
     'venv',
     '--directory',
@@ -337,6 +354,7 @@ export const installBackendWithExtra = async (
 ) => {
   const logger = loggerFor(`uv.sync-extra.${backend}.${extra}`)
   await assertUv(logger)
+  await removeBrokenBackendVenv(backend, logger)
   const uvVenvCommand = [
     'venv',
     '--directory',
@@ -406,18 +424,32 @@ export const checkBackendWithDetails = async (
   const logger = loggerFor(`uv.check-details.${backend}`)
   await assertUv(logger)
 
-  // Check if venv directory exists
-  let venvExists = false
-  try {
-    await fs.promises.access(venvPath, fs.constants.F_OK)
-    venvExists = true
-    logger.info(`Venv directory exists at ${venvPath}`)
-  } catch {
-    logger.info(`Venv directory does not exist at ${venvPath}`)
-    venvExists = false
+  // Leftover `.venv` after an app upgrade often has no python.exe — not usable.
+  const venvExists = isUsableVenv(venvPath)
+  if (!venvExists) {
+    const interpreter = venvInterpreterPath(venvPath)
+    const dirExists = fs.existsSync(venvPath)
+    if (dirExists) {
+      logger.warn(
+        `Venv directory exists at ${venvPath} but interpreter is missing at ${interpreter}`,
+      )
+    } else {
+      logger.info(`Venv directory does not exist at ${venvPath}`)
+    }
+    return {
+      venvExists: false,
+      action: 'create',
+      needsInstallation: true,
+      envMismatch: false,
+      exitCode: -1,
+      stdout: dirExists
+        ? `Virtual environment directory exists at ${venvPath} but ${interpreter} is missing.\nThe environment needs to be recreated.`
+        : undefined,
+    }
   }
+  logger.info(`Venv interpreter exists at ${venvInterpreterPath(venvPath)}`)
 
-  if (options?.skipLockfileCheck && venvExists) {
+  if (options?.skipLockfileCheck) {
     logger.info(`Skipping uv lockfile check for ${backend} (flexible ComfyUI deps mode)`)
     return {
       venvExists: true,

--- a/WebUI/electron/subprocesses/uvBasedBackends/uv.ts
+++ b/WebUI/electron/subprocesses/uvBasedBackends/uv.ts
@@ -5,7 +5,12 @@ import path from 'path'
 import fs from 'fs'
 import { spawn } from 'child_process'
 import z from 'zod'
-import { isUsableVenv, removeBrokenVenv, venvInterpreterPath } from './venvState.ts'
+import {
+  isUsableVenv,
+  removeBrokenVenv,
+  requireUsableVenv,
+  venvInterpreterPath,
+} from './venvState.ts'
 
 export const aipgBaseDir = app.isPackaged
   ? packagedResourcesRoot()
@@ -389,6 +394,13 @@ export const installBackendWithExtra = async (
 export const checkBackend = async (backend: string, extra?: UvExtra) => {
   const logger = loggerFor(`uv.check.${backend}`)
   await assertUv(logger)
+  const venvDir = backendVenvDir(backend)
+  if (!isUsableVenv(venvDir)) {
+    logger.warn(
+      `Backend ${backend} venv is missing its interpreter at ${venvInterpreterPath(venvDir)}`,
+    )
+    requireUsableVenv(venvDir)
+  }
   const uvCommand = ['sync', '--check', '--directory', aipgBaseDir, '--project', backend]
   // Resolve against the same optional-dependency extra the backend was installed
   // with (e.g. 'xpu'). Without it, uv resolves the base deps — generic torch,

--- a/WebUI/electron/subprocesses/uvBasedBackends/venvState.ts
+++ b/WebUI/electron/subprocesses/uvBasedBackends/venvState.ts
@@ -1,0 +1,45 @@
+import fs from 'node:fs'
+import path from 'node:path'
+import { restoreTreeWritePermissions } from '../tools.ts'
+
+export function venvInterpreterPath(venvDir: string): string {
+  return path.join(
+    venvDir,
+    process.platform === 'win32' ? 'Scripts' : 'bin',
+    process.platform === 'win32' ? 'python.exe' : 'python',
+  )
+}
+
+export function isUsableVenv(venvDir: string): boolean {
+  return fs.existsSync(venvInterpreterPath(venvDir))
+}
+
+/**
+ * Remove a leftover `.venv` that has no interpreter. `uv venv --allow-existing`
+ * preserves that directory instead of recreating python.exe — the state an
+ * incomplete uninstall / app upgrade leaves behind (dir exists, spawn ENOENT).
+ * Returns true when a broken venv was removed.
+ */
+export async function removeBrokenVenv(venvDir: string): Promise<boolean> {
+  if (!fs.existsSync(venvDir)) return false
+  if (isUsableVenv(venvDir)) return false
+
+  await restoreTreeWritePermissions(venvDir)
+
+  let lastError: unknown
+  for (let attempt = 0; attempt < 5; attempt++) {
+    try {
+      await fs.promises.rm(venvDir, { recursive: true, force: true })
+      return true
+    } catch (error) {
+      lastError = error
+      if ((error as NodeJS.ErrnoException)?.code === 'EACCES') {
+        await restoreTreeWritePermissions(venvDir)
+      }
+      if (attempt < 4) {
+        await new Promise((resolve) => setTimeout(resolve, 200 * (attempt + 1)))
+      }
+    }
+  }
+  throw lastError
+}

--- a/WebUI/electron/subprocesses/uvBasedBackends/venvState.ts
+++ b/WebUI/electron/subprocesses/uvBasedBackends/venvState.ts
@@ -14,6 +14,11 @@ export function isUsableVenv(venvDir: string): boolean {
   return fs.existsSync(venvInterpreterPath(venvDir))
 }
 
+export function requireUsableVenv(venvDir: string): void {
+  if (isUsableVenv(venvDir)) return
+  throw new Error(`Virtual environment at ${venvDir} is missing ${venvInterpreterPath(venvDir)}`)
+}
+
 /**
  * Remove a leftover `.venv` that has no interpreter. `uv venv --allow-existing`
  * preserves that directory instead of recreating python.exe — the state an

--- a/WebUI/electron/test/subprocesses/service.test.ts
+++ b/WebUI/electron/test/subprocesses/service.test.ts
@@ -1,7 +1,10 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { ChildProcess } from 'node:child_process'
-import { DeviceService, LongLivedPythonApiService } from '../../subprocesses/service'
+import fs from 'node:fs'
+import os from 'node:os'
 import path from 'node:path'
+import { DeviceService, LongLivedPythonApiService } from '../../subprocesses/service'
+import { venvInterpreterPath } from '../../subprocesses/uvBasedBackends/venvState'
 
 vi.mock('electron', () => ({
   app: {
@@ -17,7 +20,7 @@ vi.mock('electron', () => ({
 class FakeBackendService extends LongLivedPythonApiService {
   readonly isRequired = false
   healthEndpointUrl = `${this.baseUrl}/healthy`
-  readonly pythonEnvDir = '/tmp/fake/.venv'
+  readonly pythonEnvDir: string
   readonly serviceDir = '/tmp/fake'
   isSetUp = true
   devices: InferenceDevice[] = []
@@ -26,6 +29,17 @@ class FakeBackendService extends LongLivedPythonApiService {
   // Controls the base-class start guard: a false provisioning check must abort
   // startup before the process is spawned.
   setUpResult = true
+
+  constructor(
+    name: BackendServiceName,
+    port: number,
+    win: ConstructorParameters<typeof LongLivedPythonApiService>[2],
+    settings: ConstructorParameters<typeof LongLivedPythonApiService>[3],
+    pythonEnvDir = '/tmp/fake/.venv',
+  ) {
+    super(name, port, win, settings)
+    this.pythonEnvDir = pythonEnvDir
+  }
 
   async serviceIsSetUp(): Promise<boolean> {
     return this.setUpResult
@@ -52,11 +66,28 @@ class FakeBackendService extends LongLivedPythonApiService {
   }
 }
 
-function makeFakeBackend(): FakeBackendService {
+const tempDirs: string[] = []
+
+function makeUsableVenvDir(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'python-backend-venv-'))
+  tempDirs.push(dir)
+  const python = venvInterpreterPath(dir)
+  fs.mkdirSync(path.dirname(python), { recursive: true })
+  fs.writeFileSync(python, '')
+  return dir
+}
+
+function makeFakeBackend(pythonEnvDir = '/tmp/fake/.venv'): FakeBackendService {
   const win = { webContents: { send: vi.fn() } } as unknown as ConstructorParameters<
-    typeof FakeBackendService
+    typeof LongLivedPythonApiService
   >[2]
-  return new FakeBackendService('ai-backend' as BackendServiceName, 12345, win, {} as never)
+  return new FakeBackendService(
+    'ai-backend' as BackendServiceName,
+    12345,
+    win,
+    {} as never,
+    pythonEnvDir,
+  )
 }
 
 describe('DeviceService', () => {
@@ -115,8 +146,28 @@ describe('LongLivedPythonApiService start guard', () => {
     vi.clearAllMocks()
   })
 
+  afterEach(() => {
+    while (tempDirs.length > 0) {
+      const dir = tempDirs.pop()
+      if (dir) fs.rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  it('fails the start without spawning when the interpreter is missing', async () => {
+    const venvDir = fs.mkdtempSync(path.join(os.tmpdir(), 'broken-venv-'))
+    tempDirs.push(venvDir)
+    const service = makeFakeBackend(venvDir)
+
+    const status = await service.start()
+
+    expect(service.spawnCalled).toBe(false)
+    expect(status).toBe('failed')
+    expect(service.isSetUp).toBe(false)
+    expect(service.get_info().errorDetails?.stderr).toContain('not fully installed')
+  })
+
   it('fails the start without spawning when the backend is not set up', async () => {
-    const service = makeFakeBackend()
+    const service = makeFakeBackend(makeUsableVenvDir())
     service.setUpResult = false // serviceIsSetUp() → false triggers the base guard
 
     const status = await service.start()
@@ -134,7 +185,7 @@ describe('LongLivedPythonApiService start guard', () => {
   })
 
   it('proceeds to spawn when the backend is set up', async () => {
-    const service = makeFakeBackend()
+    const service = makeFakeBackend(makeUsableVenvDir())
     // serviceIsSetUp() → true → guard passes and startup continues into
     // spawnAPIProcess. listenServerReady is stubbed to report a clean boot.
     vi.spyOn(

--- a/WebUI/electron/test/subprocesses/venvState.test.ts
+++ b/WebUI/electron/test/subprocesses/venvState.test.ts
@@ -5,6 +5,7 @@ import path from 'node:path'
 import {
   isUsableVenv,
   removeBrokenVenv,
+  requireUsableVenv,
   venvInterpreterPath,
 } from '../../subprocesses/uvBasedBackends/venvState'
 
@@ -50,6 +51,21 @@ describe('isUsableVenv', () => {
     fs.mkdirSync(path.dirname(venvInterpreterPath(venvDir)), { recursive: true })
     fs.writeFileSync(venvInterpreterPath(venvDir), '')
     expect(isUsableVenv(venvDir)).toBe(true)
+  })
+})
+
+describe('requireUsableVenv', () => {
+  it('throws when the interpreter is missing', () => {
+    const venvDir = path.join(createTempDir(), '.venv')
+    fs.mkdirSync(venvDir)
+    expect(() => requireUsableVenv(venvDir)).toThrow(venvInterpreterPath(venvDir))
+  })
+
+  it('does not throw when the interpreter exists', () => {
+    const venvDir = path.join(createTempDir(), '.venv')
+    fs.mkdirSync(path.dirname(venvInterpreterPath(venvDir)), { recursive: true })
+    fs.writeFileSync(venvInterpreterPath(venvDir), '')
+    expect(() => requireUsableVenv(venvDir)).not.toThrow()
   })
 })
 

--- a/WebUI/electron/test/subprocesses/venvState.test.ts
+++ b/WebUI/electron/test/subprocesses/venvState.test.ts
@@ -1,0 +1,81 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import {
+  isUsableVenv,
+  removeBrokenVenv,
+  venvInterpreterPath,
+} from '../../subprocesses/uvBasedBackends/venvState'
+
+const tempDirs: string[] = []
+
+function createTempDir(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'venv-state-'))
+  tempDirs.push(dir)
+  return dir
+}
+
+afterEach(() => {
+  while (tempDirs.length > 0) {
+    const dir = tempDirs.pop()
+    if (dir) fs.rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+describe('venvInterpreterPath', () => {
+  it('points at Scripts/python.exe on Windows and bin/python elsewhere', () => {
+    const venvDir = path.join('ComfyUI', '.venv')
+    const expected =
+      process.platform === 'win32'
+        ? path.join(venvDir, 'Scripts', 'python.exe')
+        : path.join(venvDir, 'bin', 'python')
+    expect(venvInterpreterPath(venvDir)).toBe(expected)
+  })
+})
+
+describe('isUsableVenv', () => {
+  it('is false when the venv directory is missing', () => {
+    expect(isUsableVenv(path.join(createTempDir(), 'missing'))).toBe(false)
+  })
+
+  it('is false when the directory exists but the interpreter is missing', () => {
+    const venvDir = path.join(createTempDir(), '.venv')
+    fs.mkdirSync(venvDir)
+    expect(isUsableVenv(venvDir)).toBe(false)
+  })
+
+  it('is true when the interpreter file exists', () => {
+    const venvDir = path.join(createTempDir(), '.venv')
+    fs.mkdirSync(path.dirname(venvInterpreterPath(venvDir)), { recursive: true })
+    fs.writeFileSync(venvInterpreterPath(venvDir), '')
+    expect(isUsableVenv(venvDir)).toBe(true)
+  })
+})
+
+describe('removeBrokenVenv', () => {
+  it('is a no-op when the directory does not exist', async () => {
+    const venvDir = path.join(createTempDir(), '.venv')
+    expect(await removeBrokenVenv(venvDir)).toBe(false)
+    expect(fs.existsSync(venvDir)).toBe(false)
+  })
+
+  it('keeps a venv that still has its interpreter', async () => {
+    const venvDir = path.join(createTempDir(), '.venv')
+    const python = venvInterpreterPath(venvDir)
+    fs.mkdirSync(path.dirname(python), { recursive: true })
+    fs.writeFileSync(python, '')
+    expect(await removeBrokenVenv(venvDir)).toBe(false)
+    expect(fs.existsSync(python)).toBe(true)
+  })
+
+  it('removes a leftover venv directory with no interpreter', async () => {
+    const venvDir = path.join(createTempDir(), '.venv')
+    fs.mkdirSync(path.join(venvDir, process.platform === 'win32' ? 'Scripts' : 'bin'), {
+      recursive: true,
+    })
+    fs.writeFileSync(path.join(venvDir, 'pyvenv.cfg'), 'home = leftover')
+    expect(await removeBrokenVenv(venvDir)).toBe(true)
+    expect(fs.existsSync(venvDir)).toBe(false)
+  })
+})


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
**Description:**

After installing a new AI Playground version, a leftover `.venv` *directory* without `python.exe` was treated as installed. ComfyUI (and any other uv-backed Python backend) then spawned a missing interpreter (`ENOENT`) or ran `uv venv --allow-existing`, which preserves the broken directory.

This is now the shared rule for every Python backend, not only ComfyUI.

**Related Issue:**

Reported against post-upgrade ComfyUI setup (leftover `.venv` without `python.exe`). The same leftover state can hit AI Backend, Home Agent, Qwen3-TTS, and OpenVINO's detection venv.

**Changes Made:**

- Treat a venv as present only if the Python interpreter file exists (`isUsableVenv` / `requireUsableVenv`).
- `checkBackend()` fails immediately when the interpreter is missing, so AI Backend, Home Agent, TTS, and ComfyUI all report "not installed" instead of a lockfile mismatch.
- `LongLivedPythonApiService.assertReadyToStart()` blocks spawn for any leftover `.venv` without Python.
- Shared `getPythonBinaryPath()` on the base class; OpenVINO device detection uses the same path helper.
- Before `uv venv --allow-existing`, remove leftover venvs that have no interpreter.

**Testing Done:**

- `npx vitest run electron/test/subprocesses/venvState.test.ts electron/test/subprocesses/service.test.ts` — 14 tests passed (leftover dir, `requireUsableVenv`, shared start guard).
- `npm test` — 26 files / 209 tests passed.
- ESLint on the changed files — clean.

**Screenshots:**

N/A (backend install/startup path).

**Checklist:**

- [x] I have tested the changes locally.
- [x] I have self-reviewed the code changes.
- [ ] I have updated the documentation, if necessary.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d6b81e7d-1c14-4ad3-8d1a-f424dee87982?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d6b81e7d-1c14-4ad3-8d1a-f424dee87982&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

