### PR TITLE
Port leftover-venv hardening onto improve-app-reliability

### DIFF
--- a/WebUI/electron/main.ts
+++ b/WebUI/electron/main.ts
@@ -1055,6 +1055,9 @@ function initEventHandle() {
       }
     }
     persistLocalSettingsToDisk()
+    if (updates.disabledBackends) {
+      serviceRegistry?.setDisabledBackends(updates.disabledBackends)
+    }
     appLogger.info(`Updated local settings: ${JSON.stringify(updates)}`, 'electron-backend')
     return { success: true }
   })

--- a/WebUI/electron/subprocesses/apiServiceRegistry.ts
+++ b/WebUI/electron/subprocesses/apiServiceRegistry.ts
@@ -28,6 +28,11 @@ export interface ApiServiceRegistry {
 
 export class ApiServiceRegistryImpl implements ApiServiceRegistry {
   private registeredServices: ApiService[] = []
+  private disabledBackends: string[] = []
+
+  setDisabledBackends(names: string[]): void {
+    this.disabledBackends = names
+  }
 
   register(apiService: ApiService): void {
     if (this.registeredServices.includes(apiService)) {
@@ -88,7 +93,7 @@ export class ApiServiceRegistryImpl implements ApiServiceRegistry {
    * This runs in the background and doesn't block.
    * Waits for async setup checks to complete before starting services.
    */
-  async startAllSetUpServices(disabledBackends: string[] = []): Promise<void> {
+  async startAllSetUpServices(disabledBackends: string[] = this.disabledBackends): Promise<void> {
     // Check setup status for all services.
     // Some services check asynchronously (ai-backend, comfyui-backend) and some synchronously (llamacpp-backend).
     // We'll check all services that have a serviceIsSetUp method and use the actual result,
@@ -250,7 +255,8 @@ export async function aiplaygroundApiServiceRegistry(
 
     // Automatically start all set-up services in the background
     // This happens regardless of frontend state, making it more reliable
-    instance.startAllSetUpServices(settings.disabledBackends ?? [])
+    instance.setDisabledBackends(settings.disabledBackends ?? [])
+    instance.startAllSetUpServices()
   }
   return instance
 }

--- a/WebUI/electron/subprocesses/comfyUIBackendService.ts
+++ b/WebUI/electron/subprocesses/comfyUIBackendService.ts
@@ -588,12 +588,14 @@ export class ComfyUiBackendService extends LongLivedPythonApiService {
         this.getEffectiveVariant(),
       )
 
-      // If venv doesn't exist, service is not set up
-      if (!checkDetails.venvExists) {
+      // Dir-only leftover .venv (no interpreter) or uv reporting 'create' is
+      // not installed — do not auto-start a backend that cannot boot.
+      if (!checkDetails.venvExists || checkDetails.needsInstallation) {
         this.appLogger.info(
-          `Service ${this.name} venv does not exist, needs installation`,
+          `Service ${this.name} venv is missing or incomplete, needs installation`,
           this.name,
         )
+        this.environmentMismatchError = null
         return false
       }
 

--- a/WebUI/electron/subprocesses/service.ts
+++ b/WebUI/electron/subprocesses/service.ts
@@ -12,7 +12,7 @@ import { createHash } from 'crypto'
 
 import * as childProcess from 'node:child_process'
 import { promisify } from 'util'
-import { venvInterpreterPath, venvIsUsable } from './uvBasedBackends/uv.ts'
+import { removeBrokenVenv, venvInterpreterPath, venvIsUsable } from './uvBasedBackends/venvState.ts'
 import { Arch, getArchPriority, getDeviceArch } from './deviceArch.ts'
 import { z } from 'zod'
 import { LocalSettings } from '../main.ts'
@@ -703,7 +703,7 @@ export abstract class LongLivedPythonApiService implements ApiService {
       `venv of ${this.name} has no interpreter — removing the partial tree before installing`,
       this.name,
     )
-    await filesystem.remove(this.pythonEnvDir)
+    await removeBrokenVenv(this.pythonEnvDir)
   }
 
   async uninstall(): Promise<void> {
@@ -970,7 +970,7 @@ export abstract class LongLivedPythonApiService implements ApiService {
    * which is what a broken-but-present environment should report.
    */
   protected async assertReadyToStart(): Promise<void> {
-    const ready = await this.serviceIsSetUp()
+    const ready = venvIsUsable(this.pythonEnvDir) && (await this.serviceIsSetUp())
     if (!ready) {
       this.isSetUp = false
       throw new ServiceNotInstalledError(

--- a/WebUI/electron/subprocesses/uvBasedBackends/uv.ts
+++ b/WebUI/electron/subprocesses/uvBasedBackends/uv.ts
@@ -5,6 +5,9 @@ import path from 'path'
 import fs from 'fs'
 import { spawn } from 'child_process'
 import z from 'zod'
+import { removeBrokenVenv, venvInterpreterPath, venvIsUsable } from './venvState.ts'
+
+export { venvInterpreterPath, venvIsUsable } from './venvState.ts'
 
 export const aipgBaseDir = app.isPackaged
   ? packagedResourcesRoot()
@@ -245,9 +248,24 @@ const isHashMismatchError = (errorMessage: string): boolean => {
   return /hash mismatch/i.test(errorMessage)
 }
 
+const backendVenvDir = (backend: string) => path.join(aipgBaseDir, backend, '.venv')
+
+const removeBrokenBackendVenv = async (
+  backend: string,
+  logger: ReturnType<typeof loggerFor>,
+): Promise<void> => {
+  const venvDir = backendVenvDir(backend)
+  if (await removeBrokenVenv(venvDir)) {
+    logger.warn(
+      `Removed broken venv at ${venvDir} (python interpreter missing); it will be recreated`,
+    )
+  }
+}
+
 export const ensureBackendVenv = async (backend: string, extraEnv?: Record<string, string>) => {
   const logger = loggerFor(`uv.venv.${backend}`)
   await assertUv(logger)
+  await removeBrokenBackendVenv(backend, logger)
   const uvVenvCommand = [
     'venv',
     '--directory',
@@ -303,6 +321,7 @@ export const installBackend = async (
 ) => {
   const logger = loggerFor(`uv.sync.${backend}`)
   await assertUv(logger)
+  await removeBrokenBackendVenv(backend, logger)
   const uvVenvCommand = [
     'venv',
     '--directory',
@@ -347,6 +366,7 @@ export const installBackendWithExtra = async (
 ) => {
   const logger = loggerFor(`uv.sync-extra.${backend}.${extra}`)
   await assertUv(logger)
+  await removeBrokenBackendVenv(backend, logger)
   const uvVenvCommand = [
     'venv',
     '--directory',
@@ -378,23 +398,6 @@ export const installBackendWithExtra = async (
   }
 }
 
-/**
- * Path to a venv's own interpreter. A venv is only usable if this exists — the
- * `.venv` *directory* can survive as an empty husk (e.g. the Windows
- * uninstaller's `RMDir /r` cannot delete the deeply nested `site-packages`
- * paths a ComfyUI install creates, so it removes what it can and leaves the
- * rest behind), and treating that husk as an installed environment makes the
- * app auto-start a backend that cannot possibly boot.
- */
-export const venvInterpreterPath = (venvPath: string): string =>
-  process.platform === 'win32'
-    ? path.join(venvPath, 'Scripts', 'python.exe')
-    : path.join(venvPath, 'bin', 'python')
-
-/** True only for a venv that still has its interpreter — see `venvInterpreterPath`. */
-export const venvIsUsable = (venvPath: string): boolean =>
-  fs.existsSync(venvInterpreterPath(venvPath))
-
 export const checkBackend = async (backend: string, extra?: UvExtra) => {
   const logger = loggerFor(`uv.check.${backend}`)
   await assertUv(logger)
@@ -404,7 +407,7 @@ export const checkBackend = async (backend: string, extra?: UvExtra) => {
   // uninstaller's `RMDir /r` leaves behind), which makes the app auto-start a
   // backend that cannot possibly boot. checkBackendWithDetails already did this;
   // callers of the plain check need the same protection.
-  const venvPath = path.join(aipgBaseDir, backend, '.venv')
+  const venvPath = backendVenvDir(backend)
   if (!venvIsUsable(venvPath)) {
     logger.info(`Venv at ${venvPath} has no interpreter — reporting backend as not installed`)
     throw new Error(`Python environment for ${backend} is missing its interpreter`)
@@ -444,20 +447,33 @@ export const checkBackendWithDetails = async (
   const logger = loggerFor(`uv.check-details.${backend}`)
   await assertUv(logger)
 
-  // Check if the venv exists AND still owns an interpreter. A bare directory is
-  // not enough: a partially deleted venv (see `venvInterpreterPath`) would
-  // otherwise report as installed and be auto-started, failing at spawn time.
-  let venvExists = false
-  try {
-    await fs.promises.access(venvInterpreterPath(venvPath), fs.constants.F_OK)
-    venvExists = true
-    logger.info(`Venv exists at ${venvPath}`)
-  } catch {
-    logger.info(`Venv does not exist (or has no interpreter) at ${venvPath}`)
-    venvExists = false
+  // Leftover `.venv` after an app upgrade often has no python.exe — not usable.
+  // Return immediately: `uv sync --check` can report "in sync" against that husk.
+  const venvExists = venvIsUsable(venvPath)
+  if (!venvExists) {
+    const interpreter = venvInterpreterPath(venvPath)
+    const dirExists = fs.existsSync(venvPath)
+    if (dirExists) {
+      logger.warn(
+        `Venv directory exists at ${venvPath} but interpreter is missing at ${interpreter}`,
+      )
+    } else {
+      logger.info(`Venv directory does not exist at ${venvPath}`)
+    }
+    return {
+      venvExists: false,
+      action: 'create',
+      needsInstallation: true,
+      envMismatch: false,
+      exitCode: -1,
+      stdout: dirExists
+        ? `Virtual environment directory exists at ${venvPath} but ${interpreter} is missing.\nThe environment needs to be recreated.`
+        : undefined,
+    }
   }
+  logger.info(`Venv interpreter exists at ${venvInterpreterPath(venvPath)}`)
 
-  if (options?.skipLockfileCheck && venvExists) {
+  if (options?.skipLockfileCheck) {
     logger.info(`Skipping uv lockfile check for ${backend} (flexible ComfyUI deps mode)`)
     return {
       venvExists: true,

--- a/WebUI/electron/subprocesses/uvBasedBackends/venvState.ts
+++ b/WebUI/electron/subprocesses/uvBasedBackends/venvState.ts
@@ -1,0 +1,59 @@
+import fs from 'node:fs'
+import path from 'node:path'
+import { restoreTreeWritePermissions } from '../tools.ts'
+
+/**
+ * Path to a venv's own interpreter. A venv is only usable if this exists — the
+ * `.venv` *directory* can survive as an empty husk (e.g. the Windows
+ * uninstaller's `RMDir /r` cannot delete the deeply nested `site-packages`
+ * paths a ComfyUI install creates, so it removes what it can and leaves the
+ * rest behind), and treating that husk as an installed environment makes the
+ * app auto-start a backend that cannot possibly boot.
+ */
+export function venvInterpreterPath(venvDir: string): string {
+  return process.platform === 'win32'
+    ? path.join(venvDir, 'Scripts', 'python.exe')
+    : path.join(venvDir, 'bin', 'python')
+}
+
+/** True only for a venv that still has its interpreter — see `venvInterpreterPath`. */
+export function venvIsUsable(venvDir: string): boolean {
+  return fs.existsSync(venvInterpreterPath(venvDir))
+}
+
+export const isUsableVenv = venvIsUsable
+
+export function requireUsableVenv(venvDir: string): void {
+  if (venvIsUsable(venvDir)) return
+  throw new Error(`Virtual environment at ${venvDir} is missing ${venvInterpreterPath(venvDir)}`)
+}
+
+/**
+ * Remove a leftover `.venv` that has no interpreter. `uv venv --allow-existing`
+ * preserves that directory instead of recreating python.exe — the state an
+ * incomplete uninstall / app upgrade leaves behind (dir exists, spawn ENOENT).
+ * Returns true when a broken venv was removed.
+ */
+export async function removeBrokenVenv(venvDir: string): Promise<boolean> {
+  if (!fs.existsSync(venvDir)) return false
+  if (venvIsUsable(venvDir)) return false
+
+  await restoreTreeWritePermissions(venvDir)
+
+  let lastError: unknown
+  for (let attempt = 0; attempt < 5; attempt++) {
+    try {
+      await fs.promises.rm(venvDir, { recursive: true, force: true })
+      return true
+    } catch (error) {
+      lastError = error
+      if ((error as NodeJS.ErrnoException)?.code === 'EACCES') {
+        await restoreTreeWritePermissions(venvDir)
+      }
+      if (attempt < 4) {
+        await new Promise((resolve) => setTimeout(resolve, 200 * (attempt + 1)))
+      }
+    }
+  }
+  throw lastError
+}

--- a/WebUI/electron/test/subprocesses/service.test.ts
+++ b/WebUI/electron/test/subprocesses/service.test.ts
@@ -1,7 +1,10 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { ChildProcess } from 'node:child_process'
-import { DeviceService, LongLivedPythonApiService } from '../../subprocesses/service'
+import fs from 'node:fs'
+import os from 'node:os'
 import path from 'node:path'
+import { DeviceService, LongLivedPythonApiService } from '../../subprocesses/service'
+import { venvInterpreterPath } from '../../subprocesses/uvBasedBackends/venvState'
 
 vi.mock('electron', () => ({
   app: {
@@ -17,7 +20,7 @@ vi.mock('electron', () => ({
 class FakeBackendService extends LongLivedPythonApiService {
   readonly isRequired = false
   healthEndpointUrl = `${this.baseUrl}/healthy`
-  readonly pythonEnvDir = '/tmp/fake/.venv'
+  readonly pythonEnvDir: string
   readonly serviceDir = '/tmp/fake'
   isSetUp = true
   devices: InferenceDevice[] = []
@@ -26,6 +29,17 @@ class FakeBackendService extends LongLivedPythonApiService {
   // Controls the base-class start guard: a false provisioning check must abort
   // startup before the process is spawned.
   setUpResult = true
+
+  constructor(
+    name: BackendServiceName,
+    port: number,
+    win: ConstructorParameters<typeof LongLivedPythonApiService>[2],
+    settings: ConstructorParameters<typeof LongLivedPythonApiService>[3],
+    pythonEnvDir = '/tmp/fake/.venv',
+  ) {
+    super(name, port, win, settings)
+    this.pythonEnvDir = pythonEnvDir
+  }
 
   async serviceIsSetUp(): Promise<boolean> {
     return this.setUpResult
@@ -52,11 +66,28 @@ class FakeBackendService extends LongLivedPythonApiService {
   }
 }
 
-function makeFakeBackend(): FakeBackendService {
+const tempDirs: string[] = []
+
+function makeUsableVenvDir(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'python-backend-venv-'))
+  tempDirs.push(dir)
+  const python = venvInterpreterPath(dir)
+  fs.mkdirSync(path.dirname(python), { recursive: true })
+  fs.writeFileSync(python, '')
+  return dir
+}
+
+function makeFakeBackend(pythonEnvDir = '/tmp/fake/.venv'): FakeBackendService {
   const win = { webContents: { send: vi.fn() } } as unknown as ConstructorParameters<
-    typeof FakeBackendService
+    typeof LongLivedPythonApiService
   >[2]
-  return new FakeBackendService('ai-backend' as BackendServiceName, 12345, win, {} as never)
+  return new FakeBackendService(
+    'ai-backend' as BackendServiceName,
+    12345,
+    win,
+    {} as never,
+    pythonEnvDir,
+  )
 }
 
 describe('DeviceService', () => {
@@ -115,8 +146,28 @@ describe('LongLivedPythonApiService start guard', () => {
     vi.clearAllMocks()
   })
 
+  afterEach(() => {
+    while (tempDirs.length > 0) {
+      const dir = tempDirs.pop()
+      if (dir) fs.rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  it('reports not-installed without spawning when the interpreter is missing', async () => {
+    const venvDir = fs.mkdtempSync(path.join(os.tmpdir(), 'broken-venv-'))
+    tempDirs.push(venvDir)
+    const service = makeFakeBackend(venvDir)
+
+    const status = await service.start()
+
+    expect(service.spawnCalled).toBe(false)
+    expect(status).toBe('notInstalled')
+    expect(service.isSetUp).toBe(false)
+    expect(service.get_info().errorDetails).toBeNull()
+  })
+
   it('reports not-installed without spawning when the backend is not set up', async () => {
-    const service = makeFakeBackend()
+    const service = makeFakeBackend(makeUsableVenvDir())
     service.setUpResult = false // serviceIsSetUp() → false triggers the base guard
 
     const status = await service.start()
@@ -136,7 +187,7 @@ describe('LongLivedPythonApiService start guard', () => {
   })
 
   it('proceeds to spawn when the backend is set up', async () => {
-    const service = makeFakeBackend()
+    const service = makeFakeBackend(makeUsableVenvDir())
     // serviceIsSetUp() → true → guard passes and startup continues into
     // spawnAPIProcess. listenServerReady is stubbed to report a clean boot.
     vi.spyOn(

--- a/WebUI/electron/test/subprocesses/venvState.test.ts
+++ b/WebUI/electron/test/subprocesses/venvState.test.ts
@@ -1,0 +1,99 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import {
+  isUsableVenv,
+  removeBrokenVenv,
+  requireUsableVenv,
+  venvInterpreterPath,
+  venvIsUsable,
+} from '../../subprocesses/uvBasedBackends/venvState'
+
+const tempDirs: string[] = []
+
+function createTempDir(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'venv-state-'))
+  tempDirs.push(dir)
+  return dir
+}
+
+afterEach(() => {
+  while (tempDirs.length > 0) {
+    const dir = tempDirs.pop()
+    if (dir) fs.rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+describe('venvInterpreterPath', () => {
+  it('points at Scripts/python.exe on Windows and bin/python elsewhere', () => {
+    const venvDir = path.join('ComfyUI', '.venv')
+    const expected =
+      process.platform === 'win32'
+        ? path.join(venvDir, 'Scripts', 'python.exe')
+        : path.join(venvDir, 'bin', 'python')
+    expect(venvInterpreterPath(venvDir)).toBe(expected)
+  })
+})
+
+describe('venvIsUsable', () => {
+  it('is false when the venv directory is missing', () => {
+    expect(venvIsUsable(path.join(createTempDir(), 'missing'))).toBe(false)
+    expect(isUsableVenv(path.join(createTempDir(), 'missing'))).toBe(false)
+  })
+
+  it('is false when the directory exists but the interpreter is missing', () => {
+    const venvDir = path.join(createTempDir(), '.venv')
+    fs.mkdirSync(venvDir)
+    expect(venvIsUsable(venvDir)).toBe(false)
+  })
+
+  it('is true when the interpreter file exists', () => {
+    const venvDir = path.join(createTempDir(), '.venv')
+    fs.mkdirSync(path.dirname(venvInterpreterPath(venvDir)), { recursive: true })
+    fs.writeFileSync(venvInterpreterPath(venvDir), '')
+    expect(venvIsUsable(venvDir)).toBe(true)
+  })
+})
+
+describe('requireUsableVenv', () => {
+  it('throws when the interpreter is missing', () => {
+    const venvDir = path.join(createTempDir(), '.venv')
+    fs.mkdirSync(venvDir)
+    expect(() => requireUsableVenv(venvDir)).toThrow(venvInterpreterPath(venvDir))
+  })
+
+  it('does not throw when the interpreter exists', () => {
+    const venvDir = path.join(createTempDir(), '.venv')
+    fs.mkdirSync(path.dirname(venvInterpreterPath(venvDir)), { recursive: true })
+    fs.writeFileSync(venvInterpreterPath(venvDir), '')
+    expect(() => requireUsableVenv(venvDir)).not.toThrow()
+  })
+})
+
+describe('removeBrokenVenv', () => {
+  it('is a no-op when the directory does not exist', async () => {
+    const venvDir = path.join(createTempDir(), '.venv')
+    expect(await removeBrokenVenv(venvDir)).toBe(false)
+    expect(fs.existsSync(venvDir)).toBe(false)
+  })
+
+  it('keeps a venv that still has its interpreter', async () => {
+    const venvDir = path.join(createTempDir(), '.venv')
+    const python = venvInterpreterPath(venvDir)
+    fs.mkdirSync(path.dirname(python), { recursive: true })
+    fs.writeFileSync(python, '')
+    expect(await removeBrokenVenv(venvDir)).toBe(false)
+    expect(fs.existsSync(python)).toBe(true)
+  })
+
+  it('removes a leftover venv directory with no interpreter', async () => {
+    const venvDir = path.join(createTempDir(), '.venv')
+    fs.mkdirSync(path.join(venvDir, process.platform === 'win32' ? 'Scripts' : 'bin'), {
+      recursive: true,
+    })
+    fs.writeFileSync(path.join(venvDir, 'pyvenv.cfg'), 'home = leftover')
+    expect(await removeBrokenVenv(venvDir)).toBe(true)
+    expect(fs.existsSync(venvDir)).toBe(false)
+  })
+})

--- a/WebUI/src/assets/js/store/speechToText.ts
+++ b/WebUI/src/assets/js/store/speechToText.ts
@@ -119,6 +119,27 @@ export const useSpeechToText = defineStore(
       return svc?.isSetUp === true
     })
 
+    // Installation alone is not enough to *prefer* standalone over a configured
+    // fallback (CodeRabbit on 278): the sidecar can be set up without its model.
+    const standaloneModelPresent = ref(false)
+    async function refreshStandaloneModelPresent(): Promise<void> {
+      if (!isStandaloneAvailable.value) {
+        standaloneModelPresent.value = false
+        return
+      }
+      try {
+        standaloneModelPresent.value = await models.checkTranscriptionModelExists(
+          selectedStandaloneModel.value,
+        )
+      } catch {
+        standaloneModelPresent.value = false
+      }
+    }
+    watch([isStandaloneAvailable, selectedStandaloneModel], () => {
+      void refreshStandaloneModelPresent()
+    })
+    void refreshStandaloneModelPresent()
+
     /**
      * Whether speech-to-text is usable at all: OpenVINO Whisper (non-NVIDIA), the
      * standalone Whisper backend, or a configured external endpoint. Used to gate the
@@ -154,8 +175,9 @@ export const useSpeechToText = defineStore(
      *  SettingsStt then shows its "install a backend or enable an endpoint" hint. */
     const preferredSttEngine = computed<SttEngine>(() => {
       if (isWhisperAvailable.value) return 'whisper'
-      if (isStandaloneAvailable.value) return 'standalone'
+      if (isStandaloneAvailable.value && standaloneModelPresent.value) return 'standalone'
       if (isExternalAvailable.value) return 'external'
+      if (isStandaloneAvailable.value) return 'standalone'
       return offeredSttEngines.value[0] ?? 'external'
     })
 
@@ -241,6 +263,7 @@ export const useSpeechToText = defineStore(
       if (current.status !== 'running') {
         await backendServices.startService('whisper-backend')
       }
+      standaloneModelPresent.value = true
       return { downloadPrompted }
     }
 

--- a/WebUI/src/assets/js/store/speechToText.ts
+++ b/WebUI/src/assets/js/store/speechToText.ts
@@ -283,6 +283,20 @@ export const useSpeechToText = defineStore(
       }
     }
 
+    async function resolveStandaloneEndpointIfReady(): Promise<TranscriptionEndpoint | null> {
+      const svc = backendServices.info.find((s) => s.serviceName === 'whisper-backend')
+      if (!svc?.isSetUp || svc.status !== 'running') return null
+      try {
+        const modelExists = await models.checkTranscriptionModelExists(
+          selectedStandaloneModel.value,
+        )
+        if (!modelExists) return null
+      } catch {
+        return null
+      }
+      return resolveStandaloneEndpoint()
+    }
+
     /**
      * Ensure the OVMS Whisper server is ready to transcribe: OpenVINO must be set up
      * (or a fallback is configured), the model must be present (prompting the
@@ -336,13 +350,14 @@ export const useSpeechToText = defineStore(
       // `effectiveSttEngine`, not the raw selection: the engine that was readied
       // and recorded against must be the one we transcribe with.
       const engine = effectiveSttEngine.value
-      // The standalone engine forces its own torch sidecar.
+      // Standalone only when the sidecar can actually serve: installed-without-
+      // its-model would otherwise return the sidecar URL and skip a configured
+      // external fallback (Home Agent's dialog-free path never prompts a download).
       if (engine === 'standalone') {
-        return resolveStandaloneEndpoint()
-      }
-      // The External engine forces the fallback endpoint; otherwise prefer the OVMS
-      // Whisper server when running and fall back to the configured endpoint.
-      if (engine !== 'external') {
+        const endpoint = await resolveStandaloneEndpointIfReady()
+        if (endpoint) return endpoint
+      } else if (engine !== 'external') {
+        // Prefer the OVMS Whisper server when running; otherwise fall through.
         try {
           const ovmsUrl = await backendServices.getTranscriptionServerUrl()
           if (ovmsUrl) {

--- a/WebUI/src/views/PromptArea.vue
+++ b/WebUI/src/views/PromptArea.vue
@@ -636,7 +636,7 @@ const sttAvailable = computed(() => speechToText.available)
 const sttUnavailableHint = computed(() =>
   productModeStore.isNvidiaModeSelected
     ? 'Install the standalone Whisper backend (or set an external transcription endpoint) to use voice input'
-    : 'Install the OpenVINO or the standalone Whisper backend (or set an external transcription endpoint) to use voice input',
+    : 'Install the OpenVINO backend or standalone Whisper backend, or set an external transcription endpoint, to use voice input',
 )
 
 // Handle an uploaded audio file in the STT preset: transcribe it into a chat turn.

--- a/WebUI/src/views/PromptArea.vue
+++ b/WebUI/src/views/PromptArea.vue
@@ -90,8 +90,8 @@
                 speech.
               </template>
               <template v-else>
-                Install the OpenVINO backend (or set an external transcription endpoint in this
-                preset's settings) to transcribe speech.
+                Install the OpenVINO backend or standalone Whisper backend, or set an external
+                transcription endpoint in this preset's settings, to transcribe speech.
               </template>
             </p>
             <template v-else>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
**Description:**

Port leftover-venv hardening onto `improve-app-reliability` (PR 278) and apply the CodeRabbit review on that PR.

**Related Issue:**

PR 278 CodeRabbit review (4 inline + 1 outside-diff + 3 nitpicks).

**Changes Made:**

CodeRabbit on 278 — status:

- LlamaCPP archive signature (zip vs gzip/`tar.gz`) — already fixed on 278 (`assertDownloadedArchiveIsIntact`). No change.
- `ApiService` comment wrap (100-char) — already wrapped on 278. No change.
- Standalone STT vs external fallback — **fixed here.** `effectiveSttEngine` only *prefers* standalone when its model is on disk; `resolveTranscription` only returns the sidecar URL when the service is running and the model exists. Otherwise a configured fallback is used. Explicit standalone selection still prompts a download.
- Non-NVIDIA `sttUnavailableHint` — **aligned** with the suggested wording (standalone Whisper + OpenVINO + external). STT-preset empty-state copy updated the same way.
- Disabled backends on every auto-start — **fixed here.** The registry keeps `disabledBackends` and uses it as the default for `startAllSetUpServices()`; wizard updates sync the list via `updateLocalSettings`.
- Nitpick: `ALL_BACKENDS` from `allBackendServiceNames` — already on 278.
- Nitpick: whisper torch probe once per start — already on 278 (`torchProbeForStartGuard`).
- Nitpick: async ComfyUI tree removal — already on 278.

Leftover-venv port (the other half of this branch): `venvState.ts`, wipe husks before `uv venv`/`installBackend*`, `checkBackendWithDetails` short-circuit, ComfyUI `needsInstallation` as not installed.

**Testing Done:**

- `npm test` — 37 files, 359 passed
- Prettier + ESLint on touched files — clean

**Screenshots:**

N/A

**Checklist:**

- [x] I have tested the changes locally.
- [x] I have self-reviewed the code changes.
- [ ] I have updated the documentation, if necessary.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d6b81e7d-1c14-4ad3-8d1a-f424dee87982?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d6b81e7d-1c14-4ad3-8d1a-f424dee87982&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

