### PR TITLE
fix: count Xet wire bytes for download progress

### DIFF
--- a/service/model_downloader.py
+++ b/service/model_downloader.py
@@ -144,19 +144,40 @@ def _make_progress_reporter(downloader: "HFPlaygroundDownloader") -> type:
     place bytes are visible to the 1 Hz SSE feed. Raising from `update` aborts the
     HTTP path; the Xet path swallows exceptions, so it is stopped by
     `_abort_xet_session` and only counts bytes here.
+
+    Xet emits two streams (huggingface/huggingface_hub#4633): `update` is bytes
+    flushed to disk, which only moves when a buffered block lands, and
+    `update_transfer` is bytes on the wire. Defining that method is what makes
+    hub aggregate both into this class instead of opening a second bar. HTTP
+    calls both with the same chunk, so transfer bytes are counted only on Xet.
     """
 
     class _ProgressReporter(hf_tqdm):
         def __init__(self, *args, **kwargs):
-            self.interruptible = kwargs.get("name") != _XET_PROGRESS_NAME
+            name = kwargs.get("name")
+            self._xet = isinstance(name, str) and name.startswith(_XET_PROGRESS_NAME)
+            self.interruptible = not self._xet
+            # Count reconstruction until the wire stream starts so a hub that
+            # never calls update_transfer (pre-1.23) still reports progress.
+            self._count_reconstruction = True
             kwargs["disable"] = True  # a backend service has no terminal to draw on
             super().__init__(*args, **kwargs)
 
         def update(self, n=1):
-            downloader.add_downloaded_bytes(n)
+            if not self._xet or self._count_reconstruction:
+                downloader.add_downloaded_bytes(n)
             if self.interruptible and downloader.download_stop:
                 raise _DownloadStopped()
             return super().update(n)
+
+        def update_transfer(self, n=1):
+            if not self._xet:
+                return
+            self._count_reconstruction = False
+            downloader.add_downloaded_bytes(n)
+
+        def set_transfer_postfix_str(self, *_args, **_kwargs):
+            pass
 
     return _ProgressReporter
 

--- a/service/pyproject.toml
+++ b/service/pyproject.toml
@@ -9,7 +9,7 @@ dependencies = [
   "psutil",
   "Requests",
   "setuptools>=83.0.0",
-  "huggingface_hub",
+  "huggingface_hub>=1.23",  # 1.23+ reports Xet wire bytes via update_transfer (hf#4633)
   # Direct, not left to huggingface_hub's extras: without it every model download
   # falls back to a single HTTP stream off the CDN bridge instead of Xet.
   "hf-xet",

--- a/service/tests/test_model_downloader.py
+++ b/service/tests/test_model_downloader.py
@@ -178,6 +178,84 @@ class TestProgressReporter(unittest.TestCase):
         bar.update(5)
         self.assertEqual(dl.download_size, 5)
 
+    def test_http_does_not_double_count_update_transfer(self):
+        """http_get calls update then update_transfer with the same chunk."""
+        md = _import_model_downloader()
+        dl = _bare_downloader(md)
+        bar = self._reporter(dl, md, "huggingface_hub.http_get")
+        bar.update(10)
+        bar.update_transfer(10)
+        self.assertEqual(dl.download_size, 10)
+
+    def test_xet_counts_wire_bytes_not_disk_flushes(self):
+        """Once update_transfer fires, reconstruction update() is the same bytes."""
+        md = _import_model_downloader()
+        dl = _bare_downloader(md)
+        bar = self._reporter(dl, md, md._XET_PROGRESS_NAME)
+        bar.update_transfer(40)
+        bar.update(10)
+        self.assertEqual(dl.download_size, 40)
+
+    def test_xet_counts_update_when_transfer_never_fires(self):
+        """huggingface_hub < 1.23 only reports reconstruction via update()."""
+        md = _import_model_downloader()
+        dl = _bare_downloader(md)
+        bar = self._reporter(dl, md, md._XET_PROGRESS_NAME)
+        bar.update(10)
+        bar.update(7)
+        self.assertEqual(dl.download_size, 17)
+
+    def test_xet_update_transfer_does_not_raise_on_stop(self):
+        md = _import_model_downloader()
+        dl = _bare_downloader(md)
+        bar = self._reporter(dl, md, md._XET_PROGRESS_NAME)
+        dl.download_stop = True
+        bar.update_transfer(5)
+        self.assertEqual(dl.download_size, 5)
+
+    def test_hub_treats_the_reporter_as_aggregated(self):
+        """Defining update_transfer is what makes hub collapse the two Xet bars."""
+        md = _import_model_downloader()
+        cls = md._make_progress_reporter(_bare_downloader(md))
+        self.assertTrue(callable(getattr(cls, "update_transfer", None)))
+        bar = cls(name=md._XET_PROGRESS_NAME, total=100, initial=0, desc="model")
+        bar.set_transfer_postfix_str("1.2MB/s", refresh=False)
+
+    def test_xet_reporter_feeds_wire_bytes_into_our_class(self):
+        """Drive hub's Xet reporter the way huggingface_hub#4633 reproduces it."""
+        try:
+            from huggingface_hub.utils._xet_progress_reporting import (
+                XetDownloadProgressReporter,
+            )
+        except ImportError:
+            self.skipTest("huggingface_hub Xet reporter not installed")
+
+        import logging
+        from types import SimpleNamespace
+
+        md = _import_model_downloader()
+        dl = _bare_downloader(md)
+        cls = md._make_progress_reporter(dl)
+        reporter = XetDownloadProgressReporter(
+            reconstruction_desc="x",
+            total=100,
+            log_level=logging.INFO,
+            name=md._XET_PROGRESS_NAME,
+            tqdm_class=cls,
+        )
+        self.assertIs(reporter.transfer_bar, reporter.reconstruction_bar)
+        reporter.update_progress(
+            SimpleNamespace(
+                total_bytes_completed=0,
+                total_transfer_bytes_completed=40,
+                total_bytes_completion_rate=None,
+                total_transfer_bytes_completion_rate=None,
+                total_bytes=100,
+            )
+        )
+        reporter.close()
+        self.assertEqual(dl.download_size, 40)
+
 
 class TestStopDownload(unittest.TestCase):
     def test_user_stop_keeps_staging_dir_and_reports_no_error(self):

--- a/service/uv.lock
+++ b/service/uv.lock
@@ -27,20 +27,11 @@ requires-dist = [
     { name = "apiflask" },
     { name = "flask" },
     { name = "hf-xet" },
-    { name = "huggingface-hub" },
+    { name = "huggingface-hub", specifier = ">=1.23" },
     { name = "marshmallow-dataclass" },
     { name = "psutil" },
     { name = "requests" },
     { name = "setuptools", specifier = ">=83.0.0" },
-]
-
-[[package]]
-name = "annotated-doc"
-version = "0.0.4"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/57/ba/046ceea27344560984e26a590f90bc7f4a75b06701f653222458922b558c/annotated_doc-0.0.4.tar.gz", hash = "sha256:fbcda96e87e9c92ad167c2e53839e57503ecfda18804ea28102353485033faa4", size = 7288, upload-time = "2025-11-10T22:07:42.062Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/1e/d3/26bf1008eb3d2daa8ef4cacc7f3bfdc11818d111f7e2d0201bc6e3b49d45/annotated_doc-0.0.4-py3-none-any.whl", hash = "sha256:571ac1dc6991c450b25a9c2d84a3705e2ae7a53467b5d111c24fa8baabbed320", size = 5303, upload-time = "2025-11-10T22:07:40.673Z" },
 ]
 
 [[package]]
