### PR TITLE
Isolate the Audio history from the Assistant's

### DIFF
--- a/WebUI/electron/test/presets/audioCategory.test.ts
+++ b/WebUI/electron/test/presets/audioCategory.test.ts
@@ -3,10 +3,11 @@ import { readdirSync, readFileSync } from 'node:fs'
 import path from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { AUDIO_CATEGORY, PresetSchema, type ChatPreset } from '@/assets/js/store/presets'
+import { AUDIO_PRESET_NAMES } from '@/assets/js/store/conversationThreads'
 
 // Pin test for the Chat / Audio split. The speech presets (Text to Speech, Speech to
-// Text) are chat-*type* presets — they reuse the chat conversation and message
-// rendering — but they belong to the Audio mode, which is derived purely from their
+// Text) are chat-*type* presets — they reuse the chat message rendering, though not
+// its history — but they belong to the Audio mode, which is derived purely from their
 // `category`. A speech preset that slips back into the `chat` category would show up
 // in the Chat picker and put a record/synthesize surface where a chat prompt belongs.
 
@@ -46,5 +47,15 @@ describe('audio preset category', () => {
       .filter(({ preset }) => !isSpeechPreset(preset) && preset.category === AUDIO_CATEGORY)
       .map(({ file }) => file)
     expect(misplaced, misplaced.join('\n')).toEqual([])
+  })
+
+  // The hydration backfill that moves pre-split threads into the Audio history has
+  // only their stamped preset *name* to go on (it runs before the catalog loads), so
+  // a speech preset missing from that list would leave its threads in the Assistant's.
+  it('names every audio preset in the thread-kind backfill list', () => {
+    const audioPresets = chatTypePresets
+      .filter(({ preset }) => preset.category === AUDIO_CATEGORY)
+      .map(({ preset }) => preset.name)
+    expect([...audioPresets].sort()).toEqual([...AUDIO_PRESET_NAMES].sort())
   })
 })

--- a/WebUI/electron/test/store/conversationThreads.test.ts
+++ b/WebUI/electron/test/store/conversationThreads.test.ts
@@ -1,0 +1,205 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+import { createPinia, setActivePinia } from 'pinia'
+import { nextTick } from 'vue'
+import type { Preset } from '@/assets/js/store/presets'
+import type { AipgUiMessage } from '@/assets/js/store/openAiCompatibleChat'
+import {
+  backfillAudioThreadKind,
+  findOrCreateEmptyThread,
+  isAudioPresetName,
+  mintThreadKey,
+  resolveThreadForKind,
+  threadKindForPreset,
+  type ConversationThreadMeta,
+} from '@/assets/js/store/conversationThreads'
+import { useConversations } from '@/assets/js/store/conversations'
+
+// One store holds every chat-like conversation, so the thread kind is the only
+// thing keeping the Assistant, Home Agent and Audio histories apart. These tests
+// cover that: which list a thread is filed under, that neither list can hand the
+// other its draft, and that threads from before Audio had its own list are moved.
+
+const message = () => ({ id: 'm', role: 'user', parts: [] }) as unknown as AipgUiMessage
+
+const TTS: Preset = {
+  type: 'chat',
+  category: 'audio',
+  name: 'Text to Speech',
+  backends: ['llamaCPP'],
+  ttsPreset: true,
+} as Preset
+
+const CHAT: Preset = {
+  type: 'chat',
+  category: 'chat',
+  name: 'Assistant',
+  backends: ['llamaCPP'],
+} as Preset
+
+describe('isAudioPresetName', () => {
+  it('recognizes the speech presets and nothing else', () => {
+    expect(isAudioPresetName('Text to Speech')).toBe(true)
+    expect(isAudioPresetName('Speech to Text')).toBe(true)
+    expect(isAudioPresetName('Assistant')).toBe(false)
+    expect(isAudioPresetName('')).toBe(false)
+    expect(isAudioPresetName(undefined)).toBe(false)
+  })
+})
+
+describe('mintThreadKey', () => {
+  it('never returns a key the list already holds', () => {
+    const taken = String(Date.now())
+    const list = { [taken]: [] }
+    expect(mintThreadKey(list)).not.toBe(taken)
+  })
+})
+
+describe('findOrCreateEmptyThread', () => {
+  it("reuses a kind's own empty draft", () => {
+    const list: Record<string, AipgUiMessage[]> = { '1': [message()], '2': [] }
+    expect(findOrCreateEmptyThread(list, {}, 'main')).toBe('2')
+  })
+
+  it('does not hand the Assistant an empty Audio draft', () => {
+    const list: Record<string, AipgUiMessage[]> = { '1': [message()], '2': [] }
+    const meta: Record<string, ConversationThreadMeta> = {
+      '2': { presetName: 'Text to Speech', kind: 'audio' },
+    }
+    const key = findOrCreateEmptyThread(list, meta, 'main')
+    expect(key).not.toBe('2')
+    expect(list[key]).toEqual([])
+  })
+
+  it('does not hand Audio the Assistant’s empty draft', () => {
+    const list: Record<string, AipgUiMessage[]> = { '1': [] }
+    const key = findOrCreateEmptyThread(list, {}, 'audio')
+    expect(key).not.toBe('1')
+  })
+
+  it('allocates when the kind’s latest thread has messages', () => {
+    const list: Record<string, AipgUiMessage[]> = { '1': [], '2': [message()] }
+    const meta: Record<string, ConversationThreadMeta> = {
+      '2': { presetName: 'Text to Speech', kind: 'audio' },
+    }
+    const key = findOrCreateEmptyThread(list, meta, 'audio')
+    expect(key).not.toBe('1')
+    expect(key).not.toBe('2')
+  })
+})
+
+describe('resolveThreadForKind', () => {
+  const list: Record<string, AipgUiMessage[]> = { '1': [message()], '2': [message()] }
+  const meta: Record<string, ConversationThreadMeta> = {
+    '2': { presetName: 'Speech to Text', kind: 'audio' },
+  }
+
+  it('prefers the remembered thread', () => {
+    expect(resolveThreadForKind(list, meta, 'audio', '2')).toBe('2')
+  })
+
+  it('ignores a remembered thread of another kind, or one since deleted', () => {
+    expect(resolveThreadForKind(list, meta, 'main', '2')).toBe('1')
+    expect(resolveThreadForKind(list, meta, 'audio', '404')).toBe('2')
+  })
+
+  it('falls back to the newest of that kind, else nothing', () => {
+    expect(resolveThreadForKind({ '1': [], '3': [] }, {}, 'main', null)).toBe('3')
+    expect(resolveThreadForKind(list, meta, 'homeAgent', null)).toBeNull()
+  })
+})
+
+describe('backfillAudioThreadKind', () => {
+  it('moves threads held with a speech preset into the Audio history', () => {
+    const meta: Record<string, ConversationThreadMeta> = {
+      '1': { presetName: 'Text to Speech' },
+      '2': { presetName: 'Speech to Text', kind: 'main' },
+      '3': { presetName: 'Assistant', kind: 'main' },
+      '4': { presetName: 'Home Agent', kind: 'homeAgent' },
+    }
+    backfillAudioThreadKind(meta)
+    expect(meta['1'].kind).toBe('audio')
+    expect(meta['2'].kind).toBe('audio')
+    expect(meta['3'].kind).toBe('main')
+    expect(meta['4'].kind).toBe('homeAgent')
+  })
+})
+
+describe('threadKindForPreset', () => {
+  const presets = [TTS, CHAT]
+
+  it('files a speech preset’s thread under Audio', () => {
+    expect(threadKindForPreset('Text to Speech', undefined, presets)).toBe('audio')
+    expect(threadKindForPreset('Text to Speech', 'main', presets)).toBe('audio')
+  })
+
+  it('leaves a chat preset’s thread where it is', () => {
+    expect(threadKindForPreset('Assistant', undefined, presets)).toBe('main')
+    expect(threadKindForPreset('Assistant', 'audio', presets)).toBe('audio')
+  })
+
+  it('keeps a Home Agent thread remote whatever preset ran', () => {
+    expect(threadKindForPreset('Text to Speech', 'homeAgent', presets)).toBe('homeAgent')
+  })
+
+  it('falls back to the name when the catalog has no such preset', () => {
+    expect(threadKindForPreset('Speech to Text', undefined, [])).toBe('audio')
+    expect(threadKindForPreset('Assistant', undefined, [])).toBe('main')
+  })
+})
+
+describe('conversations store', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+  })
+
+  it('stamps the kind of an Audio draft, so it is listed under Audio', () => {
+    const conversations = useConversations()
+    const key = conversations.addNewConversation('audio')
+    expect(conversations.getThreadKind(key)).toBe('audio')
+    expect(conversations.activeKey).toBe(key)
+  })
+
+  it('keeps the Assistant and Audio drafts apart', () => {
+    const conversations = useConversations()
+    const audioKey = conversations.addNewConversation('audio')
+    const mainKey = conversations.addNewConversation('main')
+    expect(mainKey).not.toBe(audioKey)
+    expect(conversations.getThreadKind(mainKey)).toBe('main')
+  })
+
+  it('returns each mode to the thread it left behind', async () => {
+    const conversations = useConversations()
+    const mainKey = conversations.addNewConversation('main')
+    conversations.updateConversation([message()], mainKey)
+    await nextTick()
+
+    const audioKey = conversations.activateThreadForKind('audio')
+    conversations.updateConversation([message()], audioKey)
+    await nextTick()
+    expect(audioKey).not.toBe(mainKey)
+
+    expect(conversations.activateThreadForKind('main')).toBe(mainKey)
+    await nextTick()
+    expect(conversations.activateThreadForKind('audio')).toBe(audioKey)
+  })
+
+  it('allocates an Audio thread the first time the mode is entered', () => {
+    const conversations = useConversations()
+    const mainKey = conversations.addNewConversation('main')
+    const audioKey = conversations.activateThreadForKind('audio')
+    expect(audioKey).not.toBe(mainKey)
+    expect(conversations.getThreadKind(audioKey)).toBe('audio')
+  })
+
+  it('never falls back to an Audio thread when the active one is gone', async () => {
+    const conversations = useConversations()
+    const mainKey = conversations.addNewConversation('main')
+    conversations.updateConversation([message()], mainKey)
+    const audioKey = conversations.activateThreadForKind('audio')
+    await nextTick()
+
+    conversations.deleteConversation(audioKey)
+    await nextTick()
+    expect(conversations.activeKey).toBe(mainKey)
+  })
+})

