### PR TITLE
Start TTS and STT backends only when requested

### DIFF
--- a/WebUI/electron/subprocesses/apiServiceRegistry.ts
+++ b/WebUI/electron/subprocesses/apiServiceRegistry.ts
@@ -2,6 +2,7 @@ import { ApiService } from './service.ts'
 import { ComfyUiBackendService } from './comfyUIBackendService.ts'
 import { AiBackendService } from './aiBackendService.ts'
 import { BrowserWindow } from 'electron'
+import { isOnDemandBackend } from '@/lib/onDemandBackends'
 import { appLoggerInstance } from '../logging/logger.ts'
 import getPort, { portNumbers } from 'get-port'
 import { LlamaCppBackendService } from './llamaCppBackendService.ts'
@@ -89,7 +90,8 @@ export class ApiServiceRegistryImpl implements ApiServiceRegistry {
   }
 
   /**
-   * Automatically start all services that are set up.
+   * Automatically start all services that are set up, except on-demand TTS/STT
+   * sidecars (those start when a feature requests them, to preserve VRAM).
    * This runs in the background and doesn't block.
    * Waits for async setup checks to complete before starting services.
    */
@@ -144,15 +146,52 @@ export class ApiServiceRegistryImpl implements ApiServiceRegistry {
       return
     }
 
-    appLoggerInstance.info(
-      `Starting ${setUpServices.length} backend service(s) automatically:`,
-      'apiServiceRegistry',
-    )
-    appLoggerInstance.info(setUpServices.map((s) => s.name).join(', '), 'apiServiceRegistry')
+    const autoStartServices = setUpServices.filter((service) => !isOnDemandBackend(service.name))
+    const onDemandServices = setUpServices.filter((service) => isOnDemandBackend(service.name))
+    if (onDemandServices.length > 0) {
+      appLoggerInstance.info(
+        `Not auto-starting on-demand backend(s) (started when requested): ${onDemandServices
+          .map((s) => s.name)
+          .join(', ')}`,
+        'apiServiceRegistry',
+      )
+    }
 