@@ -140,14 +131,11 @@ wheels = [
 
 [[package]]
 name = "click"
-version = "8.4.1"
+version = "8.5.0"
 source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "colorama", marker = "sys_platform == 'win32'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/9b/98/518d8e5081007684232226f475082b30087d0f585e8457db087298259f49/click-8.4.1.tar.gz", hash = "sha256:918b5633eddf6b41c32d4f454bf0de810065c74e3f7dbf8ee5452f8be88d3e96", size = 353007, upload-time = "2026-05-22T04:08:37.769Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c7/0e/7fa0ef50764b67090eca4114772a2abf8b6148198475e54c660b97caeee6/click-8.5.0.tar.gz", hash = "sha256:ba0d2089de75ea0310e2dde03160e6ca10009947fb95a182f9b54021bb272e34", size = 382235, upload-time = "2026-08-26T13:33:14.56Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c7/0d/67e5b4109ea4a837e80daa87c2c696711955e40449a97e8926672534def2/click-8.4.1-py3-none-any.whl", hash = "sha256:482be17c6991b8c19c5429a1e995d9b0efdbb63172824c41f99965dc0ade8ec2", size = 116639, upload-time = "2026-05-22T04:08:35.26Z" },
+    { url = "https://files.pythonhosted.org/packages/58/50/6c0d534c5f134586a8e1ba4e330569e32f057e33372ae556463212fb4cd3/click-8.5.0-py3-none-any.whl", hash = "sha256:255bc9599cf7748b4b1a446ccc735421bd08a2ae529a8b88597d3de5664ee360", size = 125251, upload-time = "2026-08-26T13:33:12.928Z" },
 ]
 
 [[package]]