--- a/WebUI/src/App.vue
+++ b/WebUI/src/App.vue
@@ -216,7 +216,8 @@
         </DemoModeBlocker>
       </div>
       <!-- The Audio mode renders its turns (synthesized audio, transcripts) as chat
-           messages, so it shares this view with the Chat mode. -->
+           messages, so it shares this view with the Chat mode — its own history,
+           the same rendering. -->
       <Chat
         v-if="promptStore.getCurrentMode() === 'chat' || promptStore.getCurrentMode() === 'audio'"
         ref="chatRef"

--- a/WebUI/src/assets/js/store/conversationThreads.ts
+++ b/WebUI/src/assets/js/store/conversationThreads.ts
@@ -1,0 +1,137 @@
+import type { AipgUiMessage } from './openAiCompatibleChat'
+import type { Preset } from './presets'
+import { presetToMode } from '@/lib/presetModes'
+import { currentPresetName } from '@/lib/presetRenames'
+
+// ── Which history a conversation belongs to ──────────────────────────────────
+//
+// One conversation store holds every chat-like thread, so the kind is what keeps
+// the three lists apart: the Assistant's own threads, the remote Home Agent ones,
+// and the Audio mode's (Text to Speech takes, Speech to Text transcripts). Pure
+// helpers, no store imports, so they are unit-tested directly and the store stays
+// wiring.
+
+export type ThreadKind = 'main' | 'homeAgent' | 'audio'
+
+/**
+ * Per-conversation inference profile snapshot. Stamped on every outbound
+ * generate/regenerate so the thread is reproducible and "revisit = reactivate"
+ * works in the Chat UI.
+ */
+export type ConversationThreadMeta = {
+  presetName: string
+  variant?: string | null
+  kind?: ThreadKind
+}
+
+/**
+ * The shipped presets that own the Audio history. Named rather than looked up,
+ * because the hydration backfill below runs before the preset catalog is loaded.
+ * A preset added to the audio category must be listed here too — pinned by
+ * `audioCategory.test.ts`.
+ */
+export const AUDIO_PRESET_NAMES = ['Text to Speech', 'Speech to Text']
+
+/** Whether a stored preset name is one of the speech presets. */
+export function isAudioPresetName(presetName: string | null | undefined): boolean {
+  if (!presetName) return false
+  return AUDIO_PRESET_NAMES.includes(currentPresetName(presetName))
+}
+
+/**
+ * Which history a thread belongs in, given the preset that just ran in it. A Home
+ * Agent thread stays remote whatever preset drove it; a speech preset files the
+ * thread under Audio, and once filed it stays there. Falls back to the preset's
+ * name for a preset the catalog does not (yet) hold.
+ */
+export function threadKindForPreset(
+  presetName: string,
+  existingKind: ThreadKind | undefined,
+  presets: Preset[],
+): ThreadKind {
+  if (existingKind === 'homeAgent') return 'homeAgent'
+  const preset = presets.find((entry) => entry.name === presetName)
+  const isAudio = preset ? presetToMode(preset) === 'audio' : isAudioPresetName(presetName)
+  return isAudio ? 'audio' : (existingKind ?? 'main')
+}
+
+export function threadKindOf(
+  meta: Record<string, ConversationThreadMeta> | undefined,
+  conversationKey: string,
+): ThreadKind {
+  return meta?.[conversationKey]?.kind ?? 'main'
+}
+
+/**
+ * A conversation key no thread already holds. Keys are minted from the clock, and
+ * two kinds can now be minted in the same millisecond (switching mode allocates
+ * the other list's first draft), which would make them one thread.
+ */
+export function mintThreadKey(list: Record<string, unknown>): string {
+  let key = Date.now()
+  while (String(key) in list) key += 1
+  return String(key)
+}
+
+/**
+ * Find or allocate the "current empty draft" of one kind — i.e. that kind's most
+ * recently inserted conversation, reused when empty so we don't accumulate a long
+ * tail of empty drafts.
+ *
+ * Only the kind's own tail is considered. Reusing another kind's empty thread
+ * would silently retitle it AND, via the activeKey watcher in `textInference`,
+ * snap the desktop preset to that thread's preset — observable as "first click on
+ * another preset bounces back, second click sticks".
+ */
+export function findOrCreateEmptyThread(
+  list: Record<string, AipgUiMessage[]>,
+  meta: Record<string, ConversationThreadMeta> | undefined,
+  kind: ThreadKind = 'main',
+): string {
+  const keys = Object.keys(list)
+  let latestOfKind: string | undefined
+  for (let i = keys.length - 1; i >= 0; i--) {
+    if (threadKindOf(meta, keys[i]) !== kind) continue
+    latestOfKind = keys[i]
+    break
+  }
+
+  if (latestOfKind && list[latestOfKind].length === 0) {
+    return latestOfKind
+  }
+
+  const newKey = mintThreadKey(list)
+  list[newKey] = []
+  return newKey
+}
+
+/**
+ * The conversation to open for a kind: the remembered one when it still exists
+ * and still belongs to that kind, else the newest of that kind, else nothing (the
+ * caller allocates a draft).
+ */
+export function resolveThreadForKind(
+  list: Record<string, AipgUiMessage[]>,
+  meta: Record<string, ConversationThreadMeta> | undefined,
+  kind: ThreadKind,
+  rememberedKey?: string | null,
+): string | null {
+  if (rememberedKey && list[rememberedKey] && threadKindOf(meta, rememberedKey) === kind) {
+    return rememberedKey
+  }
+  const keys = Object.keys(list).filter((key) => threadKindOf(meta, key) === kind)
+  if (keys.length === 0) return null
+  return keys.sort((a, b) => (parseInt(b) || 0) - (parseInt(a) || 0))[0]
+}
+
+/**
+ * Move threads held with a speech preset into the Audio history. Installs from
+ * before Audio had its own list stamped them `main`, so their synthesized takes
+ * and transcripts would sit among the Assistant's conversations.
+ */
+export function backfillAudioThreadKind(meta: Record<string, ConversationThreadMeta>): void {
+  for (const entry of Object.values(meta)) {
+    if (entry.kind === 'homeAgent' || entry.kind === 'audio') continue
+    if (isAudioPresetName(entry.presetName)) entry.kind = 'audio'
+  }
+}