-    // Start all services in parallel, but don't block
+    if (autoStartServices.length > 0) {
+      appLoggerInstance.info(
+        `Starting ${autoStartServices.length} backend service(s) automatically:`,
+        'apiServiceRegistry',
+      )
+      appLoggerInstance.info(autoStartServices.map((s) => s.name).join(', '), 'apiServiceRegistry')
+    } else {
+      appLoggerInstance.info('No services are set up to auto-start', 'apiServiceRegistry')
+    }
+
+    // Detect devices for on-demand services so the device picker is accurate
+    // before first use; do not start them (they occupy VRAM once running).
     Promise.all(
-      setUpServices.map(async (service) => {
+      onDemandServices.map(async (service) => {
+        try {
+          await service.detectDevices()
+        } catch (error) {
+          appLoggerInstance.error(
+            `Failed to detect devices for ${service.name}: ${error}`,
+            'apiServiceRegistry',
+            true,
+          )
+        }
+      }),
+    ).catch((error) => {
+      appLoggerInstance.error(
+        `Error during on-demand device detection: ${error}`,
+        'apiServiceRegistry',
+        true,
+      )
+    })
+
+    // Start remaining services in parallel, but don't block
+    Promise.all(
+      autoStartServices.map(async (service) => {
         try {
           // Detect devices first
           await service.detectDevices()

--- a/WebUI/electron/subprocesses/qwen3TtsBackendService.ts
+++ b/WebUI/electron/subprocesses/qwen3TtsBackendService.ts
@@ -32,6 +32,7 @@ export class Qwen3TtsBackendService extends LongLivedPythonApiService {
 
   isSetUp: boolean = false
   readonly isRequired = false
+  // Started on first synthesize, not at boot or install, so idle VRAM stays free.
   healthEndpointUrl = `${this.baseUrl}/healthy`
 
   private loopbackAuthToken: string = randomBytes(32).toString('hex')

--- a/WebUI/electron/subprocesses/whisperBackendService.ts
+++ b/WebUI/electron/subprocesses/whisperBackendService.ts
@@ -32,6 +32,7 @@ export class WhisperBackendService extends LongLivedPythonApiService {
 
   isSetUp: boolean = false
   readonly isRequired = false
+  // Started on first transcribe, not at boot or install, so idle VRAM stays free.
   healthEndpointUrl = `${this.baseUrl}/healthy`
 
   private loopbackAuthToken: string = randomBytes(32).toString('hex')

--- a/WebUI/src/assets/js/store/backendServices.ts
+++ b/WebUI/src/assets/js/store/backendServices.ts
@@ -3,6 +3,7 @@ import { ref, computed, watch } from 'vue'
 import z from 'zod'
 import { demoAwareStorage } from '../demoAwareStorage'
 import { invalidateBackendAuthToken } from '@/lib/loopbackAuth'
+import { isOnDemandBackend } from '@/lib/onDemandBackends'
 
 export const allBackendServiceNames = [
   'ai-backend',
@@ -327,6 +328,12 @@ export const useBackendServices = defineStore(
                 console.log(`Re-selecting device ${lastSelectedDeviceId} for ${s.serviceName}`)
                 await selectDevice(s.serviceName, lastSelectedDeviceId)
               }
+              if (isOnDemandBackend(s.serviceName)) {
+                console.log(
+                  `Not auto-starting ${s.serviceName}: started when requested, to preserve VRAM`,
+                )
+                return 'notYetStarted'
+              }
               return await startService(s.serviceName)
             } catch (error) {
               console.error(`Service startup failed for ${s.serviceName}:`, error)
@@ -335,7 +342,9 @@ export const useBackendServices = defineStore(
           }),
       )
       const serverStartupsCompleted = {
-        allServicesStarted: serverStartups.every((serverStatus) => serverStatus === 'running'),
+        allServicesStarted: serverStartups.every(
+          (serverStatus) => serverStatus === 'running' || serverStatus === 'notYetStarted',
+        ),
       }
       if (!serverStartupsCompleted.allServicesStarted) {
         console.warn('Not all services started')

--- a/WebUI/src/assets/js/store/setupWizard.ts
+++ b/WebUI/src/assets/js/store/setupWizard.ts
@@ -18,6 +18,7 @@ import { useCloudMode } from './cloudMode'
 import { useQwen3TextToSpeech } from './qwen3TextToSpeech'
 import { CHANNELS } from './channels/channelRegistry'
 import { mapServiceNameToDisplayName, mapStatusToColor, mapToDisplayStatus } from '@/lib/utils'
+import { isOnDemandBackend } from '@/lib/onDemandBackends'
 import * as toast from '@/assets/js/toast'
 import { useErrors } from './errors'
 import { extractMessage } from '../errors/appError'
@@ -768,7 +769,11 @@ export const useSetupWizard = defineStore('setupWizard', () => {
       installSelection.value.add(serviceName)
       disabledBackends.value.delete(serviceName)
       disabledBackends.value = new Set(disabledBackends.value)
-      if (info?.isSetUp && (info.status === 'stopped' || info.status === 'notYetStarted')) {
+      if (
+        info?.isSetUp &&
+        (info.status === 'stopped' || info.status === 'notYetStarted') &&
+        !isOnDemandBackend(serviceName)
+      ) {
         await backendServices.startService(serviceName)
       }
     } else {
@@ -1065,6 +1070,10 @@ export const useSetupWizard = defineStore('setupWizard', () => {
       wizardActivity.value = new Map(wizardActivity.value)
       await backendServices.detectDevices(name)
 
+      if (isOnDemandBackend(name)) {
+        return
+      }
+
       wizardActivity.value.set(name, 'Starting...')
       wizardActivity.value = new Map(wizardActivity.value)
       const startStatus = await backendServices.startService(name)
@@ -1099,7 +1108,7 @@ export const useSetupWizard = defineStore('setupWizard', () => {
       const info = backendServices.info.find((s) => s.serviceName === serviceName)
       if (!info?.isSetUp) continue
       if (info.isRequired || installSelection.value.has(serviceName)) {
-        if (info.status !== 'running') {
+        if (info.status !== 'running' && !isOnDemandBackend(serviceName)) {
           backendServices.startService(serviceName)
         }
       }

--- a/WebUI/src/assets/js/store/speechToText.ts
+++ b/WebUI/src/assets/js/store/speechToText.ts
@@ -431,11 +431,8 @@ export const useSpeechToText = defineStore(
     }
 
     /**
-     * Initialize the transcription server on app startup if STT is enabled.
-     * This validates all prerequisites and auto-disables STT if they are not met,
-     * providing user feedback via toast notifications.
-     *
-     * This should be called once during app initialization after backends are started.
+     * Validate STT prerequisites on app startup if STT is enabled.
+     * Does not start the transcription server — that happens on first mic / transcribe.
      */
     async function initialize(): Promise<void> {
       if (productMode.isNvidiaModeSelected) {
@@ -468,10 +465,7 @@ export const useSpeechToText = defineStore(
         if (!modelExists) {
           enabled.value = false
           toast.warning('Speech To Text disabled: Whisper model not found')
-          return
         }
-
-        await backendServices.startTranscriptionServer(selectedOvmsModel.value)
       } catch (error) {
         enabled.value = false
         const errorMessage = error instanceof Error ? error.message : String(error)

--- a/WebUI/src/assets/js/store/textToSpeech.ts
+++ b/WebUI/src/assets/js/store/textToSpeech.ts
@@ -274,8 +274,8 @@ export const useTextToSpeech = defineStore(
     }
 
     /**
-     * Initialize the speech server on app startup if TTS is enabled.
-     * Validates prerequisites and auto-disables TTS if they are not met.
+     * Validate TTS prerequisites on app startup if TTS is enabled.
+     * Does not start the speech server — that happens on first speak / synthesize.
      */
     async function initialize(): Promise<void> {
       if (productMode.isNvidiaModeSelected) {
@@ -305,12 +305,6 @@ export const useTextToSpeech = defineStore(
         if (!modelExists) {
           enabled.value = false
           toast.warning('Text To Speech disabled: speech model not found')
-          return
-        }
-
-        const url = await backendServices.getSpeechServerUrl()
-        if (!url) {
-          await backendServices.startSpeechServer(SPEECHT5_MODEL_NAME)
         }
       } catch (error) {
         enabled.value = false

--- a/WebUI/src/components/BackendOptions.vue
+++ b/WebUI/src/components/BackendOptions.vue
@@ -34,6 +34,7 @@ import { Input } from '@/components/ui/input'
 import { Checkbox } from '@/components/ui/checkbox'
 import { Button } from '@/components/ui/button'
 import { mapServiceNameToDisplayName, compareVersions } from '@/lib/utils'
+import { isOnDemandBackend } from '@/lib/onDemandBackends'
 import { z } from 'zod'
 import SettingsMenu from '@/components/SettingsMenu.vue'
 
@@ -190,6 +191,9 @@ const handleReinstall = async (versionToInstall?: { version?: string; releaseTag
     )
 
     if (setupResult.success) {
+      if (isOnDemandBackend(props.backend)) {
+        return
+      }
       try {
         const startStatus = await backendServices.startService(props.backend)
         if (startStatus !== 'running') {

--- a/WebUI/src/components/DeviceSelector.vue
+++ b/WebUI/src/components/DeviceSelector.vue
@@ -22,8 +22,13 @@ const props = defineProps<{
 
 const selectInferenceDevice = async (item: string) => {
   await backendServices.selectDevice(props.backend, item)
-  await backendServices.stopService(props.backend)
-  await backendServices.startService(props.backend)
+  // Persist the pick for the next start. Only bounce a running service so
+  // changing device on an idle on-demand backend (TTS/STT) does not load it.
+  const info = backendServices.info.find((s) => s.serviceName === props.backend)
+  if (info?.status === 'running') {
+    await backendServices.stopService(props.backend)
+    await backendServices.startService(props.backend)
+  }
 }
 const backendServices = useBackendServices()
 const devices = computed(

--- a/WebUI/src/components/InstallationManagement.vue
+++ b/WebUI/src/components/InstallationManagement.vue
@@ -433,6 +433,7 @@ import {
   mapToDisplayStatus,
   compareVersions,
 } from '@/lib/utils.ts'
+import { isOnDemandBackend } from '@/lib/onDemandBackends'
 import { useBackendServices } from '@/assets/js/store/backendServices'
 import LanguageSelector from '@/components/LanguageSelector.vue'
 import BackendOptions from '@/components/BackendOptions.vue'
@@ -714,6 +715,11 @@ async function installBackend(name: BackendServiceName) {
   const setupProgress = await backendServices.setUpService(name)
   console.log('setup finished with', setupProgress)
   if (setupProgress.success) {
+    // TTS/STT sidecars stay stopped after install; first use starts them.
+    if (isOnDemandBackend(name)) {
+      loadingComponents.value.delete(name)
+      return
+    }
     await restartBackend(name)
   } else {
     errors.report('Backend setup failed', {

--- a/WebUI/src/components/SettingsTts.vue
+++ b/WebUI/src/components/SettingsTts.vue
@@ -47,7 +47,7 @@
     <!-- === Qwen3-TTS engine === -->
     <template v-if="textToSpeech.selectedEngine === 'qwen3'">
       <!-- Hardware: which accelerator the TTS model loads on. Changing it restarts
-           the backend so the model reloads on the chosen device. -->
+           the backend only if it is already running. -->
       <div v-if="qwen3BackendSetUp" class="grid grid-cols-[120px_1fr] items-center gap-4">
         <Label class="whitespace-nowrap">{{ languages.SETTINGS_INFERENCE_DEVICE }}</Label>
         <device-selector backend="qwen3-tts-backend" name-only></device-selector>

--- a/WebUI/src/lib/onDemandBackends.test.ts
+++ b/WebUI/src/lib/onDemandBackends.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest'
+import { isOnDemandBackend, ON_DEMAND_BACKENDS } from './onDemandBackends'
+
+describe('isOnDemandBackend', () => {
+  it('marks the dedicated TTS and STT sidecars as on-demand', () => {
+    expect(isOnDemandBackend('qwen3-tts-backend')).toBe(true)
+    expect(isOnDemandBackend('whisper-backend')).toBe(true)
+  })
+
+  it('does not mark inference or core backends as on-demand', () => {
+    expect(isOnDemandBackend('ai-backend')).toBe(false)
+    expect(isOnDemandBackend('llamacpp-backend')).toBe(false)
+    expect(isOnDemandBackend('openvino-backend')).toBe(false)
+    expect(isOnDemandBackend('comfyui-backend')).toBe(false)
+    expect(isOnDemandBackend('home-agent-backend')).toBe(false)
+  })
+
+  it('lists only the two dedicated audio sidecars', () => {
+    expect([...ON_DEMAND_BACKENDS]).toEqual(['qwen3-tts-backend', 'whisper-backend'])
+  })
+})

--- a/WebUI/src/lib/onDemandBackends.ts
+++ b/WebUI/src/lib/onDemandBackends.ts
@@ -1,0 +1,9 @@
+/** Dedicated TTS/STT sidecars: installed they stay stopped until first use. */
+export const ON_DEMAND_BACKENDS = [
+  'qwen3-tts-backend',
+  'whisper-backend',
+] as const satisfies readonly BackendServiceName[]
+
+export function isOnDemandBackend(name: string): boolean {
+  return (ON_DEMAND_BACKENDS as readonly string[]).includes(name)
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
**Description:**

Installed TTS and STT backends (Qwen3-TTS and standalone Whisper) were started automatically at app boot and immediately after install, occupying VRAM even when unused. They now stay stopped until a feature actually requests them.

**Related Issue:**

N/A

**Changes Made:**

- Added `isOnDemandBackend()` for `qwen3-tts-backend` and `whisper-backend`.
- `startAllSetUpServices` (main process + renderer) still detects devices for those sidecars so the device picker is accurate, but does not start them.
- Setup wizard, Installation Management, and backend reinstall no longer start TTS/STT after install. The explicit Start button still does.
- Enabling an already-installed TTS/STT row in the wizard no longer starts it.
- Device picker only restarts a backend if it is already running, so changing device on an idle sidecar does not load it into VRAM.
- OVMS Kokoro speech and Whisper transcription servers no longer start from TTS/STT `initialize()` on boot; first speak / transcribe still starts them via the existing `ensure*` paths.

**Testing Done:**

- `npx vue-tsc --noEmit` — pass
- `npm run lint:ci` — pass
- `npm test` — 38 files, 362 tests passed (including new `onDemandBackends` tests)
- `npx playwright test --config playwright-e2e.config.ts --list` — 37 tests listed

**Screenshots:**

N/A (lifecycle change; no UI).

**Checklist:**

- [x] I have tested the changes locally.
- [x] I have self-reviewed the code changes.
- [x] I have updated the documentation, if necessary.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-57426c22-d537-43c3-b1bd-da6df53c7c25?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-57426c22-d537-43c3-b1bd-da6df53c7c25&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