@@ -296,7 +284,7 @@ wheels = [
 
 [[package]]
 name = "huggingface-hub"
-version = "1.20.1"
+version = "1.26.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click" },
@@ -307,12 +295,11 @@ dependencies = [
     { name = "packaging" },
     { name = "pyyaml" },
     { name = "tqdm" },
-    { name = "typer" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e6/7e/fad82ad491b226e832d2da90a1a59f36acd4526cda8c726f639834754aa4/huggingface_hub-1.20.1.tar.gz", hash = "sha256:9f6d63bfbeab2d2a8357200a9bc4f18cd2c8bfac9579f792f5922e77bf6471d0", size = 859910, upload-time = "2026-06-18T22:06:53.348Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/89/64/bfe23dab749cb2342e1e13b61c9e684ce46b4d189c7d433cd26f76f52baf/huggingface_hub-1.26.1.tar.gz", hash = "sha256:7c28860777594ac679233f571552d0e46df34ed4e4239e844190fad3ca05e4cd", size = 936700, upload-time = "2026-08-06T09:42:24.859Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/8e/b5/ff8516e74b459da3dce9567540c39f2d305ee7a2655109f6802873ff1588/huggingface_hub-1.20.1-py3-none-any.whl", hash = "sha256:274448a45c1ba6f112fe2fb168ead05574c654faa156904157a84085cfae14bd", size = 719837, upload-time = "2026-06-18T22:06:51.486Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/a7/b519cd01e57b685c5f3e9db02cb1bd7aaade35fb6554e0d36bee6d6aae28/huggingface_hub-1.26.1-py3-none-any.whl", hash = "sha256:d8676e4ec96c1e481a22a93232bd86d73bbac643fb767399aefaeaa503890fb0", size = 780754, upload-time = "2026-08-06T09:42:22.497Z" },
 ]
 
 [[package]]
@@ -343,18 +330,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/df/bf/f7da0350254c0ed7c72f3e33cef02e048281fec7ecec5f032d4aac52226b/jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d", size = 245115, upload-time = "2025-03-05T20:05:02.478Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl", hash = "sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67", size = 134899, upload-time = "2025-03-05T20:05:00.369Z" },
-]
-
-[[package]]
-name = "markdown-it-py"
-version = "4.2.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "mdurl" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/06/ff/7841249c247aa650a76b9ee4bbaeae59370dc8bfd2f6c01f3630c35eb134/markdown_it_py-4.2.0.tar.gz", hash = "sha256:04a21681d6fbb623de53f6f364d352309d4094dd4194040a10fd51833e418d49", size = 82454, upload-time = "2026-05-07T12:08:28.36Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/b3/81/4da04ced5a082363ecfa159c010d200ecbd959ae410c10c0264a38cac0f5/markdown_it_py-4.2.0-py3-none-any.whl", hash = "sha256:9f7ebbcd14fe59494226453aed97c1070d83f8d24b6fc3a3bcf9a38092641c4a", size = 91687, upload-time = "2026-05-07T12:08:27.182Z" },
 ]
 
 [[package]]
