### PR TITLE
Enable Windows 11 snap layouts via native title-bar overlay

### DIFF
--- a/WebUI/electron/main.ts
+++ b/WebUI/electron/main.ts
@@ -101,6 +101,11 @@ import {
   type McpServerConfig,
 } from './subprocesses/mcpServers'
 import { getAudioDir, getMediaDir } from './util.ts'
+import {
+  mainWindowChromeOptions,
+  titleBarOverlayForTheme,
+  usesNativeWindowControls,
+} from './titleBarOverlay.ts'
 import { packagedResourcesRoot, writableConfigRoot } from './aipgRoot.ts'
 import { loadDemoProfile, type DemoProfile } from './demoProfile.ts'
 import type { ModelPaths } from '@/assets/js/store/models.ts'
@@ -653,7 +658,7 @@ async function createWindow() {
     icon: path.join(process.env.VITE_PUBLIC, 'app-ico.svg'),
     transparent: false,
     resizable: true,
-    frame: false,
+    ...mainWindowChromeOptions(process.platform, settings.currentTheme),
     // fullscreen: true,
     width: 1440,
     height: 951,
@@ -1197,6 +1202,13 @@ function initEventHandle() {
     if (win) {
       win.setFullScreen(enable)
     }
+  })
+
+  ipcMain.on('setTitleBarTheme', (_event: IpcMainEvent, theme: unknown) => {
+    const parsed = ThemeSchema.safeParse(theme)
+    if (!parsed.success || !win || win.isDestroyed()) return
+    if (!usesNativeWindowControls(process.platform)) return
+    win.setTitleBarOverlay(titleBarOverlayForTheme(parsed.data))
   })
 
   ipcMain.on('exitApp', async () => {

--- a/WebUI/electron/preload.ts
+++ b/WebUI/electron/preload.ts
@@ -1,6 +1,7 @@
 import { contextBridge, ipcRenderer, webUtils } from 'electron'
 import pkg from '../package.json'
 import { LocalSettings } from './main'
+import { usesNativeWindowControls } from './titleBarOverlay.ts'
 import { ModelPaths } from '@/assets/js/store/models'
 import {
   EmbedInquiry,
@@ -13,6 +14,7 @@ contextBridge.exposeInMainWorld('envVars', {
   platformTitle: import.meta.env.VITE_PLATFORM_TITLE,
   debugToolsEnabled: import.meta.env.VITE_DEBUG_TOOLS === 'true',
   productVersion: pkg.version,
+  nativeWindowControls: usesNativeWindowControls(process.platform),
 })
 contextBridge.exposeInMainWorld('electronAPI', {
   startDrag: (fileName: string) => ipcRenderer.send('ondragstart', fileName),
@@ -116,6 +118,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
   openImageWithSystem: (url: string) => ipcRenderer.send('openImageWithSystem', url),
   openImageInFolder: (url: string) => ipcRenderer.send('openImageInFolder', url),
   setFullScreen: (enable: boolean) => ipcRenderer.send('setFullScreen', enable),
+  setTitleBarTheme: (theme: Theme) => ipcRenderer.send('setTitleBarTheme', theme),
   onDebugLog: (callback: (data: { level: string; source: string; message: string }) => void) =>
     ipcRenderer.on('debugLog', (_event, value) => callback(value)),
   wakeupComfyUIService: () => ipcRenderer.send('wakeupComfyUIService'),

--- a/WebUI/electron/test/titleBarOverlay.test.ts
+++ b/WebUI/electron/test/titleBarOverlay.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import {
   TITLE_BAR_HEIGHT,
+  OVERLAY_COLOR_TRANSPARENT,
   hslToHex,
   mainWindowChromeOptions,
   titleBarOverlayForTheme,
@@ -24,23 +25,20 @@ describe('titleBarOverlayForTheme', () => {
     for (const theme of ['dark', 'lnl', 'bmg', 'light'] as const) {
       const overlay = titleBarOverlayForTheme(theme)
       expect(overlay.height).toBe(TITLE_BAR_HEIGHT)
-      expect(overlay.color).toMatch(HEX)
+      expect(overlay.color).toBe(OVERLAY_COLOR_TRANSPARENT)
       expect(overlay.symbolColor).toMatch(HEX)
     }
   })
 
-  it('matches the light header’s solid --background, not --muted', () => {
-    expect(titleBarOverlayForTheme('light').color).toBe('#ffffff')
+  it('keeps the overlay background transparent so the header shows through', () => {
+    expect(titleBarOverlayForTheme('light').color).toBe('#00000000')
+    expect(titleBarOverlayForTheme('bmg').color).toBe('#00000000')
   })
 
   it('uses dark symbols on the light theme and light symbols on dark themes', () => {
-    expect(luminance(titleBarOverlayForTheme('light').symbolColor)).toBeLessThan(
-      luminance(titleBarOverlayForTheme('light').color),
-    )
+    expect(luminance(titleBarOverlayForTheme('light').symbolColor)).toBeLessThan(128)
     for (const theme of ['dark', 'lnl', 'bmg'] as const) {
-      expect(luminance(titleBarOverlayForTheme(theme).symbolColor)).toBeGreaterThan(
-        luminance(titleBarOverlayForTheme(theme).color),
-      )
+      expect(luminance(titleBarOverlayForTheme(theme).symbolColor)).toBeGreaterThan(128)
     }
   })
 })

--- a/WebUI/electron/test/titleBarOverlay.test.ts
+++ b/WebUI/electron/test/titleBarOverlay.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'vitest'
+import {
+  TITLE_BAR_HEIGHT,
+  hslToHex,
+  mainWindowChromeOptions,
+  titleBarOverlayForTheme,
+  usesNativeWindowControls,
+} from '../titleBarOverlay'
+
+const HEX = /^#[0-9a-f]{6}$/
+
+describe('hslToHex', () => {
+  it('converts primary colors and greyscale', () => {
+    expect(hslToHex(0, 0, 100)).toBe('#ffffff')
+    expect(hslToHex(0, 0, 0)).toBe('#000000')
+    expect(hslToHex(0, 100, 50)).toBe('#ff0000')
+    expect(hslToHex(120, 100, 50)).toBe('#00ff00')
+    expect(hslToHex(240, 100, 50)).toBe('#0000ff')
+  })
+})
+
+describe('titleBarOverlayForTheme', () => {
+  it('sizes the overlay to the custom header', () => {
+    for (const theme of ['dark', 'lnl', 'bmg', 'light'] as const) {
+      const overlay = titleBarOverlayForTheme(theme)
+      expect(overlay.height).toBe(TITLE_BAR_HEIGHT)
+      expect(overlay.color).toMatch(HEX)
+      expect(overlay.symbolColor).toMatch(HEX)
+    }
+  })
+
+  it('uses dark symbols on the light theme and light symbols on dark themes', () => {
+    expect(luminance(titleBarOverlayForTheme('light').symbolColor)).toBeLessThan(
+      luminance(titleBarOverlayForTheme('light').color),
+    )
+    for (const theme of ['dark', 'lnl', 'bmg'] as const) {
+      expect(luminance(titleBarOverlayForTheme(theme).symbolColor)).toBeGreaterThan(
+        luminance(titleBarOverlayForTheme(theme).color),
+      )
+    }
+  })
+})
+
+describe('mainWindowChromeOptions', () => {
+  it('exposes a native maximize hit target on Windows', () => {
+    const chrome = mainWindowChromeOptions('win32', 'bmg')
+    expect(chrome.frame).toBe(false)
+    expect(chrome.titleBarStyle).toBe('hidden')
+    expect(chrome.titleBarOverlay).toEqual(titleBarOverlayForTheme('bmg'))
+  })
+
+  it('keeps a fully custom title bar on macOS and Linux', () => {
+    expect(mainWindowChromeOptions('linux', 'bmg')).toEqual({ frame: false })
+    expect(mainWindowChromeOptions('darwin', 'light')).toEqual({ frame: false })
+  })
+})
+
+describe('usesNativeWindowControls', () => {
+  it('is Windows-only', () => {
+    expect(usesNativeWindowControls('win32')).toBe(true)
+    expect(usesNativeWindowControls('linux')).toBe(false)
+    expect(usesNativeWindowControls('darwin')).toBe(false)
+  })
+})
+
+function luminance(hex: string): number {
+  const n = parseInt(hex.slice(1), 16)
+  const r = (n >> 16) & 255
+  const g = (n >> 8) & 255
+  const b = n & 255
+  return 0.2126 * r + 0.7152 * g + 0.0722 * b
+}

--- a/WebUI/electron/test/titleBarOverlay.test.ts
+++ b/WebUI/electron/test/titleBarOverlay.test.ts
@@ -29,6 +29,10 @@ describe('titleBarOverlayForTheme', () => {
     }
   })
 
+  it('matches the light header’s solid --background, not --muted', () => {
+    expect(titleBarOverlayForTheme('light').color).toBe('#ffffff')
+  })
+
   it('uses dark symbols on the light theme and light symbols on dark themes', () => {
     expect(luminance(titleBarOverlayForTheme('light').symbolColor)).toBeLessThan(
       luminance(titleBarOverlayForTheme('light').color),

--- a/WebUI/electron/titleBarOverlay.ts
+++ b/WebUI/electron/titleBarOverlay.ts
@@ -1,0 +1,63 @@
+export const TITLE_BAR_HEIGHT = 58
+
+type Hsl = readonly [number, number, number]
+
+// Matches WebUI/src/assets/css/index.css --background/--foreground (light uses --muted).
+const OVERLAY_HSL: Record<Theme, { color: Hsl; symbolColor: Hsl }> = {
+  light: { color: [210, 40, 96.1], symbolColor: [222.2, 47.4, 11.2] },
+  dark: { color: [280, 50, 5], symbolColor: [280, 5, 90] },
+  lnl: { color: [209, 58, 10], symbolColor: [209, 5, 95] },
+  bmg: { color: [280, 50, 10], symbolColor: [280, 5, 90] },
+}
+
+export type TitleBarOverlayOptions = {
+  color: string
+  symbolColor: string
+  height: number
+}
+
+export function hslToHex(h: number, sPercent: number, lPercent: number): string {
+  const s = sPercent / 100
+  const l = lPercent / 100
+  const a = s * Math.min(l, 1 - l)
+  const f = (n: number) => {
+    const k = (n + h / 30) % 12
+    const color = l - a * Math.max(Math.min(k - 3, 9 - k, 1), -1)
+    return Math.round(255 * color)
+      .toString(16)
+      .padStart(2, '0')
+  }
+  return `#${f(0)}${f(8)}${f(4)}`
+}
+
+export function titleBarOverlayForTheme(theme: Theme): TitleBarOverlayOptions {
+  const { color, symbolColor } = OVERLAY_HSL[theme]
+  return {
+    color: hslToHex(...color),
+    symbolColor: hslToHex(...symbolColor),
+    height: TITLE_BAR_HEIGHT,
+  }
+}
+
+export function usesNativeWindowControls(platform: NodeJS.Platform): boolean {
+  return platform === 'win32'
+}
+
+export function mainWindowChromeOptions(
+  platform: NodeJS.Platform,
+  theme: Theme,
+): {
+  frame: false
+  titleBarStyle?: 'hidden'
+  titleBarOverlay?: TitleBarOverlayOptions
+} {
+  if (!usesNativeWindowControls(platform)) {
+    return { frame: false }
+  }
+  // Snap layouts only appear over a native HTMAXBUTTON; titleBarOverlay provides it.
+  return {
+    frame: false,
+    titleBarStyle: 'hidden',
+    titleBarOverlay: titleBarOverlayForTheme(theme),
+  }
+}

--- a/WebUI/electron/titleBarOverlay.ts
+++ b/WebUI/electron/titleBarOverlay.ts
@@ -1,13 +1,13 @@
 export const TITLE_BAR_HEIGHT = 58
+export const OVERLAY_COLOR_TRANSPARENT = '#00000000'
 
 type Hsl = readonly [number, number, number]
 
-// Header composites to --background; --muted on light was a visible grey-blue block.
-const OVERLAY_HSL: Record<Theme, { color: Hsl; symbolColor: Hsl }> = {
-  light: { color: [0, 0, 100], symbolColor: [222.2, 47.4, 11.2] },
-  dark: { color: [280, 50, 5], symbolColor: [280, 5, 90] },
-  lnl: { color: [209, 58, 10], symbolColor: [209, 5, 95] },
-  bmg: { color: [280, 50, 10], symbolColor: [280, 5, 90] },
+const OVERLAY_SYMBOL_HSL: Record<Theme, Hsl> = {
+  light: [222.2, 47.4, 11.2],
+  dark: [280, 5, 90],
+  lnl: [209, 5, 95],
+  bmg: [280, 5, 90],
 }
 
 export type TitleBarOverlayOptions = {
@@ -31,10 +31,10 @@ export function hslToHex(h: number, sPercent: number, lPercent: number): string 
 }
 
 export function titleBarOverlayForTheme(theme: Theme): TitleBarOverlayOptions {
-  const { color, symbolColor } = OVERLAY_HSL[theme]
   return {
-    color: hslToHex(...color),
-    symbolColor: hslToHex(...symbolColor),
+    // Header is translucent over themed wallpaper/pattern; an opaque overlay cannot match it.
+    color: OVERLAY_COLOR_TRANSPARENT,
+    symbolColor: hslToHex(...OVERLAY_SYMBOL_HSL[theme]),
     height: TITLE_BAR_HEIGHT,
   }
 }

--- a/WebUI/electron/titleBarOverlay.ts
+++ b/WebUI/electron/titleBarOverlay.ts
@@ -2,9 +2,9 @@ export const TITLE_BAR_HEIGHT = 58
 
 type Hsl = readonly [number, number, number]
 
-// Matches WebUI/src/assets/css/index.css --background/--foreground (light uses --muted).
+// Header composites to --background; --muted on light was a visible grey-blue block.
 const OVERLAY_HSL: Record<Theme, { color: Hsl; symbolColor: Hsl }> = {
-  light: { color: [210, 40, 96.1], symbolColor: [222.2, 47.4, 11.2] },
+  light: { color: [0, 0, 100], symbolColor: [222.2, 47.4, 11.2] },
   dark: { color: [280, 50, 5], symbolColor: [280, 5, 90] },
   lnl: { color: [209, 58, 10], symbolColor: [209, 5, 95] },
   bmg: { color: [280, 50, 10], symbolColor: [280, 5, 90] },

--- a/WebUI/src/App.vue
+++ b/WebUI/src/App.vue
@@ -11,8 +11,11 @@
     class="absolute -z-50 w-screen h-screen bg-cover bg-center bg-light"
   ></div>
   <header
-    class="main-title text-2xl font-bold flex justify-between items-center px-4 border-b border-border/20 text-foreground bg-background/20"
-    :class="{ 'bg-muted/50': theme.active === 'light' }"
+    class="main-title text-2xl font-bold flex justify-between items-center pl-4 border-b border-border/20 text-foreground bg-background/20"
+    :class="{
+      'bg-muted/50': theme.active === 'light',
+      'has-native-window-controls': nativeWindowControls,
+    }"
   >
     <div class="flex items-center gap-4">
       <h1 class="select-none flex gap-2 items-baseline">
@@ -75,19 +78,20 @@
         ?
       </button>
       <button
-        v-if="!demoMode.enabled"
+        v-if="!demoMode.enabled && !nativeWindowControls"
         :title="languages.COM_MINI"
         @click="miniWindow"
         class="svg-icon i-mini w-6 h-6"
       ></button>
       <button
-        v-if="!demoMode.enabled"
+        v-if="!demoMode.enabled && !nativeWindowControls"
         :title="fullscreen ? languages.COM_FULLSCREEN_EXIT : languages.COM_FULLSCREEN"
         @click="toggleFullScreen"
         class="svg-icon w-6 h-6"
         :class="fullscreen ? 'i-fullscreen-exit' : 'i-fullscreen'"
       ></button>
       <button
+        v-if="!nativeWindowControls"
         :title="languages.COM_CLOSE"
         @click="closeWindow"
         class="svg-icon i-close w-6 h-6"
@@ -384,6 +388,7 @@ const showSpecificSettings = ref(false)
 const platformTitle = window.envVars.platformTitle
 const productVersion = window.envVars.productVersion
 const debugToolsEnabled = window.envVars.debugToolsEnabled
+const nativeWindowControls = window.envVars.nativeWindowControls
 
 const gitHubRepoUrl = ref('https://github.com/intel/ai-playground/blob/main/')
 const userGuideUrl = computed(() => `${gitHubRepoUrl.value}AI%20Playground%20Users%20Guide.pdf`)
@@ -448,6 +453,9 @@ onMounted(async () => {
       // Add current theme class (light theme is default via :root, so no class needed)
       if (newTheme !== 'light') {
         root.classList.add(newTheme)
+      }
+      if (nativeWindowControls) {
+        window.electronAPI.setTitleBarTheme(newTheme)
       }
     },
     { immediate: true },

--- a/WebUI/src/assets/css/main.css
+++ b/WebUI/src/assets/css/main.css
@@ -40,6 +40,12 @@ textarea {
   height: 58px;
   flex: none;
   -webkit-app-region: drag;
+  padding-inline-end: 1rem;
+}
+
+.main-title.has-native-window-controls {
+  /* Keep header actions in the WCO content rect (overlay is at the trailing edge). */
+  padding-inline-end: calc(100% - env(titlebar-area-x, 0px) - env(titlebar-area-width, 100%));
 }
 
 .main-tabs {

--- a/WebUI/src/env.d.ts
+++ b/WebUI/src/env.d.ts
@@ -2,7 +2,12 @@ declare interface Window {
   __AIPG_DEMO_MODE__?: boolean
   chrome: Chrome
   electronAPI: electronAPI
-  envVars: { platformTitle: string; productVersion: string; debugToolsEnabled: boolean }
+  envVars: {
+    platformTitle: string
+    productVersion: string
+    debugToolsEnabled: boolean
+    nativeWindowControls: boolean
+  }
   // Dev-only Home Agent mock-channel drive surface (see channels/mockAdapter.ts).
   // Only attached when debug tools are enabled.
   __homeAgentMock?: HomeAgentMockApi
@@ -366,6 +371,7 @@ type electronAPI = {
   openImageWithSystem(url: string): void
   openImageInFolder(url: string): void
   setFullScreen(enable: boolean): void
+  setTitleBarTheme(theme: Theme): void
   onDebugLog(
     callback: (data: {
       level: 'error' | 'warn' | 'info'


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
**Description:**

Windows 11 snap layouts (hover on maximize, Win+Z) only appear when the OS hit-tests a native `HTMAXBUTTON`. The app window was fully frameless with custom HTML caption buttons (and the middle control was fullscreen, not maximize), so that target never existed.

This change keeps our custom header drawing, but on Windows lets the OS draw the caption overlay so snap layouts work. macOS and Linux keep the existing custom min / fullscreen / close controls. F11 fullscreen is unchanged.

**Related Issue:**

N/A — gap analysis for AIPG window chrome / snap layouts.

**Changes Made:**

- On `win32`, create the main window with `titleBarStyle: 'hidden'` and a 58px `titleBarOverlay` (provides native minimize / maximize / close, including `HTMAXBUTTON`).
- Hide the custom HTML caption buttons on Windows so they do not sit under or beside the overlay.
- Pad the header with Window Controls Overlay `env(titlebar-area-*)` so Home Agent, settings, and help stay in the usable title-bar rect.
- Overlay **background is transparent** so the header (including `bg-background/20` and themed wallpaper/pattern) shows through; symbol color still follows the active theme.
- Keep F11 → `setFullScreen` on all platforms.
- Unit tests for overlay chrome options (Windows vs macOS/Linux, height, transparent fill, symbol contrast).

**Testing Done:**

- `npx vitest run electron/test/titleBarOverlay.test.ts`
- `npm run typecheck`
- `npm run lint:ci`
- Linux runtime: custom caption buttons unchanged (`nativeWindowControls: false`).
- Windows 11: snap layouts work. Follow-up: opaque `--background` / `--muted` fills did not match the real header (light grey, navy, BMG diamonds); overlay fill is now transparent.

Please re-check light, lnl, and bmg: the caption strip should no longer be a solid block, and the header/pattern should continue under the min/max/close glyphs.

**Checklist:**

- [x] I have tested the changes locally.
- [x] I have self-reviewed the code changes.
- [ ] I have updated the documentation, if necessary.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b2fd6095-e434-442d-bd44-fae6befc00d3?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b2fd6095-e434-442d-bd44-fae6befc00d3&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