--- a/WebUI/src/assets/js/store/conversations.ts
+++ b/WebUI/src/assets/js/store/conversations.ts
@@ -3,6 +3,15 @@ import { computed, ref, watch, watchEffect } from 'vue'
 import { demoAwareStorage } from '../demoAwareStorage'
 import { AipgUiMessage } from './openAiCompatibleChat'
 import { completeOrphanedToolParts, sanitizeBulkyToolOutputs } from './toolMessageSanitize'
+import {
+  backfillAudioThreadKind,
+  findOrCreateEmptyThread,
+  mintThreadKey,
+  resolveThreadForKind,
+  threadKindOf,
+  type ConversationThreadMeta,
+  type ThreadKind,
+} from './conversationThreads'
 import { currentPresetName } from '@/lib/presetRenames'
 
 /**
@@ -25,18 +34,10 @@ export const HOME_AGENT_CONVERSATION_TITLE = 'Home Agent'
  */
 export const HOME_AGENT_CHAT_PRESET_NAME = 'Home Agent'
 
-export type ThreadKind = 'main' | 'homeAgent'
+export type { ConversationThreadMeta, ThreadKind } from './conversationThreads'
 
-/**
- * Per-conversation inference profile snapshot. Stamped on every outbound
- * generate/regenerate so the thread is reproducible and "revisit = reactivate"
- * works in the Chat UI.
- */
-export type ConversationThreadMeta = {
-  presetName: string
-  variant?: string | null
-  kind?: ThreadKind
-}
+/** The two histories a mode switch moves between (Home Agent is a filter, not a mode). */
+export type ModeThreadKind = 'main' | 'audio'
 
 export type CreateConversationOptions = {
   kind?: ThreadKind
@@ -68,6 +69,8 @@ export const useConversations = defineStore(
      * thread by insertion order.
      */
     const lastMainKey = ref<string | null>(null)
+    /** The same, for the Audio mode's own list (Text to Speech / Speech to Text). */
+    const lastAudioKey = ref<string | null>(null)
 
     function updateConversation(messages: AipgUiMessage[], conversationKey: string) {
       // Never persist an orphaned tool call (interrupted/stopped turn): it would
@@ -115,7 +118,21 @@ export const useConversations = defineStore(
     }
 
     function getThreadKind(conversationKey: string): ThreadKind {
-      return conversationThreadMeta.value[conversationKey]?.kind ?? 'main'
+      return threadKindOf(conversationThreadMeta.value, conversationKey)
+    }
+
+    /**
+     * File a thread under a history without touching the preset it was stamped
+     * with. Used when a list allocates its own draft, so an empty Audio thread is
+     * in the Audio list before any turn has stamped a preset on it.
+     */
+    function setThreadKind(conversationKey: string, kind: ThreadKind) {
+      const existing = conversationThreadMeta.value[conversationKey]
+      conversationThreadMeta.value[conversationKey] = {
+        ...existing,
+        presetName: existing?.presetName ?? '',
+        kind,
+      }
     }
 
     function getThreadRagHashes(conversationKey: string): string[] {
@@ -126,15 +143,17 @@ export const useConversations = defineStore(
       conversationRagSelection.value[conversationKey] = [...new Set(hashes)]
     }
 
-    // Keep `lastMainKey` synced with the most recently selected main thread so
-    // toggling the history filter back to Local lands on what the user was
-    // working in (not just the newest bucket by timestamp).
+    // Keep the per-list "last active" keys synced with the most recently selected
+    // thread of each kind, so switching back to a list (the Local/Home Agent
+    // filter, or the Chat/Audio mode buttons) lands on what the user was working
+    // in — not just the newest bucket by timestamp.
     watch(
       () => activeKey.value,
       (k) => {
-        if (k && conversationList.value[k] && getThreadKind(k) === 'main') {
-          lastMainKey.value = k
-        }
+        if (!k || !conversationList.value[k]) return
+        const kind = getThreadKind(k)
+        if (kind === 'main') lastMainKey.value = k
+        else if (kind === 'audio') lastAudioKey.value = k
       },
       { immediate: true },
     )
@@ -145,7 +164,7 @@ export const useConversations = defineStore(
      * and the Home Agent /new command.
      */
     function createConversation(options: CreateConversationOptions = {}): string {
-      const newKey = new Date().getTime().toString()
+      const newKey = mintThreadKey(conversationList.value)
       conversationList.value[newKey] = []
       if (options.presetName || options.kind) {
         conversationThreadMeta.value[newKey] = {
@@ -157,29 +176,54 @@ export const useConversations = defineStore(
       return newKey
     }
 
-    function addNewConversation() {
-      const list = conversationList.value
-      const newKey = addNewConversationIfLatestIsNotEmpty(
-        list,
-        undefined,
+    /**
+     * Open a fresh (or the current empty) conversation in one of the lists. The
+     * Audio list gets its kind stamped right away — an unstamped draft counts as
+     * `main` and would show up under the Assistant.
+     */
+    function addNewConversation(kind: ThreadKind = 'main') {
+      const newKey = findOrCreateEmptyThread(
+        conversationList.value,
         conversationThreadMeta.value,
+        kind,
       )
+      if (kind !== 'main') setThreadKind(newKey, kind)
       activeKey.value = newKey
       return newKey
+    }
+
+    /**
+     * Land on a list's own conversation, which is what makes Chat and Audio
+     * separate histories: the mode owns the thread, so switching mode leaves the
+     * other list's thread behind instead of appending to it.
+     */
+    function activateThreadForKind(kind: ModeThreadKind): string {
+      const remembered = kind === 'audio' ? lastAudioKey.value : lastMainKey.value
+      const resolved = resolveThreadForKind(
+        conversationList.value,
+        conversationThreadMeta.value,
+        kind,
+        remembered,
+      )
+      if (!resolved) return addNewConversation(kind)
+      activeKey.value = resolved
+      return resolved
     }
 
     const isNewConversation = (key: string) => conversationList.value[key].length === 0
 
     watchEffect(() => {
       if (Object.keys(conversationList.value).includes(activeKey.value)) return
-      // Prefer the latest MAIN thread so app launch doesn't drop the user into
-      // a Home Agent thread (which would also flip the desktop preset to
-      // Home Agent via the activeKey watcher in textInference).
+      // Prefer the latest MAIN thread so app launch doesn't drop the user into a
+      // Home Agent or Audio thread (which would also flip the desktop preset to
+      // that thread's own preset via the activeKey watcher in textInference).
+      // The app boots in Chat mode; `alignModeToActivePreset` moves it to Audio
+      // afterwards when that is where the user left off, and takes the thread.
       const keys = Object.keys(conversationList.value)
       const meta = conversationThreadMeta.value
       let fallback: string | undefined
       for (let i = keys.length - 1; i >= 0; i--) {
-        if (meta[keys[i]]?.kind === 'homeAgent') continue
+        if (threadKindOf(meta, keys[i]) !== 'main') continue
         fallback = keys[i]
         break
       }
@@ -195,6 +239,7 @@ export const useConversations = defineStore(
       activeKey,
       activeConversation,
       lastMainKey,
+      lastAudioKey,
       deleteConversation,
       clearConversation,
       isNewConversation,
@@ -204,10 +249,12 @@ export const useConversations = defineStore(
       setThreadMeta,
       getThreadMeta,
       getThreadKind,
+      setThreadKind,
       getThreadRagHashes,
       setThreadRagHashes,
       createConversation,
       addNewConversation,
+      activateThreadForKind,
     }
   },
   {
@@ -218,6 +265,7 @@ export const useConversations = defineStore(
         'conversationThreadMeta',
         'conversationRagSelection',
         'lastMainKey',
+        'lastAudioKey',
       ],
       afterHydrate: (ctx) => {
         // Backfill legacy meta first so the helper below can correctly skip
@@ -229,57 +277,22 @@ export const useConversations = defineStore(
         // A thread names the preset it was held with; a renamed preset no longer
         // answers to that name, which would leave the thread's preset unresolved.
         followRenamedPresets(ctx.store.$state.conversationThreadMeta)
-        addNewConversationIfLatestIsNotEmpty(
+        // Speech threads predate the Audio history and are stamped `main`, so
+        // they have to be moved before anything reads a kind. Runs after the
+        // rename pass, whose names this recognizes.
+        backfillAudioThreadKind(ctx.store.$state.conversationThreadMeta)
+        // Guarantee an empty Assistant draft: the app boots in Chat mode, and
+        // its list must have somewhere to type. Audio allocates its own on
+        // demand (`activateThreadForKind`).
+        findOrCreateEmptyThread(
           ctx.store.$state.conversationList,
-          undefined,
           ctx.store.$state.conversationThreadMeta,
+          'main',
         )
       },
     },
   },
 )
-
-/**
- * Find or allocate the "current empty main bucket" — i.e. the most recently
- * inserted MAIN-kind conversation, reused when empty so we don't accumulate
- * a long tail of empty drafts.
- *
- * Home Agent threads are intentionally skipped: they form a separate logical
- * list (driven by Telegram /new and the bundled Home Agent preset). Reusing
- * an empty Home Agent thread as "the new main thread" would silently retitle
- * a remote chat AND, via the activeKey watcher in `textInference`, snap the
- * desktop preset back to Home Agent — observable as "first click on another
- * preset bounces back, second click sticks".
- */
-function addNewConversationIfLatestIsNotEmpty(
-  list: Record<string, AipgUiMessage[]>,
-  conversationKey?: string,
-  meta?: Record<string, ConversationThreadMeta>,
-): string {
-  console.log('Checking if new conversation is needed', {
-    threadCount: Object.keys(list).length,
-    conversationKey,
-  })
-
-  const isHomeAgent = (key: string) => meta?.[key]?.kind === 'homeAgent'
-
-  const keys = Object.keys(list)
-  let latestMainKey: string | undefined
-  for (let i = keys.length - 1; i >= 0; i--) {
-    const k = keys[i]
-    if (isHomeAgent(k)) continue
-    latestMainKey = k
-    break
-  }
-
-  if (latestMainKey && list[latestMainKey].length === 0) {
-    return latestMainKey
-  }
-
-  const newKey = new Date().getTime().toString()
-  list[newKey] = []
-  return newKey
-}
 
 /**
  * Migrate the legacy singleton Home Agent thread to the new metadata model so

--- a/WebUI/src/assets/js/store/openAiCompatibleChat.ts
+++ b/WebUI/src/assets/js/store/openAiCompatibleChat.ts
@@ -1315,6 +1315,11 @@ export const useOpenAiCompatibleChat = defineStore(
         toast.warning("Couldn't make out any speech in that audio. Please try again.")
         return
       }
+      // A transcript is the whole turn, and it never goes through `generate`, so
+      // this is the only chance to record which preset held the thread — without
+      // it an STT conversation has no preset and no kind, and lands under the
+      // Assistant's history.
+      textInference.stampMetaForConversation(targetKey)
       const chat = getOrCreateChat(targetKey)
       const userMessage = {
         id: crypto.randomUUID(),

--- a/WebUI/src/assets/js/store/promptArea.ts
+++ b/WebUI/src/assets/js/store/promptArea.ts
@@ -6,9 +6,11 @@ import { useBackendServices } from './backendServices'
 import { useDialogStore } from './dialogs'
 import { useSetupWizard } from './setupWizard'
 import { usePresets } from './presets'
+import { useConversations } from './conversations'
 
 export const usePromptStore = defineStore('prompt', () => {
   const setupWizard = useSetupWizard()
+  const conversations = useConversations()
 
   const currentMode = ref<ModeType>('chat')
   // The mode the user last deliberately selected from the UI (mode buttons /
@@ -25,6 +27,24 @@ export const usePromptStore = defineStore('prompt', () => {
 
   function getCurrentMode() {
     return currentMode.value
+  }
+
+  /**
+   * Chat and Audio keep separate histories, so the mode owns the conversation:
+   * entering one lands on that list's own thread rather than appending speech
+   * takes and assistant replies to each other. Keyed off the thread's kind, not
+   * the mode we came from, so a detour through a ComfyUI mode can't strand the
+   * Assistant on an Audio thread. Home Agent threads are left alone — that split
+   * is a filter inside Chat, not a mode. Only the deliberate entry points call
+   * this; `setModeOnly` (a tool borrowing a mode mid-turn) must not move a thread.
+   */
+  function alignThreadWithMode(mode: ModeType) {
+    const kind = conversations.getThreadKind(conversations.activeKey)
+    if (mode === 'audio') {
+      if (kind !== 'audio') conversations.activateThreadForKind('audio')
+    } else if (mode === 'chat' || mode === 'agent') {
+      if (kind === 'audio') conversations.activateThreadForKind('main')
+    }
   }
 
   /**
@@ -72,6 +92,8 @@ export const usePromptStore = defineStore('prompt', () => {
       // the preset that comes back decides which of the two actually renders.
       presetSwitching.switchToLastUsedForCategory(categories, presetType)
     }
+
+    alignThreadWithMode(mode)
     return true
   }
 
@@ -124,6 +146,7 @@ export const usePromptStore = defineStore('prompt', () => {
   function setModeForPreset(mode: ModeType) {
     currentMode.value = mode
     userSelectedMode.value = mode
+    alignThreadWithMode(mode)
   }
 
   function injectPromptText(text: string) {

--- a/WebUI/src/assets/js/store/textInference.ts
+++ b/WebUI/src/assets/js/store/textInference.ts
@@ -23,6 +23,7 @@ import { useDeveloperSettings } from './developerSettings'
 import { useHomeAgent } from './homeAgent'
 import { useCloudMode, CLOUD_DEFAULT_MODEL } from './cloudMode'
 import { useConversations, HOME_AGENT_CHAT_PRESET_NAME } from './conversations'
+import { threadKindForPreset } from './conversationThreads'
 import * as toast from '@/assets/js/toast.ts'
 import { useActivities } from './activities'
 import { useI18N } from './i18n'
@@ -2070,7 +2071,9 @@ export const useTextInference = defineStore(
       conversations.setThreadMeta(conversationKey, {
         presetName: resolved.presetName,
         variant: resolved.variant,
-        kind: existingKind ?? 'main',
+        // A speech preset files the thread under the Audio history, so its takes
+        // and transcripts never land among the Assistant's conversations.
+        kind: threadKindForPreset(resolved.presetName, existingKind, presetsStore.presets),
       })
     }
 

--- a/WebUI/src/components/HistoryChat.vue
+++ b/WebUI/src/components/HistoryChat.vue
@@ -1,134 +1,155 @@
 <template>
-  <div class="flex flex-col space-y-2 pr-3 h-full overflow-y-auto">
-    <div class="flex items-center justify-center gap-2 px-1 pb-1">
-      <span
-        class="text-xs font-medium select-none"
-        :class="filterKind === 'main' ? 'text-foreground' : 'text-muted-foreground'"
-      >
-        Local
-      </span>
-      <Switch
-        :model-value="filterKind === 'homeAgent'"
-        aria-label="Toggle between Local and Home Agent conversations"
-        @update:model-value="(checked: boolean) => switchKind(checked ? 'homeAgent' : 'main')"
-      />
-      <span
-        class="text-xs font-medium select-none"
-        :class="filterKind === 'homeAgent' ? 'text-foreground' : 'text-muted-foreground'"
-      >
-        Home Agent
-      </span>
-    </div>
-    <div
-      v-if="reversedConversationKeys.length === 0"
-      class="px-2 py-4 text-xs text-muted-foreground italic"
-    >
-      {{
-        filterKind === 'homeAgent'
-          ? 'No Home Agent conversations yet.'
-          : 'No local conversations yet.'
-      }}
-    </div>
-    <div
-      v-for="key in reversedConversationKeys"
-      :key="key"
-      class="flex flex-col items-center justify-between rounded-lg px-3 py-1 transition cursor-pointer border-2"
-      :class="
-        conversations.activeKey === key
-          ? 'border-primary bg-muted hover:bg-muted/80'
-          : 'border-transparent bg-muted hover:bg-muted/80'
-      "
-      @click="selectConversation(key)"
-    >
-      <div class="flex items-center justify-between w-full">
-        <span class="truncate text-sm text-foreground">
-          {{ conversationTitle(key) }}
-        </span>
-        <DropdownMenu
-          :open="menuOpenKey === key"
-          @update:open="(open) => onMenuOpenChange(key, open)"
+  <TooltipProvider :delay-duration="200">
+    <div class="flex flex-col space-y-2 pr-3 h-full overflow-y-auto">
+      <!-- The Local / Home Agent split lives inside the Assistant's own list. The
+           Audio list is a mode of its own, so it is locked to its kind. -->
+      <div v-if="!props.lockedKind" class="flex items-center justify-center gap-2 px-1 pb-1">
+        <span
+          class="text-xs font-medium select-none"
+          :class="filterKind === 'main' ? 'text-foreground' : 'text-muted-foreground'"
         >
-          <DropdownMenuTrigger as-child>
-            <Button variant="ghost" size="icon" class="h-6 w-6" @click.stop>
-              <span class="svg-icon i-dots-vertical w-4 h-4"></span>
-            </Button>
-          </DropdownMenuTrigger>
-          <DropdownMenuContent
-            align="end"
-            class="w-28"
-            :onCloseAutoFocus="
-              (ev) => {
-                ev.preventDefault?.()
-              }
-            "
+          Local
+        </span>
+        <Switch
+          :model-value="filterKind === 'homeAgent'"
+          aria-label="Toggle between Local and Home Agent conversations"
+          @update:model-value="(checked: boolean) => switchKind(checked ? 'homeAgent' : 'main')"
+        />
+        <span
+          class="text-xs font-medium select-none"
+          :class="filterKind === 'homeAgent' ? 'text-foreground' : 'text-muted-foreground'"
+        >
+          Home Agent
+        </span>
+      </div>
+      <div
+        v-if="reversedConversationKeys.length === 0"
+        class="px-2 py-4 text-xs text-muted-foreground italic"
+      >
+        {{ emptyMessage }}
+      </div>
+      <div
+        v-for="key in reversedConversationKeys"
+        :key="key"
+        class="flex flex-col items-center justify-between rounded-lg px-3 py-1 transition cursor-pointer border-2"
+        :class="
+          conversations.activeKey === key
+            ? 'border-primary bg-muted hover:bg-muted/80'
+            : 'border-transparent bg-muted hover:bg-muted/80'
+        "
+        @click="selectConversation(key)"
+      >
+        <div class="flex items-center justify-between w-full gap-1.5">
+          <!-- Text to Speech and Speech to Text share the Audio list, so the preset
+               that held a thread is what tells its rows apart. -->
+          <Tooltip v-if="threadPresets[key]">
+            <TooltipTrigger as-child>
+              <span class="inline-flex flex-none cursor-help" :aria-label="threadPresets[key].name">
+                <img
+                  v-if="threadPresets[key].image"
+                  :src="threadPresets[key].image"
+                  :alt="threadPresets[key].name"
+                  class="size-5 rounded object-cover border border-border"
+                />
+                <span
+                  v-else
+                  class="size-5 rounded border border-border bg-muted grid place-items-center text-[10px] font-medium"
+                >
+                  {{ threadPresets[key].name.slice(0, 1) }}
+                </span>
+              </span>
+            </TooltipTrigger>
+            <TooltipContent>{{ threadPresets[key].name }}</TooltipContent>
+          </Tooltip>
+          <span class="truncate text-sm text-foreground mr-auto">
+            {{ conversationTitle(key) }}
+          </span>
+          <DropdownMenu
+            :open="menuOpenKey === key"
+            @update:open="(open) => onMenuOpenChange(key, open)"
           >
-            <Dialog
-              v-model:open="renameDialogOpen"
-              @update:open="
-                (open) => {
-                  if (!open) menuOpenKey = null
+            <DropdownMenuTrigger as-child>
+              <Button variant="ghost" size="icon" class="h-6 w-6" @click.stop>
+                <span class="svg-icon i-dots-vertical w-4 h-4"></span>
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent
+              align="end"
+              class="w-28"
+              :onCloseAutoFocus="
+                (ev) => {
+                  ev.preventDefault?.()
                 }
               "
             >
-              <DialogTrigger asChild>
-                <DropdownMenuItem
-                  @select="
-                    (e: Event) => {
-                      e.preventDefault()
-                      openRenameDialog(key)
-                    }
-                  "
-                >
-                  Rename
-                </DropdownMenuItem>
-              </DialogTrigger>
-              <DialogContent>
-                <DialogHeader>
-                  <DialogTitle>Rename conversation</DialogTitle>
-                  <DialogDescription>Set a new title for this conversation.</DialogDescription>
-                </DialogHeader>
-                <div class="mt-2">
-                  <Input
-                    autofocus
-                    type="text"
-                    placeholder="Enter title"
-                    v-model="renameTitle"
-                    @keydown.enter.prevent="saveRename"
-                  />
-                </div>
-                <DialogFooter>
-                  <Button variant="ghost" @click="cancelRename">Cancel</Button>
-                  <Button :disabled="!renameTitle.trim()" @click="saveRename">Save</Button>
-                </DialogFooter>
-              </DialogContent>
-            </Dialog>
-            <AlertDialog>
-              <AlertDialogTrigger asChild>
-                <DropdownMenuItem @select="(e: Event) => e.preventDefault()">
-                  Delete
-                </DropdownMenuItem>
-              </AlertDialogTrigger>
-              <AlertDialogContent>
-                <AlertDialogHeader>
-                  <AlertDialogTitle>Delete conversation?</AlertDialogTitle>
-                  <AlertDialogDescription>
-                    This will permanently remove this conversation and its messages.
-                  </AlertDialogDescription>
-                </AlertDialogHeader>
-                <AlertDialogFooter>
-                  <AlertDialogCancel>Cancel</AlertDialogCancel>
-                  <AlertDialogAction @click="() => conversations.deleteConversation(key)">
+              <Dialog
+                v-model:open="renameDialogOpen"
+                @update:open="
+                  (open) => {
+                    if (!open) menuOpenKey = null
+                  }
+                "
+              >
+                <DialogTrigger asChild>
+                  <DropdownMenuItem
+                    @select="
+                      (e: Event) => {
+                        e.preventDefault()
+                        openRenameDialog(key)
+                      }
+                    "
+                  >
+                    Rename
+                  </DropdownMenuItem>
+                </DialogTrigger>
+                <DialogContent>
+                  <DialogHeader>
+                    <DialogTitle>Rename conversation</DialogTitle>
+                    <DialogDescription>Set a new title for this conversation.</DialogDescription>
+                  </DialogHeader>
+                  <div class="mt-2">
+                    <Input
+                      autofocus
+                      type="text"
+                      placeholder="Enter title"
+                      v-model="renameTitle"
+                      @keydown.enter.prevent="saveRename"
+                    />
+                  </div>
+                  <DialogFooter>
+                    <Button variant="ghost" @click="cancelRename">Cancel</Button>
+                    <Button :disabled="!renameTitle.trim()" @click="saveRename">Save</Button>
+                  </DialogFooter>
+                </DialogContent>
+              </Dialog>
+              <AlertDialog>
+                <AlertDialogTrigger asChild>
+                  <DropdownMenuItem @select="(e: Event) => e.preventDefault()">
                     Delete
-                  </AlertDialogAction>
-                </AlertDialogFooter>
-              </AlertDialogContent>
-            </AlertDialog>
-          </DropdownMenuContent>
-        </DropdownMenu>
+                  </DropdownMenuItem>
+                </AlertDialogTrigger>
+                <AlertDialogContent>
+                  <AlertDialogHeader>
+                    <AlertDialogTitle>Delete conversation?</AlertDialogTitle>
+                    <AlertDialogDescription>
+                      This will permanently remove this conversation and its messages.
+                    </AlertDialogDescription>
+                  </AlertDialogHeader>
+                  <AlertDialogFooter>
+                    <AlertDialogCancel>Cancel</AlertDialogCancel>
+                    <AlertDialogAction @click="() => conversations.deleteConversation(key)">
+                      Delete
+                    </AlertDialogAction>
+                  </AlertDialogFooter>
+                </AlertDialogContent>
+              </AlertDialog>
+            </DropdownMenuContent>
+          </DropdownMenu>
+        </div>
+        <ThumbnailPreviewStrip :items="images(conversations.conversationList[key])" />
       </div>
-      <ThumbnailPreviewStrip :items="images(conversations.conversationList[key])" />
     </div>
-  </div>
+  </TooltipProvider>
 </template>
 
 <script setup lang="ts">
@@ -163,12 +184,24 @@ import {
 import { Input } from '@/components/ui/input'
 import { Button } from '@/components/ui/button'
 import { Switch } from '@/components/ui/switch'
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip'
 import { useConversations, type ThreadKind } from '@/assets/js/store/conversations'
 import { useHomeAgent } from '@/assets/js/store/homeAgent'
+import { usePresets } from '@/assets/js/store/presets'
 import { AipgUiMessage } from '@/assets/js/store/openAiCompatibleChat'
 
 const conversations = useConversations()
 const homeAgent = useHomeAgent()
+const presetsStore = usePresets()
+
+/**
+ * The list this panel shows, when the mode owns one kind of conversation
+ * outright: Audio does, the Assistant's Local / Home Agent split does not.
+ */
+const props = defineProps<{
+  lockedKind?: ThreadKind
+}>()
+
 const emits = defineEmits<{
   (e: 'conversationSelected'): void
   (e: 'filterKindChange', kind: ThreadKind): void
@@ -216,8 +249,16 @@ const images = (conversation: AipgUiMessage[]) => {
 // kind of the currently active conversation so the switch reflects whatever
 // state the rest of the app left us in (e.g. Telegram poll just moved
 // activeKey onto a Home Agent thread). Kept in sync with external activeKey
-// changes via the watcher below.
-const filterKind = ref<ThreadKind>(conversations.getThreadKind(conversations.activeKey))
+// changes via the watcher below. A locked list has no filter to track.
+function filterFor(conversationKey: string): ThreadKind {
+  if (props.lockedKind) return props.lockedKind
+  const kind = conversations.getThreadKind(conversationKey)
+  // Only this panel's own two kinds can be filtered to; an Audio thread has no
+  // row here, so showing its (empty) list would be a dead end.
+  return kind === 'homeAgent' ? 'homeAgent' : 'main'
+}
+
+const filterKind = ref<ThreadKind>(filterFor(conversations.activeKey))
 
 watch(filterKind, (kind) => emits('filterKindChange', kind), { immediate: true })
 
@@ -225,7 +266,7 @@ watch(
   () => conversations.activeKey,
   (k) => {
     if (!k) return
-    filterKind.value = conversations.getThreadKind(k)
+    filterKind.value = filterFor(k)
   },
 )
 
@@ -234,6 +275,27 @@ const reversedConversationKeys = computed(() => {
   return Object.keys(list)
     .filter((k) => conversations.getThreadKind(k) === filterKind.value)
     .reverse()
+})
+
+const emptyMessage = computed(() => {
+  if (filterKind.value === 'audio') return 'No audio conversations yet.'
+  if (filterKind.value === 'homeAgent') return 'No Home Agent conversations yet.'
+  return 'No local conversations yet.'
+})
+
+/**
+ * The preset each listed thread was last held with, resolved once per render
+ * rather than per row element.
+ */
+const threadPresets = computed(() => {
+  const byKey: Record<string, { name: string; image?: string }> = {}
+  for (const key of reversedConversationKeys.value) {
+    const presetName = conversations.getThreadMeta(key)?.presetName
+    if (!presetName) continue
+    const preset = presetsStore.presets.find((p) => p.name === presetName)
+    byKey[key] = { name: presetName, image: preset?.image }
+  }
+  return byKey
 })
 
 // Pick the target conversation when the user flips the switch:

--- a/WebUI/src/components/SettingsAudio.vue
+++ b/WebUI/src/components/SettingsAudio.vue
@@ -34,6 +34,7 @@ import PresetSelector from '@/components/PresetSelector.vue'
 import SettingsTts from '@/components/SettingsTts.vue'
 import SettingsStt from '@/components/SettingsStt.vue'
 import { AUDIO_CATEGORY, usePresets, type ChatPreset } from '@/assets/js/store/presets'
+import { useConversations } from '@/assets/js/store/conversations'
 import { usePresetSwitching } from '@/assets/js/store/presetSwitching'
 import { useI18N } from '@/assets/js/store/i18n'
 import { useQwen3TextToSpeech } from '@/assets/js/store/qwen3TextToSpeech'
@@ -43,6 +44,7 @@ import * as toast from '@/assets/js/toast'
 
 const languages = useI18N().state
 const presetsStore = usePresets()
+const conversations = useConversations()
 const presetSwitching = usePresetSwitching()
 const qwen3Tts = useQwen3TextToSpeech()
 const textToSpeech = useTextToSpeech()
@@ -79,6 +81,13 @@ async function handlePresetChange(presetName: string) {
     skipModeSwitch: true, // We're already in audio mode
   })
   if (result.success) {
+    // Text to Speech and Speech to Text share one list, so this stays on the
+    // current thread. Skipping the mode switch skips the thread routing with it,
+    // so a thread the panel was left on from elsewhere is claimed here instead —
+    // the next take would otherwise stamp an Assistant thread as audio.
+    if (conversations.getThreadKind(conversations.activeKey) !== 'audio') {
+      conversations.activateThreadForKind('audio')
+    }
     toast.success(`Switched to ${presetName}`)
   } else if (result.error) {
     toast.error(`Failed to switch preset: ${result.error}`)

--- a/WebUI/src/components/SideModalHistory.vue
+++ b/WebUI/src/components/SideModalHistory.vue
@@ -53,9 +53,11 @@
       />
     </template>
 
-    <!-- Audio turns (synthesized audio, transcripts) are chat conversations too. -->
+    <!-- Audio turns (synthesized takes, transcripts) render like chat messages, but
+         they are their own history: the same list component, locked to that kind. -->
     <HistoryChat
       v-if="isChatLikeMode"
+      :locked-kind="props.mode === 'audio' ? 'audio' : undefined"
       @conversation-selected="emit('conversationSelected')"
       @filter-kind-change="(kind) => (chatFilterKind = kind)"
     />
@@ -109,7 +111,7 @@ const isWorkflowMode = computed(() => workflowModes.includes(props.mode))
 const isChatLikeMode = computed(() => props.mode === 'chat' || props.mode === 'audio')
 
 function selectNewConversation() {
-  const key = conversations.addNewConversation()
+  const key = conversations.addNewConversation(props.mode === 'audio' ? 'audio' : 'main')
   if (!key) return
   conversations.activeKey = key
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
**Description:**

Text to Speech and Speech to Text shared one conversation store, one `activeKey` and one history list with Chat, so synthesized takes and transcripts landed among the Assistant's threads — and Speech to Text turns were stamped with no preset at all. Audio now follows the Home Agent pattern: a thread kind of its own, a remembered last thread per list, and a history panel locked to that kind. Both speech presets share the one Audio list (so a take and the transcript of it sit together), and each row shows the preset it was held with, which is what tells them apart.

What stays shared by design: the same `Chat.vue` rendering, and the per-thread `presetName` that makes revisiting a thread reactivate its preset.

**Related Issue:**

None.

**Changes Made:**

- `store/conversationThreads.ts` (new) holds the pure part — the kind, empty-draft reuse scoped per kind, which list a preset files a thread under, and the hydration backfill that moves pre-split speech threads — so it is unit-tested directly and the store stays wiring.
- `store/conversations.ts`: `ThreadKind` gains `'audio'`; a persisted `lastAudioKey` mirrors `lastMainKey` and the `activeKey` watcher records whichever list the thread belongs to; `activateThreadForKind` opens a list's own conversation; `addNewConversation(kind)` stamps the kind so an Audio draft is in the Audio list before any turn has run in it. Empty-draft reuse no longer crosses kinds, and key minting can no longer collide when two lists allocate in the same millisecond.
- `store/textInference.ts`: `stampMetaForConversation` files a thread under Audio when the resolved preset is a speech one (a Home Agent thread stays remote).
- `store/openAiCompatibleChat.ts`: `appendTranscriptTurn` stamps too. A transcript is the whole turn and never goes through `generate()`, so this was the only place it could be recorded.
- `store/promptArea.ts`: the mode owns the thread. `alignThreadWithMode` runs from the deliberate entry points (`setCurrentMode`, `setModeForPreset`) but never from `setModeOnly`, which is how a ComfyUI tool or Home Agent inference borrows a mode mid-turn and must not move `activeKey`.
- `components/SettingsAudio.vue`: switching Text to Speech ↔ Speech to Text stays on the same thread, but claims an Audio one if the panel was left on another list's thread.
- `components/HistoryChat.vue` / `SideModalHistory.vue`: a `lockedKind` list hides the Local / Home Agent toggle and shows only its own threads; Chat's list now excludes Audio threads; "+" in Audio mode creates an Audio thread; every row carries its preset's image and tooltip.
- Hydration backfill: a thread stamped with a speech preset before the split is moved into the Audio list, and `lastMainKey` no longer points at it.

**Testing Done:**

- `npm test` — 987 tests across 100 files pass, including 23 in the two files touched here (`electron/test/store/conversationThreads.test.ts`, new, covers kind-scoped draft reuse, `resolveThreadForKind`, the backfill and `threadKindForPreset`; `audioCategory.test.ts` now pins `AUDIO_PRESET_NAMES` against the shipped audio presets so adding one cannot silently miss the backfill).
- `npx vue-tsc --noEmit`, `npm run lint:ci`, `npm run format:ci` — all clean.
- Manual, in the running app (`npm run dev` on Linux): a real llama.cpp chat turn for the Assistant threads and a real Speech to Text turn through `appendTranscriptTurn` for the Audio list, then Chat ↔ Audio round trips. The Audio list shows only speech threads and no Local / Home Agent toggle; the Chat list shows only Assistant threads and keeps the toggle; each mode returns to its own last thread (`lastMainKey` / `lastAudioKey` are remembered independently).
- Migration checked end to end: a thread seeded as `kind: 'main'` with `presetName: 'Speech to Text'`, with `lastMainKey` aimed at it, was reclassified to `kind: 'audio'` on reload and `lastMainKey` moved off it.

**Screenshots:**

Chat ↔ Audio round trip — the panel title, the Local / Home Agent toggle and the whole list change with the mode, and neither list ever shows the other's threads:

[audio_history_is_separate_from_chat_history.mp4](https://cursor.com/agents/bc-4a88737d-688b-4c7a-bae1-91f2d5fc66a2/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Faudio_history_is_separate_from_chat_history.mp4)

The Audio list holding all three speech threads (two Speech to Text, one Text to Speech), with the Speech to Text transcript in view:

[Audio History panel listing three speech threads](https://cursor.com/agents/bc-4a88737d-688b-4c7a-bae1-91f2d5fc66a2/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshot_audio_history.png)

The rows close up: the two transcripts carry the Speech to Text cover, the synthesized take carries the Text to Speech one, which is how the shared list stays readable:

[Audio History rows showing distinct Text to Speech and Speech to Text preset icons](https://cursor.com/agents/bc-4a88737d-688b-4c7a-bae1-91f2d5fc66a2/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshot_audio_history_preset_icons.png)

**Checklist:**

- [x] I have tested the changes locally.
- [x] I have self-reviewed the code changes.
- [x] I have updated the documentation, if necessary.


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4a88737d-688b-4c7a-bae1-91f2d5fc66a2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4a88737d-688b-4c7a-bae1-91f2d5fc66a2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