@@ -397,15 +372,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/01/23/a863a5d569f03454d733f884a72415ac3f1e1b1b3215de3a9f4f621a83a6/marshmallow_dataclass-8.7.1.tar.gz", hash = "sha256:4fb80e1bf7b31ce1b192aa87ffadee2cedb3f6f37bb0042f8500b07e6fad59c4", size = 32059, upload-time = "2024-09-12T16:18:51.952Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/3e/f5/6764f3f3203d14a0e6df0fce4838f8195ccc61ec7d48d7ed89acfb8adeed/marshmallow_dataclass-8.7.1-py3-none-any.whl", hash = "sha256:405cbaaad9cea56b3de2f85eff32a9880e3bf849f652e7f6de7395e4b1ddc072", size = 19111, upload-time = "2024-09-12T16:18:50.286Z" },
-]
-
-[[package]]
-name = "mdurl"
-version = "0.1.2"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729, upload-time = "2022-08-14T12:40:10.846Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779Z" },
 ]
 
 [[package]]
@@ -493,15 +459,6 @@ wheels = [
 ]
 
 [[package]]
-name = "pygments"
-version = "2.20.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
-]
-
-[[package]]
 name = "pyyaml"
 version = "6.0.3"
 source = { registry = "https://pypi.org/simple" }
@@ -535,34 +492,12 @@ wheels = [
 ]
 
 [[package]]
-name = "rich"
-version = "15.0.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "markdown-it-py" },
-    { name = "pygments" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/c0/8f/0722ca900cc807c13a6a0c696dacf35430f72e0ec571c4275d2371fca3e9/rich-15.0.0.tar.gz", hash = "sha256:edd07a4824c6b40189fb7ac9bc4c52536e9780fbbfbddf6f1e2502c31b068c36", size = 230680, upload-time = "2026-04-12T08:24:00.75Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/82/3b/64d4899d73f91ba49a8c18a8ff3f0ea8f1c1d75481760df8c68ef5235bf5/rich-15.0.0-py3-none-any.whl", hash = "sha256:33bd4ef74232fb73fe9279a257718407f169c09b78a87ad3d296f548e27de0bb", size = 310654, upload-time = "2026-04-12T08:24:02.83Z" },
-]
-
-[[package]]
 name = "setuptools"
 version = "83.0.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/34/26/f5d29e25ffdb535afef2d35cdb55b325298f96debd670da4c325e08d70f4/setuptools-83.0.0.tar.gz", hash = "sha256:025bccbbf0fa05b6192bc64ae1e7b16e001fd6d6d4d5de03c97b1c1ade523bef", size = 1154254, upload-time = "2026-07-04T15:31:22.699Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/5d/40/e1e72872c6354b306daef1703549e8e83b4d43cfea356311bf722a043752/setuptools-83.0.0-py3-none-any.whl", hash = "sha256:29b23c360f22f414dc7336bb39178cc7bcbf6021ed2733cde173f09dba19abb3", size = 1008090, upload-time = "2026-07-04T15:31:20.885Z" },
-]
-
-[[package]]
-name = "shellingham"
-version = "1.5.4"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/58/15/8b3609fd3830ef7b27b655beb4b4e9c62313a4e8da8c676e142cc210d58e/shellingham-1.5.4.tar.gz", hash = "sha256:8dbca0739d487e5bd35ab3ca4b36e11c4078f3a234bfce294b0a0291363404de", size = 10310, upload-time = "2023-10-24T04:13:40.426Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/e0/f9/0595336914c5619e5f28a1fb793285925a8cd4b432c9da0a987836c7f822/shellingham-1.5.4-py2.py3-none-any.whl", hash = "sha256:7ecfff8f2fd72616f7481040475a65b2bf8af90a56c89140852d1120324e8686", size = 9755, upload-time = "2023-10-24T04:13:38.866Z" },
 ]
 
 [[package]]
@@ -587,21 +522,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/67/1c/dfba5c4633cafc4c701f237d2ba63b416805047fd6d96aab4cfc40969f98/typeguard-4.5.2.tar.gz", hash = "sha256:5a16dcac23502039299c97c8941651bc33d7ea8cc4b2f7d6bbb1b528f6eea423", size = 80240, upload-time = "2026-05-14T12:59:40.857Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/5b/29/74eeb4d3f3ae61ca096b018ad486b3b3c74b17bec09ab4edab721cbefec3/typeguard-4.5.2-py3-none-any.whl", hash = "sha256:fcf9de18bd945cdb4c7b996e12b4c51ce83f92f191314a6d7cf1739586ec98cf", size = 36748, upload-time = "2026-05-14T12:59:39.473Z" },
-]
-
-[[package]]
-name = "typer"
-version = "0.25.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "annotated-doc" },
-    { name = "click" },
-    { name = "rich" },
-    { name = "shellingham" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/e4/51/9aed62104cea109b820bbd6c14245af756112017d309da813ef107d42e7e/typer-0.25.1.tar.gz", hash = "sha256:9616eb8853a09ffeabab1698952f33c6f29ffdbceb4eaeecf571880e8d7664cc", size = 122276, upload-time = "2026-04-30T19:32:16.964Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/3f/f9/2b3ff4e56e5fa7debfaf9eb135d0da96f3e9a1d5b27222223c7296336e5f/typer-0.25.1-py3-none-any.whl", hash = "sha256:75caa44ed46a03fb2dab8808753ffacdbfea88495e74c85a28c5eefcf5f39c89", size = 58409, upload-time = "2026-04-30T19:32:18.271Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
**Description:**

Xet downloads were reporting almost no progress in the model-download dialog. huggingface_hub emits two byte streams for Xet: disk flushes on `update()` (sparse, with gaps of tens of seconds) and network bytes on `update_transfer()`. Our custom `tqdm_class` only implemented `update()`, which is exactly [huggingface_hub#4633](https://github.com/huggingface/huggingface_hub/issues/4633).

Defining `update_transfer` makes hub aggregate both streams into our reporter instead of opening a second bar, and the 1 Hz SSE feed now follows wire bytes so the bar keeps moving.

HTTP still counts `update()` only — `http_get` calls both methods with the same chunk, so summing them would double-count.

**Related Issue:**

huggingface/huggingface_hub#4633

**Changes Made:**

- `_ProgressReporter` implements `update_transfer` and `set_transfer_postfix_str`
- Xet counts wire bytes; reconstruction `update()` is ignored once transfer starts
- HTTP ignores `update_transfer` to avoid double-counting
- Pin `huggingface_hub>=1.23` (1.23 is when hub started calling `update_transfer`) and lock to 1.26.1
- Unit tests covering HTTP, Xet, old-hub fallback, and a live `XetDownloadProgressReporter` drive

**Testing Done:**

`python3 -m unittest service.tests.test_model_downloader` — 21 tests OK, including `test_xet_reporter_feeds_wire_bytes_into_our_class` against installed huggingface_hub 1.26.1 (the #4633 reproduction: 40 transfer bytes, 0 disk bytes, our class receives them and hub aggregates into one bar).

**Checklist:**

- [x] I have tested the changes locally.
- [x] I have self-reviewed the code changes.
- [x] I have updated the documentation, if necessary.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b236058e-c582-4c58-8128-9bf34487b477?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b236058e-c582-4c58-8128-9bf34487b477&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

